### PR TITLE
Support using a record key in the URL query for annotations

### DIFF
--- a/packages/Playlist/playlist/playlistMode/AddAnotationUI.tsx
+++ b/packages/Playlist/playlist/playlistMode/AddAnotationUI.tsx
@@ -1,6 +1,6 @@
 const { useState, useLayoutEffect, useRef, useMemo } = os.appHooks;
 import {
-  getUserRecord,
+  getAnnotationRecord,
   createAnnotation,
   saveAnnotation,
 } from "db.annotations.library";
@@ -533,16 +533,16 @@ const AddAnotationUI = ({
         setList([]);
         try {
           // const latestData = await shout("chronicle_loadData", { record: latestRecord[0], targetVersion: 0 })[0];
-          const userRecord = await getUserRecord();
+          const userRecord = await getAnnotationRecord();
           const res = await os.getData(userRecord, editData?.address);
           let data = res.data.data;
-          if(data.type === 'comment') {
+          if (data.type === "comment") {
             data = res.data;
             setTextHTML(data.data.html);
             setTags([...(data.chronicle_tags || [])]);
             globalThis.IsEditingAnnotation = true;
             const booksDetails = globalThis.findNameRank(data.bookId);
-            setEditDataDetails({ 
+            setEditDataDetails({
               type: "heading",
               content: data.data.html,
               additionalInfo: {
@@ -555,8 +555,8 @@ const AddAnotationUI = ({
                 bookRank: booksDetails.item,
               },
               id: data.id,
-             });
-             console.log("editDataDetails", editDataDetails);
+            });
+            console.log("editDataDetails", editDataDetails);
           } else if (data.data) {
             setEditDataDetails({ ...data.data });
             const layers = data.data.additionalInfo?.layers?.filter(
@@ -1014,9 +1014,14 @@ const AddAnotationUI = ({
         // },
       };
 
-      const annotation = createAnnotation(book, chapter, comment, editDataDetails.additionalInfo?.verse);
+      const annotation = createAnnotation(
+        book,
+        chapter,
+        comment,
+        editDataDetails.additionalInfo?.verse
+      );
       console.log("annotation", annotation);
-      const userRecord = await getUserRecord();
+      const userRecord = await getAnnotationRecord();
       promisesArray.push(
         saveAnnotation(userRecord, { ...annotation, id: isEditAddress })
       );
@@ -1117,7 +1122,7 @@ const AddAnotationUI = ({
 
     try {
       const promisesArray = [];
-      const userRecord = await getUserRecord();
+      const userRecord = await getAnnotationRecord();
       const singleRangeTrack = {};
 
       currentList.forEach((ele) => {
@@ -1161,7 +1166,12 @@ const AddAnotationUI = ({
             //   },
             // },
           };
-          const annotation = createAnnotation(book, chapter, comment, ele.additionalInfo.verse);
+          const annotation = createAnnotation(
+            book,
+            chapter,
+            comment,
+            ele.additionalInfo.verse
+          );
           promisesArray.push(saveAnnotation(userRecord, annotation));
         }
       });

--- a/packages/Playlist/playlist/playlistMode/AnnotationList.tsx
+++ b/packages/Playlist/playlist/playlistMode/AnnotationList.tsx
@@ -1,5 +1,5 @@
 const { LoaderSecondary } = Components;
-import { deleteAnnotation, getUserRecord } from "db.annotations.library";
+import { deleteAnnotation, getAnnotationRecord } from "db.annotations.library";
 
 const { useState, useRef } = os.appHooks;
 
@@ -40,7 +40,7 @@ const AnnotationList = ({
   const onDelete = async (address) => {
     try {
       setLoading(true);
-      const userRecord = await getUserRecord();
+      const userRecord = await getAnnotationRecord();
       const res = await deleteAnnotation(userRecord, { id: address });
       if (res.success) {
         setAnnotationData((prev) => {

--- a/packages/Playlist/playlist/playlistMode/PlaylistUI.tsx
+++ b/packages/Playlist/playlist/playlistMode/PlaylistUI.tsx
@@ -1,6 +1,6 @@
 os.unregisterApp("playlist-cont-ui");
 os.registerApp("playlist-cont-ui");
-import { getUserRecord, loadAnnotations } from "db.annotations.library";
+import { getAnnotationRecord, loadAnnotations } from "db.annotations.library";
 import { ProjectProvider } from "playlist.playlistMode.useProjectContext";
 const { useSideBarContext } = await import("app.hooks.sideBar");
 const RenderIcon = await thisBot.RenderIcon();
@@ -338,7 +338,7 @@ const Playlist = () => {
         try {
           setFetchingAnnotation(true);
 
-          const userRecord = await getUserRecord();
+          const userRecord = await getAnnotationRecord();
 
           const annotations = await loadAnnotations(
             userRecord,

--- a/packages/seed-bible/db/annotations/library.tsx
+++ b/packages/seed-bible/db/annotations/library.tsx
@@ -153,6 +153,18 @@ export function getAnnotationMarker(
 }
 
 /**
+ * Gets the record that should be used for annotations.
+ * @param forceLogin Whether to force the user to log in if they are not already logged in.
+ */
+export async function getAnnotationRecord(forceLogin?: boolean) {
+  const injectedRecordKey = configBot.tags.annotationRecordKey;
+  if (injectedRecordKey) {
+    return injectedRecordKey;
+  }
+  return await getUserRecord(forceLogin);
+}
+
+/**
  * Gets the user's record name.
  *
  * Returns null if the user isn't logged in or refuses to login.


### PR DESCRIPTION
This PR adds the ability to use the `annotationRecordKey` tag from the query string of the URL for saving and loading annotations. This makes it possible for the [Seed Bible Codex Extension](https://github.com/HelloAOLab/codex-seed-bible-upload) to allow users to save annotations for translation projects in the Seed Bible and view the annotations directly in codex.