### PR TITLE
Fix a bunch of fonts

### DIFF
--- a/packages/Assistant/aiApps/voiceAssistant/App.css
+++ b/packages/Assistant/aiApps/voiceAssistant/App.css
@@ -38,7 +38,7 @@
 }
 
 .thinking {
-  font-family: Arial, sans-serif;
+  font-family: "DM Sans", system-ui, sans-serif;
   font-size: 18px;
   font-weight: 500;
   color: #444;
@@ -94,7 +94,7 @@
   padding: 5px;
   border-radius: 5px;
   font-size: 16px;
-  font-family: Satoshi;
+  font-family: 'Satoshi', system-ui, sans-serif;
   max-width: 80%;
 }
 
@@ -104,7 +104,7 @@
   padding: 5px;
   border-radius: 5px;
   font-size: 16px;
-  font-family: Satoshi;
+  font-family: 'Satoshi', system-ui, sans-serif;
   max-width: 80%;
 }
 
@@ -120,7 +120,7 @@
     padding: 10px;
     box-shadow: rgba(0, 0, 0, 0.35) 0px 5px 15px;
     height: fit-content;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
+    font-family: "DM Sans", system-ui, sans-serif;
 }
 
 .draggable {
@@ -267,7 +267,7 @@
 }
 
 body {
-  font-family: Arial, sans-serif;
+  font-family: "DM Sans", system-ui, sans-serif;
   display: flex;
   justify-content: center;
   align-items: center;

--- a/packages/BookSelector/introduction/searchBar/App.css
+++ b/packages/BookSelector/introduction/searchBar/App.css
@@ -16,7 +16,7 @@
 }
 
 .testament-title {
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-weight: 700;
     font-style: Bold;
     font-size: 18px;

--- a/packages/BookSelector/introduction/searchBar/lore-card.css
+++ b/packages/BookSelector/introduction/searchBar/lore-card.css
@@ -1,7 +1,7 @@
 html {
   font-size: 62.5%;
   box-sizing: border-box;
-  font-family: 'Pacifico'; 
+  /* font-family: 'Pacifico';  */
 }
 
 *, *::after, *::before {

--- a/packages/Painter/aiApps/painter/App.css
+++ b/packages/Painter/aiApps/painter/App.css
@@ -251,7 +251,7 @@
     justify-content: center;
     align-items: center;
     background: transparent;
-    font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Oxygen, sans-serif;
+    font-family: 'DM Sans', system-ui, sans-serif;
 }
 
 .sliderTrack {

--- a/packages/Playlist/playlist/playlistMode/PlaylistPlayerControls.tsx
+++ b/packages/Playlist/playlist/playlistMode/PlaylistPlayerControls.tsx
@@ -776,7 +776,7 @@ const PlayerControls = ({ parentId = "default" }) => {
                   alignItems: "center",
                   margin: "0",
                   marginBottom: "0.5rem",
-                  fontFamily: "DM Mono",
+                  fontFamily: "DM Sans",
                   height: "12px",
                 }}>
                 {showCurrent

--- a/packages/Playlist/playlist/playlistMode/ScreenRecording.css
+++ b/packages/Playlist/playlist/playlistMode/ScreenRecording.css
@@ -28,7 +28,7 @@
 }
 
 .ScreenRecording .hide {
-    font-family: DM Sans;
+    font-family: 'DM Sans', system-ui, sans-serif;
     font-weight: 400;
     font-style: Regular;
     font-size: 14px;

--- a/packages/Playlist/playlist/playlistMode/playlist.css
+++ b/packages/Playlist/playlist/playlistMode/playlist.css
@@ -22,7 +22,7 @@
     padding: 0;
     box-sizing: border-box;
     color: #5F5E5C;
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
 }
 
 .material-symbols-outlined {
@@ -307,7 +307,7 @@ history-item:active {
     align-items: center;
     justify-content: center;
     cursor: pointer;
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-weight: 700;
     font-size: 14px;
     line-height: 24.3px;
@@ -514,19 +514,19 @@ div.history-item.current-date-disorder .playlist-item-type {
 }
 
 .playlist-item-type.bookmark .number-style {
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-weight: 600;
     font-size: 15px;
 }
 
 .playlist-item-type.bookmark .verse-style {
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-weight: 500;
     font-size: 12px;
 }
 
 .playlist-item-type.bookmark .time-style {
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-weight: 400;
     font-style: Italic;
     font-size: 12px;
@@ -801,7 +801,7 @@ div.attachment-link.dropabble-Embed .playlist-item-type {
 }
 
 .info-type {
-    font-family: DM Sans;
+    font-family: 'DM Sans', system-ui, sans-serif;
     font-weight: 500;
     font-size: 10px;
     line-height: 100%;
@@ -884,7 +884,7 @@ div.attachment-link.dropabble-Embed .playlist-item-type {
 }
 
 .what-this {
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-weight: 500;
     font-size: 16px;
     line-height: 18.9px;
@@ -970,7 +970,7 @@ div.attachment-link.dropabble-Embed .playlist-item-type {
     height: 32px;
     border-radius: 24px;
     min-width: fit-content;
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-weight: 500;
     font-size: 10px;
     cursor: pointer;
@@ -1013,7 +1013,7 @@ div.attachment-link.dropabble-Embed .playlist-item-type {
 }
 
 .content-type p {
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-weight: 500;
     font-size: 14px;
     line-height: 100%;
@@ -1035,7 +1035,7 @@ div.attachment-link.dropabble-Embed .playlist-item-type {
     display: flex;
     align-items: center;
     justify-content: space-between;
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-weight: 700;
     font-size: 16px;
     line-height: 100%;
@@ -1043,7 +1043,7 @@ div.attachment-link.dropabble-Embed .playlist-item-type {
 }
 
 .annotation-list-item {
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-weight: 500;
     display: flex;
     justify-content: space-between;
@@ -1059,7 +1059,7 @@ div.attachment-link.dropabble-Embed .playlist-item-type {
 }
 
 .annotation .verse-annotation {
-    font-family: Satoshi;
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-weight: 700;
     font-size: 14px;
     line-height: 100%;

--- a/packages/seed-bible/app/components/commands.tsx
+++ b/packages/seed-bible/app/components/commands.tsx
@@ -1123,7 +1123,7 @@ const BiblePassageDisplay = ({ content }) => {
         <div className="bible-passage-container">
             <style jsx>{`
         .bible-passage-container {
-  font-family: 'Georgia', 'Times New Roman', serif;
+  font-family: "Newsreader", "Georgia", "Times New Roman", serif;
   line-height: 1.15;
   color: #2c3e50;
   max-width: 100%;
@@ -1189,7 +1189,7 @@ const BiblePassageDisplay = ({ content }) => {
   font-size: 1.3em;
   color: #e67e22;
   opacity: 0.25;
-  font-family: Georgia, serif;
+  font-family: "Newsreader", "Georgia", "Times New Roman", serif;
 }
 
 /* Bullet points */

--- a/packages/seed-bible/app/components/icons.tsx
+++ b/packages/seed-bible/app/components/icons.tsx
@@ -55,7 +55,7 @@ export function SeedBibleIcon() {
   );
 }
 export const ApologistIcon = () => {
-  return <img style={{ filter: "invert(1)" }} src="https://res.cloudinary.com/dfbtwwa8p/image/upload/v1755794631/svgviewer-png-output_1_tgtfvm.png" />
+  return <img style={{ filter: "invert(1)", width: "24px" }} src="https://res.cloudinary.com/dfbtwwa8p/image/upload/v1755794631/svgviewer-png-output_1_tgtfvm.png" />
 }
 const AiIcon = (props) => (
   <svg

--- a/packages/seed-bible/app/components/sideBar.tsx
+++ b/packages/seed-bible/app/components/sideBar.tsx
@@ -811,7 +811,7 @@ function SideBar() {
             textAlign: "left",
             marginBottom: "10px",
             color: " #FFF",
-            "font-family": "Satoshi",
+            "font-family": "'Satoshi', system-ui, sans-serif",
             "font-size": "16px",
             "font-style": "normal",
             "font-weight": "700",

--- a/packages/seed-bible/app/components/textSettings.tsx
+++ b/packages/seed-bible/app/components/textSettings.tsx
@@ -6,8 +6,8 @@ import { useTabsContext } from 'app.hooks.tabs';
 import { useSideBarContext } from 'app.hooks.sideBar'
 export const defaultTextConfig = {
     bookchapter: {
-        font: `'Helvetica Neue', sans-serif`,
-        weight: '500',
+        font: `'Newsreader', serif`,
+        weight: '600',
         color: 'black',
         marginVertical: '0',
         marginHorizontal: '27',
@@ -19,20 +19,21 @@ export const defaultTextConfig = {
         },
     },
     heading: {
-        font: `'Montserrat', sans-serif`,
-        weight: '600',
+        font: `'Plus Jakarta Sans', sans-serif`,
+        weight: '200',
         color: 'black',
-        marginVertical: '24',
+        marginTop: '18',
+        marginBottom: '12',
         marginHorizontal: '27',
         styles: {
-            bold: true,
-            italic: false,
+            bold: false,
+            italic: true,
             underline: false,
             alignment: 'left',
         },
     },
     chapter: {
-        font: `'Montserrat', sans-serif`,
+        font: `'Newsreader', serif`,
         weight: '600',
         color: 'black',
         marginVertical: '8',
@@ -45,7 +46,7 @@ export const defaultTextConfig = {
         },
     },
     verse: {
-        font: 'EB Garamond',
+        font: `'Newsreader', serif`,
         weight: '400',
         color: 'black',
         marginVertical: '30',
@@ -72,8 +73,8 @@ export function exportTextConfigToCSS(textConfig) {
         cssVars.push(`${toCSSVarName(section, 'font-bold')}: ${styles.bold ? 'bold' : config.weight || 'normal'};`);
         cssVars.push(`${toCSSVarName(section, 'alignment')}: ${styles.alignment || 'left'};`);
         cssVars.push(`${toCSSVarName(section, 'color')}: ${config.color || 'black'};`);
-        cssVars.push(`${toCSSVarName(section, 'margin-top')}: ${config.marginVertical || '16'}px;`);
-        cssVars.push(`${toCSSVarName(section, 'margin-bottom')}: ${config.marginVertical || '16'}px;`);
+        cssVars.push(`${toCSSVarName(section, 'margin-top')}: ${config.marginTop || config.marginVertical || '16'}px;`);
+        cssVars.push(`${toCSSVarName(section, 'margin-bottom')}: ${config.marginBottom || config.marginVertical || '16'}px;`);
         cssVars.push(`${toCSSVarName(section, 'margin-left')}: ${config.marginHorizontal || '0'}%;`);
         cssVars.push(`${toCSSVarName(section, 'margin-right')}: ${config.marginHorizontal || '0'}%;`);
 

--- a/packages/seed-bible/app/components/textSettings.tsx
+++ b/packages/seed-bible/app/components/textSettings.tsx
@@ -151,7 +151,8 @@ function TextSettings() {
                                 })
                             }
                         >
-                            <option selected={textConfig[section].font === 'EB Garamond'}>EB Garamond</option>
+                            <option selected={textConfig[section].font === `'Newsreader', serif`}>Newsreader</option>
+                            <option selected={textConfig[section].font === `'Plus Jakarta Sans', sans-serif`}>Plus Jakarta Sans</option>
                             <option selected={textConfig[section].font === `'Helvetica Neue', sans-serif`}>Montserrat</option>
                             <option selected={textConfig[section].font === `Helvetica Neue`}>Helvetica Neue</option>
                             <option selected={textConfig[section].font === 'Roboto'}>Roboto</option>

--- a/packages/seed-bible/app/components/thePage.tsx
+++ b/packages/seed-bible/app/components/thePage.tsx
@@ -826,15 +826,6 @@ function ThePage({
       onMouseUp={handleMouseUp}
       onClick={hanldNavFunctions}
     >
-      <link
-        href="https://fonts.cdnfonts.com/css/helvetica-neue-55"
-        rel="stylesheet"
-      />
-      <link href="https://fonts.cdnfonts.com/css/montserrat" rel="stylesheet" />
-      <link
-        href="https://fonts.googleapis.com/css2?family=EB+Garamond:ital,wght@0,400..800;1,400..800&display=swap"
-        rel="stylesheet"
-      />
       {data && tab && !tabEntered ? (
         <>
           <div
@@ -1420,9 +1411,7 @@ function Section({
           });
         }}
         className="sectionTitle"
-      >
-        {heading}
-      </div>
+      >{heading}</div>
       <div style={textEdit ? editTextStyle : null}>
         {textEdit && <div className="editVerseTitle">Verse - Text</div>}
         {textEdit && (

--- a/packages/seed-bible/app/hooks/sideBar.tsx
+++ b/packages/seed-bible/app/hooks/sideBar.tsx
@@ -161,6 +161,10 @@ export function PopupSettings({ items, type, disabled, sidebarContext }) {
                 pointerEvents: 'auto'
             }}
         >
+            <link rel="preconnect" href="https://fonts.googleapis.com"/>
+            <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+            <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap" rel="stylesheet"/>
+            <link href="https://api.fontshare.com/v2/css?f[]=satoshi@400&display=swap" rel="stylesheet"/>
             {sidebarContext.popupComponent || <div className={`popupSettings ${disabled ? 'disabled' : null}`}>
                 {external && <div className=" externalPopupSettings">{external}</div>}
                 {null /*<div className="triangle-up"></div>*/}

--- a/packages/seed-bible/app/main/main.tsx
+++ b/packages/seed-bible/app/main/main.tsx
@@ -265,6 +265,10 @@ const Main = () => {
 
 const Root = () => {
     return <>
+        <link rel="preconnect" href="https://fonts.googleapis.com"/>
+        <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin/>
+        <link href="https://fonts.googleapis.com/css2?family=DM+Sans:ital,opsz,wght@0,9..40,100..1000;1,9..40,100..1000&family=Newsreader:ital,opsz,wght@0,6..72,200..800;1,6..72,200..800&family=Plus+Jakarta+Sans:ital,wght@0,200..800;1,200..800&display=swap" rel="stylesheet"/>
+        <link href="https://api.fontshare.com/v2/css?f[]=satoshi@400&display=swap" rel="stylesheet"/>
         <script src="https://cdn.jsdelivr.net/npm/fullcalendar@6.1.17/index.global.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/fullcalendar/timegrid@6.1.17/index.global.min.js"></script>
         <script src="https://cdn.jsdelivr.net/npm/fullcalendar/interaction@6.1.17/index.global.min.js"></script>

--- a/packages/seed-bible/app/sn_styles/studyNotes.css
+++ b/packages/seed-bible/app/sn_styles/studyNotes.css
@@ -7,7 +7,7 @@
 
 /* each book block */
 .studyTextContainer {
-  font-family: 'EB Garamond', serif;
+  font-family: "Newsreader", serif;
   margin-bottom: 40px;
   /* space between books */
 }

--- a/packages/seed-bible/app/styles/aiSettings.css
+++ b/packages/seed-bible/app/styles/aiSettings.css
@@ -1,5 +1,5 @@
 .aiSettings-container {
-    font-family: sans-serif;
+    font-family: 'DM Sans', system-ui, sans-serif;
     padding: 16px;
     width: 280px;
     height: 100%;

--- a/packages/seed-bible/app/styles/createAccountSettings.css
+++ b/packages/seed-bible/app/styles/createAccountSettings.css
@@ -3,7 +3,7 @@
     height: 100vh;
     display: flex;
     flex-direction: column;
-    font-family: 'Segoe UI', Arial, sans-serif;
+    font-family: 'DM Sans', system-ui, sans-serif;
     border-left: 1px solid #e0e0e0;
     background-color: #f0f1f1;
     padding: 10px;

--- a/packages/seed-bible/app/styles/extensions.css
+++ b/packages/seed-bible/app/styles/extensions.css
@@ -1,5 +1,5 @@
 .extensions-container {
-    font-family: sans-serif;
+    font-family: 'DM Sans', system-ui, sans-serif;
     padding: 16px;
     width: 280px;
     height: 100%;

--- a/packages/seed-bible/app/styles/main.css
+++ b/packages/seed-bible/app/styles/main.css
@@ -3,6 +3,7 @@ body {
   position: fixed !important;
   left: -10px !important;
   top: -10px !important;
+  font-optical-sizing: auto;
 }
 
 * {
@@ -183,7 +184,7 @@ body {
 
 .softText {
   color: var(--text2);
-  font-family: "Helvetica Neue";
+  font-family: 'Satoshi', system-ui, sans-serif;
   font-size: 14px;
   font-style: normal;
   font-weight: 400;
@@ -192,7 +193,7 @@ body {
 
 .mediumText {
   color: var(--themeText1);
-  font-family: "Open Sans";
+  font-family: 'Satoshi', system-ui, sans-serif;
   font-size: 14px;
   font-style: normal;
   font-weight: 400;
@@ -203,7 +204,7 @@ body {
 
 .blackText {
   color: var(--themeText2);
-  font-family: "Helvetica Neue";
+  font-family: 'Satoshi', system-ui, sans-serif;
   font-size: 16px;
   font-style: normal;
   font-weight: 400;
@@ -215,7 +216,7 @@ body {
   border: 1px solid #e1e3ea;
   background: #e6e6e6;
   color: #5f5e5c;
-  font-family: Inter;
+  font-family: 'Satoshi', system-ui, sans-serif;
   font-size: 15px;
   font-style: normal;
   font-weight: 400;

--- a/packages/seed-bible/app/styles/page.css
+++ b/packages/seed-bible/app/styles/page.css
@@ -102,14 +102,11 @@
 }
 
 .bookTitle {
-  font-family: 'Helvetica Neue', sans-serif;
   font-size: 32px;
   margin-bottom: 60px;
   font-weight: 500;
   font-family: var(--text-bookchapter-font);
   color: var(--text-bookchapter-color);
-  /* font-family: 'Montserrat', sans-serif; */
-  /* font-size: 22px; */
   font-weight: var(--text-bookchapter-weight);
   text-align: var(--text-bookchapter-alignment);
   text-decoration: var(--text-bookchapter-text-decoration);
@@ -123,8 +120,8 @@
 .sectionTitle {
   font-family: var(--text-heading-font);
   color: var(--text-heading-color);
-  /* font-family: 'Montserrat', sans-serif; */
-  font-size: 22px;
+  font-size: 18px;
+  font-style: var(--text-heading-font-style);
   font-weight: var(--text-heading-weight);
   text-align: var(--text-heading-alignment);
   text-decoration: var(--text-heading-text-decoration);
@@ -138,7 +135,6 @@
 .sectionText {
   font-family: var(--text-verse-font);
   color: var(--text-verse-color);
-  /* font-family: 'EB Garamond', sans-serif; */
   font-size: 20px;
   font-weight: var(--text-verse-weight);
   font-style: var(--text-verse-font-style);
@@ -210,12 +206,13 @@
 
 .sectionTextNumber {
   color: #287F71;
-  font-family: 'EB Garamond', sans-serif;
-  font-size: 16px;
-  font-weight: 700;
+  font-family: 'Plus Jakarta Sans', sans-serif;
+  font-size: 12px;
+  font-weight: 500;
   line-height: 30px;
   font-style: normal;
-  margin: 0 5px;
+  vertical-align: super;
+  /* margin: 0 5px; */
 }
 
 .tabDrop {

--- a/packages/seed-bible/app/styles/settings.css
+++ b/packages/seed-bible/app/styles/settings.css
@@ -5,7 +5,7 @@
   /* box-shadow: 0 0 10px rgba(0, 0, 0, 0.1); */
   display: flex;
   flex-direction: column;
-  font-family: 'Segoe UI', Arial, sans-serif;
+  font-family: 'Satoshi', system-ui, sans-serif;
   border-left: 1px solid #e0e0e0;
   background-color: var(--themeSideMenu) !important;
 }
@@ -171,7 +171,7 @@
   font-size: 16px;
   /* color: var(--themeText1); */
   font-weight: 500;
-  font-family: "Helvetica Neue";
+  font-family: 'Satoshi', system-ui, sans-serif;
 }
 
 .item-chevron {
@@ -201,7 +201,7 @@
 
 .space-description {
   color: var(--text2);
-  font-family: "Open Sans";
+  font-family: 'Satoshi', system-ui, sans-serif;
   font-size: 12px;
   font-style: normal;
   font-weight: 400;

--- a/packages/seed-bible/app/styles/sidebar.css
+++ b/packages/seed-bible/app/styles/sidebar.css
@@ -5,9 +5,7 @@
     position: relative;
     /* transition: width 0.3s ease; */
     background-color: var(--themeSideMenu);
-
-    font-family: 'Segoe UI', Arial, sans-serif;
-    
+    font-family: "Satoshi", sans-serif;
 }
 
 .customCheckboxWrapper {
@@ -422,7 +420,7 @@
     background: transparent;
     width: 100%;
     color: #FFF;
-    font-family: "Helvetica Neue";
+    font-family: 'Satoshi', system-ui, sans-serif;
     font-size: 14px;
     font-style: normal;
     font-weight: 400;

--- a/packages/seed-bible/app/styles/tabSettings.css
+++ b/packages/seed-bible/app/styles/tabSettings.css
@@ -1,5 +1,5 @@
 .tabSettings-container {
-    font-family: sans-serif;
+    font-family: 'Satoshi', system-ui, sans-serif;
     padding: 16px;
     width: 280px;
     height: 100%;

--- a/packages/seed-bible/app/styles/testSettings.css
+++ b/packages/seed-bible/app/styles/testSettings.css
@@ -5,7 +5,7 @@
     /* box-shadow: 0 0 10px rgba(0, 0, 0, 0.1); */
     display: flex;
     flex-direction: column;
-    font-family: 'Segoe UI', Arial, sans-serif;
+    font-family: 'Satoshi', system-ui, sans-serif;
     border-left: 1px solid #e0e0e0;
     padding: 10px;
     overflow: scroll;

--- a/packages/seed-bible/app/styles/themeSettings.css
+++ b/packages/seed-bible/app/styles/themeSettings.css
@@ -1,5 +1,5 @@
 .themeSettings-container {
-  font-family: sans-serif;
+  font-family: 'Satoshi', system-ui, sans-serif;
   padding: 16px;
   width: 245px !important;
   height: 100%;
@@ -15,7 +15,7 @@
 
 .themeText {
   color: #000;
-  font-family: "Open Sans";
+  font-family: 'Satoshi', system-ui, sans-serif;
   font-size: 14px;
   font-style: normal;
   font-weight: 600;
@@ -77,7 +77,7 @@
 }
 
 .readyTheme-name {
-  font-family: "Open Sans";
+  font-family: 'Satoshi', system-ui, sans-serif;
   font-size: 14px;
   font-weight: 500;
   line-height: normal;

--- a/packages/seed-bible/app/styles/toolbarSettings.css
+++ b/packages/seed-bible/app/styles/toolbarSettings.css
@@ -1,5 +1,5 @@
 .toolbar-container {
-  font-family: sans-serif;
+  font-family: 'Satoshi', system-ui, sans-serif;
   padding: 16px;
   width: 280px;
   height: 100%;

--- a/packages/seed-bible/components/component/button.css
+++ b/packages/seed-bible/components/component/button.css
@@ -25,7 +25,7 @@
     border-radius: 4px !important;
     /* max-width: fit-content !important; */
     background-color: #D36433;
-    font-family: Inter !important;
+    font-family: 'Satoshi', system-ui, sans-serif;
     text-align: center;
     font-size: 14px !important;
     font-weight: 400 !important;

--- a/packages/seed-bible/components/component/chips.css
+++ b/packages/seed-bible/components/component/chips.css
@@ -6,7 +6,7 @@
     color: #2c2c2c;
     /* dark text for contrast */
     font-size: 16px;
-    font-family: 'Arial', sans-serif;
+    font-family: 'Satoshi', system-ui, sans-serif;
     padding: 6px 12px;
     border-radius: 999px;
     margin-right: 8px;

--- a/packages/seed-bible/components/component/index.css
+++ b/packages/seed-bible/components/component/index.css
@@ -99,7 +99,7 @@
 }
 
 .modal-header h3 {
-  font-family: Open Sans;
+  font-family: 'Satoshi', system-ui, sans-serif;
   font-size: 18px;
   font-weight: 600;
   margin: 0;


### PR DESCRIPTION
Changed fonts to properly include the correct font sources and also use them throughout the project.

When in doubt, Satoshi was used for app fonts and Newsreader was used for Bible fonts.

## Comparison

### Bible
Before:
<img width="1068" height="540" alt="image" src="https://github.com/user-attachments/assets/4daa0e1d-11cc-4f60-9df3-68d6e470c60c" />

After:
<img width="1068" height="495" alt="image" src="https://github.com/user-attachments/assets/9db8202b-e92d-48fe-a8e9-eff49e4e6a04" />

### Book Selector

Before:
<img width="846" height="906" alt="image" src="https://github.com/user-attachments/assets/4b7f7b5c-b364-48fa-9e2e-91aebc366e68" />

After:
<img width="846" height="930" alt="image" src="https://github.com/user-attachments/assets/9da163f6-91b3-4b55-ae0f-629e9f21269b" />


### Playlist Create

Before:
<img width="670" height="510" alt="image" src="https://github.com/user-attachments/assets/27985ddf-d486-485b-a7f9-6c7709c6a146" />

After:
<img width="674" height="464" alt="image" src="https://github.com/user-attachments/assets/f20ffea6-56b1-4887-b980-1b55eafe477d" />

### Context Menu

Before:
<img width="245" height="291" alt="image" src="https://github.com/user-attachments/assets/28a7c3ac-8b66-4881-a598-65504c8551c5" />


After:
<img width="274" height="307" alt="image" src="https://github.com/user-attachments/assets/410c7aaf-a2ae-4360-b4e0-6692822aaee2" />


### Sidebar

Before:
<img width="281" height="1259" alt="image" src="https://github.com/user-attachments/assets/93791e63-c9a7-4485-9abb-441386aae8e8" />

After:
<img width="277" height="1290" alt="image" src="https://github.com/user-attachments/assets/e897e662-40bb-4378-9989-c2bb926669f0" />


