### PR TITLE
Use the seedBibleExtensions record instead of a record key

### DIFF
--- a/packages/seed-bible/app/packager/addDependencies.tsx
+++ b/packages/seed-bible/app/packager/addDependencies.tsx
@@ -2,7 +2,7 @@ console.log(that)
 const { bots, createdAt, description, id, name, status } = that
 os.log(that)
 const realbots = bots.map(bot => getBot('system', bot.botTag))
-const uploadedBots = await os.recordFile(tags.publicKey, [...realbots])
+const uploadedBots = await os.recordFile(tags.recordName, [...realbots])
 if (!uploadedBots.success && uploadedBots.errorCode !== 'file_already_exists')
     return
 if (uploadedBots.errorCode === 'file_already_exists')
@@ -14,27 +14,7 @@ const data = {
     userAuth: authBot.id,
     source: uploadedBots.url,
 }
-const result = await os.recordData(tags.publicKey, name, data, {
+const result = await os.recordData(tags.recordName, name, data, {
     marker: 'publicRead'
 })
 console.log(result, 'dependency uploaded')
-// const mainBot = getBot('system', mainBotTag)
-// const otherBotsHolder = otherBots.map(bot => getBot('system', bot.tag))
-// if (!bots.success)
-//     return
-// const data = {
-//     ...that,
-//     // mainBot: ,
-//     mainBotTag:mainBotTag,
-//     otherBots: otherBots,
-//     recordFile: bots,
-//     userAuth: authBot.id,
-//     configEditor: getBot('system', mainBotTag).tags.config,
-// }
-// // const result = await os.recordData(tags.key, name, data);
-
-
-// const result = await os.recordData(tags.publicKey, name, JSON.stringify(data));
-
-// os.log('the re', result)
-

--- a/packages/seed-bible/app/packager/addPackage.tsx
+++ b/packages/seed-bible/app/packager/addPackage.tsx
@@ -2,7 +2,7 @@ const { name, version, description, mainBotTag, otherBots, dependencies, author,
 os.log(that)
 const mainBot = getBot('system', mainBotTag)
 const otherBotsHolder = otherBots.map(bot => getBot('system', bot.tag))
-const bots = await os.recordFile(tags.publicKey, [mainBot, ...otherBotsHolder])
+const bots = await os.recordFile(tags.recordName, [mainBot, ...otherBotsHolder])
 if (!bots.success && bots.errorCode !== 'file_already_exists')
     return
 if (bots.errorCode === 'file_already_exists')
@@ -18,10 +18,9 @@ const data = {
     type: 'package',
     configEditor: getBot('system', mainBotTag).tags.config,
 }
-// const result = await os.recordData(tags.key, name, data);
 
 
-const result = await os.recordData(tags.publicKey, name, (data));
+const result = await os.recordData(tags.recordName, name, (data));
 
 os.log('the re', result)
 

--- a/packages/seed-bible/app/packager/app.packager.bot.aux
+++ b/packages/seed-bible/app/packager/app.packager.bot.aux
@@ -6,8 +6,7 @@
       "tags": {
         "aoIDOrigin": "SeedBible",
         "color": "brown",
-        "key": "vRK2.bXlSZWNvcmQ=.WVZtNzJGL3dIRHdEbEdTdVlEYUpzQT09.subjectfull",
-        "publicKey": "vRK2.dGVzdGluZ1B1YmxpY2tLZXk=.Y1pMRkx6NksrZUFpR2FTd0ZJc0xEUT09.subjectless",
+        "recordName": "seedBibleExtensions",
         "system": "app.packager"
       }
     }

--- a/packages/seed-bible/app/packager/getDependencies.tsx
+++ b/packages/seed-bible/app/packager/getDependencies.tsx
@@ -1,5 +1,5 @@
 
-// const result = await os.listDataByMarker(tags.publicKey, ['publicRead']);
+// const result = await os.listDataByMarker(tags.recordName, ['publicRead']);
 // os.log(result, 'for test')
 // if (result.success) {
 //     return result.items
@@ -9,7 +9,7 @@
 let lastAddress;
 const items = [];
 while (true) {
-    const result = await os.listDataByMarker(tags.publicKey, 'publicRead', lastAddress);
+    const result = await os.listDataByMarker(tags.recordName, 'publicRead', lastAddress);
     if (result.success) {
         items.push(...result.items);
         if (result.items.length > 0) {

--- a/packages/seed-bible/app/packager/getPackages.tsx
+++ b/packages/seed-bible/app/packager/getPackages.tsx
@@ -2,7 +2,7 @@
 // const { force } = that
 if (tags.availablePackages) return tags.availablePackages
 
-// const result = await os.listDataByMarker(tags.publicKey, 'publicRead');
+// const result = await os.listDataByMarker(tags.recordName, 'publicRead');
 // os.log(result, 'for test')
 // if (result.success) {
 //     const output = result.items.filter(data => data.data.type === 'package').map(data => ({ data: (data.data), address: data.address }))
@@ -20,7 +20,7 @@ return output
 // let lastAddress;
 // let items = [];
 // while (true) {
-//     const result = await os.listDataByMarker(tags.publicKey, 'publicRead', lastAddress);
+//     const result = await os.listDataByMarker(tags.recordName, 'publicRead', lastAddress);
 //     if (result.success) {
 //         items.push(...result.items);
 //         if (result.items.length > 0) {

--- a/packages/seed-bible/app/packager/installPackage.tsx
+++ b/packages/seed-bible/app/packager/installPackage.tsx
@@ -32,7 +32,7 @@ await(async function mainInstaller(that) {
     }
 
     if (!data) {
-        const result = await os.getData(tags.publicKey, name);
+        const result = await os.getData(tags.recordName, name);
         if (result.success === false) {
             throw new Error(`Failed to get package data for ${name}: ${result.errorCode} ${result.errorMessage}`);
         }
@@ -188,7 +188,7 @@ await(async function mainInstaller(that) {
             if (type === 'package') {
                 await thisBot.installPackage({ name: depName });
             } else if (type === 'dependency') {
-                const result = await os.getData(tags.publicKey, depName);
+                const result = await os.getData(tags.recordName, depName);
                 if (result?.success) {
                     const data = result.data;
                     const read = await web.get(data.source);

--- a/packages/seed-bible/app/packager/main.tsx
+++ b/packages/seed-bible/app/packager/main.tsx
@@ -238,7 +238,7 @@ const PackageManager = () => {
     async function getMyPackages() {
         return
         try {
-            const result = await os.listDataByMarker(tags.publicKey, 'publicRead');
+            const result = await os.listDataByMarker(tags.recordName, 'publicRead');
             if (result.success) {
                 const filtered = result.items
                     .map(data => ({
@@ -256,7 +256,7 @@ const PackageManager = () => {
     async function loadAvailablePackages() {
         return
         try {
-            const result = await os.listDataByMarker(tags.publicKey, 'publicRead');
+            const result = await os.listDataByMarker(tags.recordName, 'publicRead');
             if (result.success) {
                 setAvailablePackages(result.items);
             }
@@ -411,7 +411,7 @@ const PackageManager = () => {
     const deletePackage = async (address) => {
         try {
             setLoading(true);
-            const result = await os.eraseData(tags.publicKey, address);
+            const result = await os.eraseData(tags.recordName, address);
             if (result.success) {
                 showNotification('Package deleted successfully!');
                 await getMyPackages();


### PR DESCRIPTION
This is so that we can restrict who is allowed to publish extensions.