### PR TITLE
Fix default extension trigger location

### DIFF
--- a/packages/seed-bible/app/packager/installPackage.tsx
+++ b/packages/seed-bible/app/packager/installPackage.tsx
@@ -85,7 +85,7 @@ await(async function mainInstaller(that) {
     }
 
     async function SetUpApplication(applicationFunction, bot, toolbarConfig) {
-        function generateAppItem({ icon, iconUrl, label, AppComponent }) {
+        function generateAppItem({ icon, iconUrl, label, AppComponent, hasToggle, showInPageToolbar, showInStarterToolbar }) {
             const panelKey = `${label?.toUpperCase()?.replace(/\s/g, '_')}_PANEL_ID`;
 
             const onClick = async () => {
@@ -156,6 +156,9 @@ await(async function mainInstaller(that) {
                 active: true,
                 onHold,
                 onClick,
+                hasToggle,
+                showInPageToolbar, 
+                showInStarterToolbar
             };
         }
 
@@ -190,6 +193,9 @@ await(async function mainInstaller(that) {
             label: toolbarConfig.label,
             AppComponent: App,
             iconUrl: toolbarConfig?.iconUrl,
+            hasToggle: toolbarConfig.hasToggle,
+            showInPageToolbar: toolbarConfig.showInPageToolbar,
+            showInStarterToolbar: toolbarConfig.showInStarterToolbar
         });
 
         if (globalThis.AddTool) globalThis.AddTool(toolbarOption);
@@ -203,12 +209,16 @@ await(async function mainInstaller(that) {
         const toolbarOption = {
             icon: !toolbarConfig?.iconUrl ? toolbarConfig.icon : toolbarConfig.iconUrl,
             label: toolbarConfig.label,
-            hasToggle: true,
+            hasToggle: toolbarConfig.hasToggle,
             active: typeof toolbarConfig?.active === 'boolean' ? toolbarConfig.active : true,
+            showInPageToolbar: toolbarConfig.showInPageToolbar,
+            showInStarterToolbar: toolbarConfig.showInStarterToolbar,
             onHold: runFn,
             onClick: runFn,
             isImg: !!toolbarConfig?.iconUrl,
         };
+
+        console.log(`[Debug] installPackage`, {toolbarOption, toolbarConfig})
 
         if (globalThis.AddTool) {
             globalThis.AddTool(toolbarOption, { to: toolbarConfig.to ? toolbarConfig.to : 'page' });

--- a/packages/seed-bible/app/packager/reInitPackage.tsx
+++ b/packages/seed-bible/app/packager/reInitPackage.tsx
@@ -42,7 +42,7 @@ async function SetUpConextMenu(contextOptions, bot, label) {
 }
 
 async function SetUpApplication(applicationFunction, bot, toolbarConfig) {
-    function generateAppItem({ icon, iconUrl, label, AppComponent }) {
+    function generateAppItem({ icon, iconUrl, label, AppComponent, hasToggle, showInPageToolbar, showInStarterToolbar }) {
         const panelKey = `${label?.toUpperCase()?.replace(/\s/g, '_')}_PANEL_ID`;
         console.log('working', pkgName)
         const onClick = async () => {
@@ -113,6 +113,9 @@ async function SetUpApplication(applicationFunction, bot, toolbarConfig) {
             active: true,
             onHold,
             onClick,
+            hasToggle,
+            showInPageToolbar, 
+            showInStarterToolbar
         };
     }
 
@@ -138,11 +141,16 @@ async function SetUpApplication(applicationFunction, bot, toolbarConfig) {
         return;
     }
 
+    const {showInPageToolbar, showInStarterToolbar, active, hasToggle} = toolbarConfig;
+
     const toolbarOption = generateAppItem({
         icon: toolbarConfig.icon,
         label: toolbarConfig.label,
         AppComponent: App,
         iconUrl: toolbarConfig?.iconUrl,
+        hasToggle: toolbarConfig.hasToggle,
+        showInPageToolbar: toolbarConfig.showInPageToolbar,
+        showInStarterToolbar: toolbarConfig.showInStarterToolbar
     });
 
     if (globalThis.AddTool) globalThis.AddTool(toolbarOption);
@@ -156,8 +164,10 @@ async function SetUpApplicationWithoutApp(toolbarConfig, bot) {
     const toolbarOption = {
         icon: !toolbarConfig?.iconUrl ? toolbarConfig.icon : toolbarConfig.iconUrl,
         label: toolbarConfig.label,
-        hasToggle: true,
-        active: true,
+        hasToggle: toolbarConfig.hasToggle,
+        active: toolbarConfig.active,
+        showInPageToolbar: toolbarConfig.showInPageToolbar,
+        showInStarterToolbar: toolbarConfig.showInStarterToolbar,
         onHold: runFn,
         onClick: runFn,
         isImg: !!toolbarConfig?.iconUrl,


### PR DESCRIPTION
Updated toolbarOption handling in installPackage and reInitPackage to correctly store the default values for active, hasToggle, showInPageToolbar, and showInStarterToolbar.

Now, the default trigger locations for extensions are properly read and applied from their config file.

Fixes #125 