### PR TITLE
feat: add arg flag tool + devtools flag

### DIFF
--- a/script/argumentUtil.ts
+++ b/script/argumentUtil.ts
@@ -1,0 +1,115 @@
+/**
+ * Cache of process arguments excluding the first two default entries.
+ */
+const argvCache: Array<string> = process.argv.slice(2);
+
+/** The prefix expected to be used for long-form flags */
+export const FLAG_PREFIX: "--" = "--" as const;
+/** The prefix expected to be used for short-form flags */
+export const SHORT_FLAG_PREFIX: "-" = "-" as const;
+
+/**
+ * Known argument flags (Flag Prefix format)
+ * * These are the predefined known flags for the application and can be extended as needed.
+ */
+export enum KnownFlags {
+  /** Whether or not to enable collaborative features (non-static insts) */
+  Collaborative,
+
+  /** Whether or not to start with dev tools open. */
+  DevTools,
+
+  /** Whether or not to load the Ao Bot inst. */
+  AoBot,
+}
+
+/**
+ * Known argument flags in their full / long format.
+ */
+export const KnownFlagsLong = {
+  [KnownFlags.Collaborative]: "collaborative",
+  [KnownFlags.DevTools]: "dev-tools",
+  [KnownFlags.AoBot]: "ao-bot",
+} as const satisfies Partial<Record<KnownFlags, string>>;
+
+export type KnownFlagsLong = (typeof KnownFlagsLong)[KnownFlags];
+
+/**
+ * Known argument flags in their short format.
+ */
+export const KnownFlagsShort = {
+  [KnownFlags.Collaborative]: "c",
+  [KnownFlags.DevTools]: "d",
+} as const satisfies Partial<Record<KnownFlags, string>>;
+
+export type KnownFlagsShort =
+  (typeof KnownFlagsShort)[keyof typeof KnownFlagsShort];
+
+/**
+ * Cache of present known flags in process arguments.
+ */
+const presentKnownFlags: Set<KnownFlagsLong | KnownFlagsShort> = new Set<
+  KnownFlagsLong | KnownFlagsShort
+>();
+
+/**
+ * Set of known flags for quick lookup.
+ */
+export const KnownFlagsSet: Set<KnownFlagsLong> = new Set(
+  Object.values(KnownFlagsLong)
+);
+/**
+ * Set of known short flags for quick lookup.
+ */
+export const KnownShortFlagsSet: Set<KnownFlagsShort> = new Set(
+  Object.values(KnownFlagsShort)
+);
+
+/**
+ * Populates the set of presentKnownFlags from process arguments (argvCache).
+ */
+for (const arg of argvCache) {
+  if (arg.startsWith(FLAG_PREFIX) && arg.length > FLAG_PREFIX.length) {
+    const flag = arg.slice(FLAG_PREFIX.length);
+    if (KnownFlagsSet.has(flag as KnownFlagsLong)) {
+      presentKnownFlags.add(flag);
+    }
+  } else if (
+    arg.startsWith(SHORT_FLAG_PREFIX) &&
+    arg.length > SHORT_FLAG_PREFIX.length
+  ) {
+    const shortFlag = arg.slice(SHORT_FLAG_PREFIX.length);
+    if (KnownShortFlagsSet.has(shortFlag as KnownFlagsShort)) {
+      presentKnownFlags.add(shortFlag);
+    }
+  }
+}
+
+/**
+ * Known argument flag checker
+ * * This function references only predefined known flags.
+ * @param flag The known flag to check for.
+ */
+export function procHasFlag(flag: KnownFlags): boolean {
+  const long = KnownFlagsLong[flag];
+  const short = KnownFlagsShort[flag];
+  if (long === undefined && short === undefined) {
+    return false;
+  }
+  return presentKnownFlags.has(long) || presentKnownFlags.has(short);
+}
+
+/**
+ * Arbitrary argument flag checker
+ * @param search Object with 'flag' and/or 'shortFlag' to search for
+ */
+export function procHasFlagString(search: {
+  flag?: string;
+  shortFlag?: string;
+}): boolean {
+  return argvCache.some(
+    (a) =>
+      a === `${FLAG_PREFIX}${search?.flag}` ||
+      a === `${SHORT_FLAG_PREFIX}${search?.shortFlag}`
+  );
+}

--- a/script/dev.ts
+++ b/script/dev.ts
@@ -26,14 +26,17 @@ import { execSync } from "node:child_process";
 import repl from "node:repl";
 import { v4 as uuid } from "uuid";
 import type { StoredAux } from "../typings/AuxLibraryDefinitions.js";
+import { KnownFlags, procHasFlag } from "./argumentUtil.js";
 
-const extraExtensions = process.argv.slice(2).filter(a => !a.startsWith("-"));
-const collaborative = process.argv.slice(2).some(a => a === "--collaborative");
-const aoBot = process.argv.slice(2).find(a => a === "--ao-bot");
+const extraExtensions = process.argv.slice(2).filter((a) => !a.startsWith("-"));
+const collaborative = procHasFlag(KnownFlags.Collaborative);
+const aoBot = procHasFlag(KnownFlags.AoBot);
+const startWithDevtools = procHasFlag(KnownFlags.DevTools);
 
 const browser = await puppeteer.launch({
   headless: false,
   defaultViewport: null,
+  devtools: startWithDevtools,
 });
 
 let page: puppeteer.Page;
@@ -44,25 +47,34 @@ async function startPage() {
   page = await browser.newPage();
 
   if (aoBot) {
-    await Promise.all(['ao.bot'].map((pkg) => packageSingle(pkg, "ignore")));
+    await Promise.all(["ao.bot"].map((pkg) => packageSingle(pkg, "ignore")));
     currentInst = await loadAoBot(page);
   } else {
-    const allPackages = [...new Set([...DEFAULT_EXTENSIONS, ...extraExtensions])];
+    const allPackages = [
+      ...new Set([...DEFAULT_EXTENSIONS, ...extraExtensions]),
+    ];
 
     await Promise.all(allPackages.map((pkg) => packageSingle(pkg, "ignore")));
-    currentInst = await loadSeedBible(page, extraExtensions, undefined, collaborative);
+    currentInst = await loadSeedBible(
+      page,
+      extraExtensions,
+      undefined,
+      collaborative
+    );
 
     const newTabPromises: Promise<string> = [];
 
-    for(let i = 0; i < extraPages.length; i++) {
+    for (let i = 0; i < extraPages.length; i++) {
       const p = extraPages[i];
 
-      newTabPromises.push(p.close()
-        .then(() => browser.newPage())
-        .then(async (p) => {
-          extraPages[i] = p;
-          await loadInst(p, currentInst, collaborative);
-        })
+      newTabPromises.push(
+        p
+          .close()
+          .then(() => browser.newPage())
+          .then(async (p) => {
+            extraPages[i] = p;
+            await loadInst(p, currentInst, collaborative);
+          })
       );
     }
 


### PR DESCRIPTION
This feature *enhances* the "development capability expansion" process (when using argument flags).
 
It provides a new function `procHasFlag` to check for short / long flags in:
```ts
process.argv
```

`procHasFlag` accepts a single parameter (an enum value from) `KnownFlags` which is mapped to `KnownFlagsLong` and `KnownFlagsShort`; each containing a partial map of `KnownFlags` *keys* to their niche *values*.

I.E.
```ts
/**
 * Known argument flags (Flag Prefix format)
 * * These are the predefined known flags for the application and can be extended as needed.
 */
export enum KnownFlags {
  /** Whether or not to enable collaborative features (non-static insts) */
  Collaborative,

  /** Whether or not to start with dev tools open. */
  DevTools,

  /** Whether or not to load the Ao Bot inst. */
  AoBot,
}

/**
 * Known argument flags in their full / long format.
 */
export const KnownFlagsLong = {
  [KnownFlags.Collaborative]: "collaborative",
  [KnownFlags.DevTools]: "dev-tools",
  [KnownFlags.AoBot]: "ao-bot",
} as const satisfies Partial<Record<KnownFlags, string>>;

/**
 * Known argument flags in their short format.
 */
export const KnownFlagsShort = {
  [KnownFlags.Collaborative]: "c",
  [KnownFlags.DevTools]: "d",
} as const satisfies Partial<Record<KnownFlags, string>>;
```

These `KnownFlagsLong` and `KnownFlagsShort` values are what are ultimately checked for in the new  `procHasFlag` function.

E.G.
```sh
bun dev -d --collaborative
```
```ts
// True when -d or --dev-tools flags are present, which in this case -d is.
const startWithDevtools = procHasFlag(KnownFlags.DevTools); 

// True when -c or --collaborative flags are present, which in this case --collaborative is.
const collaborative = procHasFlag(KnownFlags.Collaborative);
```

It should be noted the `KnownFlags` enum and at least one of `KnownFlagsLong` or `KnownFlagsShort` (mapped to the new `KnownFlags` value) needs to be updated for `procHasFlag` to check for any additional / expanded flags.

If you want to check for arbitrary flags (which follow the configured prefix format) you can use the new `procHasFlagString` function.

Configured prefix format:
```ts
/** The prefix expected to be used for long-form flags */
export const FLAG_PREFIX: "--" = "--" as const;
/** The prefix expected to be used for short-form flags */
export const SHORT_FLAG_PREFIX: "-" = "-" as const;
```

`procHasFlagString` declaration:
```ts
/**
 * Arbitrary argument flag checker
 * @param search Object with 'flag' and/or 'shortFlag' to search for
 */
export function procHasFlagString(search: {
  flag?: string;
  shortFlag?: string;
}): boolean {
  return argvCache.some(
    (a) =>
      a === `${FLAG_PREFIX}${search?.flag}` ||
      a === `${SHORT_FLAG_PREFIX}${search?.shortFlag}`
  );
}
```

Beware of `undefined` in this `procHasFlagString` search parameter because it would trigger true for (in this case) -undefined or --undefined flags.


