### PR TITLE
Now bookId and chapter gets updated when openNext and openPrevious are called

### DIFF
--- a/packages/seed-bible/app/hooks/bibleDataManager.tsx
+++ b/packages/seed-bible/app/hooks/bibleDataManager.tsx
@@ -175,12 +175,32 @@ export class BibleDataManager {
 
   async openNext() {
     if (this.data?.nextChapter) {
+
+      const match = this.data.nextChapter.match(/^\/api\/([^/]+)\/([^/]+)\/(\d+)\.json$/);
+
+      if (match) 
+      {
+        const [, , bookId, chapter] = match;
+        this.bookId = bookId;
+        this.chapter = Number(chapter);
+      }
+
       await this.fetch(this.data.nextChapter);
     }
   }
 
   async openPrevious() {
     if (this.data?.prevChapter) {
+
+      const match = this.data.prevChapter.match(/^\/api\/([^/]+)\/([^/]+)\/(\d+)\.json$/);
+
+      if (match) 
+      {
+        const [, , bookId, chapter] = match;
+        this.bookId = bookId;
+        this.chapter = Number(chapter);
+      }
+
       await this.fetch(this.data.prevChapter);
     }
   }


### PR DESCRIPTION
When playing around with _scheduleMaskRecord I realized that the setTimout callback was not being called beause this._lastRecordedKey and keyAtScheduleTime were equals.

This was happening because navigating the Bible with openNext and openPrevious was not updating bookId and chapter.