### PR TITLE
fix: Make extension write out to file path not directory

### DIFF
--- a/script/lib/extension.ts
+++ b/script/lib/extension.ts
@@ -112,7 +112,7 @@ export function generateExtension(pckgName: string, author: string) {
     version: "0.0.1",
   };
 
-  writeFile(extensionPath, JSON.stringify(extensionData, null, 2), "utf-8");
+  writeFile(extensionFilePath, JSON.stringify(extensionData, null, 2), "utf-8");
 }
 
 /**


### PR DESCRIPTION
Extremely simple fix which implements the **correct** variable representing the **file path** rather than the **directory path** for use in `writeFile`.