### PR TITLE
Added the onFloatingAppRemoved shout to the global RemoveFloatingApp function

### DIFF
--- a/packages/seed-bible/app/hooks/mouseMove.tsx
+++ b/packages/seed-bible/app/hooks/mouseMove.tsx
@@ -52,6 +52,7 @@ export function MouseMoveProvider({ children }) {
     // remove
     globalThis.RemoveFloatingApp = (appId) => {
         setFloatingApps((prev) => prev.filter((app) => app.id !== appId));
+        shout("onFloatingAppRemoved", {appId});
     };
 
     // update


### PR DESCRIPTION
The Tabernacle extension should be notified when its floating app is closed, so it can clear its data and reset the state to its default values.