### PR TITLE
Make the dev tools install packages in shared space

### DIFF
--- a/packages/Assistant/aiApps/voiceAssistant/aiApps.voiceAssistant.bot.aux
+++ b/packages/Assistant/aiApps/voiceAssistant/aiApps.voiceAssistant.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "aoIDOrigin": "assistant (9)",
         "forPackage": "AO",

--- a/packages/Bible Stack/bibleStack/main/bibleStack.main.bot.aux
+++ b/packages/Bible Stack/bibleStack/main/bibleStack.main.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "UpdateHighlightedWords": null,
         "abIDOrigin": "stuck-plum-damselfly (1)",

--- a/packages/Bible Stack/bibleStack/prefabs/bibleTransformer/bibleStack.prefabs.bibleTransformer.bot.aux
+++ b/packages/Bible Stack/bibleStack/prefabs/bibleTransformer/bibleStack.prefabs.bibleTransformer.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleStack",

--- a/packages/Bible Stack/bibleStack/prefabs/book/bibleStack.prefabs.book.bot.aux
+++ b/packages/Bible Stack/bibleStack/prefabs/book/bibleStack.prefabs.book.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleStack",

--- a/packages/Bible Stack/bibleStack/prefabs/chapter/bibleStack.prefabs.chapter.bot.aux
+++ b/packages/Bible Stack/bibleStack/prefabs/chapter/bibleStack.prefabs.chapter.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleStack",

--- a/packages/Bible Stack/bibleStack/prefabs/chunkOfVerses/bibleStack.prefabs.chunkOfVerses.bot.aux
+++ b/packages/Bible Stack/bibleStack/prefabs/chunkOfVerses/bibleStack.prefabs.chunkOfVerses.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleStack",

--- a/packages/Bible Stack/bibleStack/prefabs/cover/bibleStack.prefabs.cover.bot.aux
+++ b/packages/Bible Stack/bibleStack/prefabs/cover/bibleStack.prefabs.cover.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleStack",

--- a/packages/Bible Stack/bibleStack/prefabs/crossLine/bibleStack.prefabs.crossLine.bot.aux
+++ b/packages/Bible Stack/bibleStack/prefabs/crossLine/bibleStack.prefabs.crossLine.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleStack",

--- a/packages/Bible Stack/bibleStack/prefabs/section/bibleStack.prefabs.section.bot.aux
+++ b/packages/Bible Stack/bibleStack/prefabs/section/bibleStack.prefabs.section.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleStack",

--- a/packages/Bible Stack/bibleStack/prefabs/sectionShadow/bibleStack.prefabs.sectionShadow.bot.aux
+++ b/packages/Bible Stack/bibleStack/prefabs/sectionShadow/bibleStack.prefabs.sectionShadow.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleStack",

--- a/packages/Bible Stack/bibleStack/prefabs/shadow/bibleStack.prefabs.shadow.bot.aux
+++ b/packages/Bible Stack/bibleStack/prefabs/shadow/bibleStack.prefabs.shadow.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleStack",

--- a/packages/Bible Stack/bibleStack/prefabs/testament/bibleStack.prefabs.testament.bot.aux
+++ b/packages/Bible Stack/bibleStack/prefabs/testament/bibleStack.prefabs.testament.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleStack",

--- a/packages/Bible Stack/bibleStack/prefabs/verse/bibleStack.prefabs.verse.bot.aux
+++ b/packages/Bible Stack/bibleStack/prefabs/verse/bibleStack.prefabs.verse.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleStack",

--- a/packages/Bible Visualization Utils/bibleVizUtils/classes/bibleVizUtils.classes.bot.aux
+++ b/packages/Bible Visualization Utils/bibleVizUtils/classes/bibleVizUtils.classes.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "aoIDOrigin": "bibleVizUtils",
         "forPackage": "Bible Stack",

--- a/packages/Bible Visualization Utils/bibleVizUtils/data/bibleVizUtils.data.bot.aux
+++ b/packages/Bible Visualization Utils/bibleVizUtils/data/bibleVizUtils.data.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "BRUSH_CURSOR_URL": "https://auth-aux-aobot-prod-filesbucket-141297942820.s3.amazonaws.com/Sandbox/c323206388a7991796eef65d04389cb68ff9876a20457b6f54009de84509aaf5.webp",
         "CHAPTER_DRAGGING_TIME_THRESHOLD": "25",

--- a/packages/Bible Visualization Utils/bibleVizUtils/functions/bibleVizUtils.functions.bot.aux
+++ b/packages/Bible Visualization Utils/bibleVizUtils/functions/bibleVizUtils.functions.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "aoIDOrigin": "bibleVizUtils",
         "forPackage": "Bible Stack",

--- a/packages/Bible Visualization Utils/bibleVizUtils/main/bibleVizUtils.main.bot.aux
+++ b/packages/Bible Visualization Utils/bibleVizUtils/main/bibleVizUtils.main.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "aoIDOrigin": "bibleVizUtils",
         "forPackage": "Bible Stack",

--- a/packages/Bible Visualization Utils/bibleVizUtils/prefabs/activityNotification/bibleVizUtils.prefabs.activityNotification.bot.aux
+++ b/packages/Bible Visualization Utils/bibleVizUtils/prefabs/activityNotification/bibleVizUtils.prefabs.activityNotification.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleVizUtils",

--- a/packages/Bible Visualization Utils/bibleVizUtils/prefabs/infoLabel/bibleVizUtils.prefabs.infoLabel.bot.aux
+++ b/packages/Bible Visualization Utils/bibleVizUtils/prefabs/infoLabel/bibleVizUtils.prefabs.infoLabel.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleVizUtils",

--- a/packages/Bible Visualization Utils/bibleVizUtils/prefabs/infoLabelDate/bibleVizUtils.prefabs.infoLabelDate.bot.aux
+++ b/packages/Bible Visualization Utils/bibleVizUtils/prefabs/infoLabelDate/bibleVizUtils.prefabs.infoLabelDate.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "absoluteDateFormAddress": "https://auth-aux-aobot-prod-filesbucket-141297942820.s3.amazonaws.com/Canvas/69c95c260f512caab92f2eff1596fa654391543a3d1a33a787b9c16af5d34ce2.png",

--- a/packages/Bible Visualization Utils/bibleVizUtils/prefabs/infoLabelTail/bibleVizUtils.prefabs.infoLabelTail.bot.aux
+++ b/packages/Bible Visualization Utils/bibleVizUtils/prefabs/infoLabelTail/bibleVizUtils.prefabs.infoLabelTail.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleVizUtils",

--- a/packages/Bible Visualization Utils/bibleVizUtils/prefabs/infoLabelTransformer/bibleVizUtils.prefabs.infoLabelTransformer.bot.aux
+++ b/packages/Bible Visualization Utils/bibleVizUtils/prefabs/infoLabelTransformer/bibleVizUtils.prefabs.infoLabelTransformer.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleVizUtils",

--- a/packages/Bible Visualization Utils/bibleVizUtils/prefabs/userColor/bibleVizUtils.prefabs.userColor.bot.aux
+++ b/packages/Bible Visualization Utils/bibleVizUtils/prefabs/userColor/bibleVizUtils.prefabs.userColor.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "bibleVizUtils",

--- a/packages/BookSelector/introduction/searchBar/introduction.searchBar.bot.aux
+++ b/packages/BookSelector/introduction/searchBar/introduction.searchBar.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "aoIDOrigin": "seed-bible",
         "auxCodeOrigin": "happy-aqua-bee.aux",

--- a/packages/Calendar/ext_calendar/calendar/ext_calendar.calendar.bot.aux
+++ b/packages/Calendar/ext_calendar/calendar/ext_calendar.calendar.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "63658d83-4f20-4971-89d0-82560bf1ecba": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "forPackage": "Calendar",
         "system": "ext_calendar.calendar"

--- a/packages/Canvas/canvas/canvasApp/canvas.canvasApp.bot.aux
+++ b/packages/Canvas/canvas/canvasApp/canvas.canvasApp.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "forPackage": "Canvas",
         "system": "canvas.canvasApp"

--- a/packages/Draw/aiApps/painter/aiApps.painter.bot.aux
+++ b/packages/Draw/aiApps/painter/aiApps.painter.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "forPackage": "Draw",
         "system": "aiApps.painter"

--- a/packages/Eraser/ext_canvas/eraseTool/ext_canvas.eraseTool.bot.aux
+++ b/packages/Eraser/ext_canvas/eraseTool/ext_canvas.eraseTool.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "anchorPoint": "center",

--- a/packages/Events/ext_canvas/eventTool/ext_canvas.eventTool.bot.aux
+++ b/packages/Events/ext_canvas/eventTool/ext_canvas.eventTool.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "abIDOrigin": "stuck-plum-damselfly (1)",
         "aoIDOrigin": "eventTool",

--- a/packages/GeoImporter/ext_geoImporter/importer/ext_geoImporter.importer.bot.aux
+++ b/packages/GeoImporter/ext_geoImporter/importer/ext_geoImporter.importer.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "BookUrl": "https://bible.helloao.org/api/BSB/books.json",
         "abIDOrigin": "stuck-plum-damselfly (1)",

--- a/packages/Location/ext_canvas/highlight_locations/ext_canvas.highlight_locations.bot.aux
+++ b/packages/Location/ext_canvas/highlight_locations/ext_canvas.highlight_locations.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "forPackage": "Location",
         "system": "ext_canvas.highlight_locations"

--- a/packages/Playlist/playlist/playlistMode/playlist.playlistMode.bot.aux
+++ b/packages/Playlist/playlist/playlistMode/playlist.playlistMode.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "55f7da1d-d99e-464a-b1ab-22d99eac87e3": {
       "id": "55f7da1d-d99e-464a-b1ab-22d99eac87e3",
-      "space": "local",
       "tags": {
         "abIDOrigin": "SeedBibleDemo-KKK-Layers-1",
         "aoIDOrigin": "supporting-harlequin-limpet",

--- a/packages/Tabernacle/tabernacle/altar-of-sacrifice/tabernacle.altar-of-sacrifice.bot.aux
+++ b/packages/Tabernacle/tabernacle/altar-of-sacrifice/tabernacle.altar-of-sacrifice.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "8.26",

--- a/packages/Tabernacle/tabernacle/ark-of-covenant/tabernacle.ark-of-covenant.bot.aux
+++ b/packages/Tabernacle/tabernacle/ark-of-covenant/tabernacle.ark-of-covenant.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "Canvas-1RotationZ": "1.570796",

--- a/packages/Tabernacle/tabernacle/bars/tabernacle.bars.bot.aux
+++ b/packages/Tabernacle/tabernacle/bars/tabernacle.bars.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-4.853",

--- a/packages/Tabernacle/tabernacle/bronze-laver/tabernacle.bronze-laver.bot.aux
+++ b/packages/Tabernacle/tabernacle/bronze-laver/tabernacle.bronze-laver.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "3.3",

--- a/packages/Tabernacle/tabernacle/brown-curtain/tabernacle.brown-curtain.bot.aux
+++ b/packages/Tabernacle/tabernacle/brown-curtain/tabernacle.brown-curtain.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-4.9",

--- a/packages/Tabernacle/tabernacle/cone/tabernacle.cone.bot.aux
+++ b/packages/Tabernacle/tabernacle/cone/tabernacle.cone.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "aoIDOrigin": "tabernacle",
         "color": "#8df5f3",

--- a/packages/Tabernacle/tabernacle/fence/tabernacle.fence.bot.aux
+++ b/packages/Tabernacle/tabernacle/fence/tabernacle.fence.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionZ": "-14.3",

--- a/packages/Tabernacle/tabernacle/front-curtain/tabernacle.front-curtain.bot.aux
+++ b/packages/Tabernacle/tabernacle/front-curtain/tabernacle.front-curtain.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-0.02",

--- a/packages/Tabernacle/tabernacle/front-pillars/tabernacle.front-pillars.bot.aux
+++ b/packages/Tabernacle/tabernacle/front-pillars/tabernacle.front-pillars.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "0.104",

--- a/packages/Tabernacle/tabernacle/glow/tabernacle.glow.bot.aux
+++ b/packages/Tabernacle/tabernacle/glow/tabernacle.glow.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "aoIDOrigin": "tabernacle",
         "forPackage": "Tabernacle",

--- a/packages/Tabernacle/tabernacle/grey-curtain/tabernacle.grey-curtain.bot.aux
+++ b/packages/Tabernacle/tabernacle/grey-curtain/tabernacle.grey-curtain.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-4.9",

--- a/packages/Tabernacle/tabernacle/ground/tabernacle.ground.bot.aux
+++ b/packages/Tabernacle/tabernacle/ground/tabernacle.ground.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "0",

--- a/packages/Tabernacle/tabernacle/incense-altar/tabernacle.incense-altar.bot.aux
+++ b/packages/Tabernacle/tabernacle/incense-altar/tabernacle.incense-altar.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-5.1",

--- a/packages/Tabernacle/tabernacle/inner-curtain/tabernacle.inner-curtain.bot.aux
+++ b/packages/Tabernacle/tabernacle/inner-curtain/tabernacle.inner-curtain.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-6.16",

--- a/packages/Tabernacle/tabernacle/inner-pillars/tabernacle.inner-pillars.bot.aux
+++ b/packages/Tabernacle/tabernacle/inner-pillars/tabernacle.inner-pillars.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-6.036",

--- a/packages/Tabernacle/tabernacle/manager/tabernacle.manager.bot.aux
+++ b/packages/Tabernacle/tabernacle/manager/tabernacle.manager.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "aoIDOrigin": "tabernacle",
         "ext_manager": "true",

--- a/packages/Tabernacle/tabernacle/menorah/tabernacle.menorah.bot.aux
+++ b/packages/Tabernacle/tabernacle/menorah/tabernacle.menorah.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-3.1",

--- a/packages/Tabernacle/tabernacle/purple-curtain/tabernacle.purple-curtain.bot.aux
+++ b/packages/Tabernacle/tabernacle/purple-curtain/tabernacle.purple-curtain.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-4.66",

--- a/packages/Tabernacle/tabernacle/red-curtain/tabernacle.red-curtain.bot.aux
+++ b/packages/Tabernacle/tabernacle/red-curtain/tabernacle.red-curtain.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-4.7",

--- a/packages/Tabernacle/tabernacle/rings/tabernacle.rings.bot.aux
+++ b/packages/Tabernacle/tabernacle/rings/tabernacle.rings.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-4.88",

--- a/packages/Tabernacle/tabernacle/table-of-showbread/tabernacle.table-of-showbread.bot.aux
+++ b/packages/Tabernacle/tabernacle/table-of-showbread/tabernacle.table-of-showbread.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-3.05",

--- a/packages/Tabernacle/tabernacle/walls/tabernacle.walls.bot.aux
+++ b/packages/Tabernacle/tabernacle/walls/tabernacle.walls.bot.aux
@@ -2,7 +2,6 @@
   "state": {
     "{id}": {
       "id": "{id}",
-      "space": "local",
       "tags": {
         "Canvas-1": "false",
         "positionX": "-4.75",

--- a/packages/seed-bible/app/packager/installPackage.tsx
+++ b/packages/seed-bible/app/packager/installPackage.tsx
@@ -285,7 +285,7 @@ await (async function mainInstaller(that) {
           const check = getBot("system", bot.tags.system);
           if (!check)
             create(bot, {
-              space: "local",
+              space: tags.installSpace ?? "local",
               forPackage: NameHolder,
               packageName: depName,
             });
@@ -329,7 +329,7 @@ await (async function mainInstaller(that) {
   }
 
   os.log("installing package", name, data);
-  setTagMask(thisBot, `${name}-data`, data, "local");
+  setTagMask(thisBot, `${name}-data`, data, tags.installSpace ?? "local");
 
   // Load record/source
   const read = await web.get(data.recordFile?.url || data.source);
@@ -338,7 +338,7 @@ await (async function mainInstaller(that) {
   // Push secondary bots first (await if async)
   for (let i = 1; i < bots.length; i++) {
     const b = create(bots[i], {
-      space: "local",
+      space: tags.installSpace ?? "local",
       forPackage: NameHolder,
       packageName: name,
     });
@@ -347,7 +347,7 @@ await (async function mainInstaller(that) {
 
   // Push the primary (first) bot
   const bot = create(bots[0], {
-    space: "local",
+    space: tags.installSpace ?? "local",
     forPackage: NameHolder,
     packageName: name,
   });
@@ -402,13 +402,18 @@ await (async function mainInstaller(that) {
 
   // Ensure installedPackages tag is updated (FIX: use masks not tags)
   if (!masks.installedPackages) {
-    setTagMask(thisBot, "installedPackages", [name], "local");
+    setTagMask(
+      thisBot,
+      "installedPackages",
+      [name],
+      tags.installSpace ?? "local"
+    );
   } else if (!masks.installedPackages.includes(name)) {
     setTagMask(
       thisBot,
       "installedPackages",
       [...masks.installedPackages, name],
-      "local"
+      tags.installSpace ?? "local"
     );
   }
 

--- a/script/dev.ts
+++ b/script/dev.ts
@@ -15,6 +15,7 @@ import {
   loadSeedBible,
   DEFAULT_EXTENSIONS,
   loadAoBot,
+  initPage,
 } from "./lib/browser.js";
 import { rmdir, writeFile } from "node:fs/promises";
 import path from "node:path";
@@ -27,9 +28,10 @@ import type {
   StoredAux,
   StoredAuxVersion1,
 } from "@casual-simulation/aux-common";
+import prompts from "prompts";
 
 const extraExtensions = process.argv.slice(2).filter((a) => !a.startsWith("-"));
-const collaborative = procHasFlag(KnownFlags.Collaborative);
+const defaultCollaborative = procHasFlag(KnownFlags.Collaborative);
 const aoBot = procHasFlag(KnownFlags.AoBot);
 const startWithDevtools = procHasFlag(KnownFlags.DevTools);
 
@@ -39,63 +41,52 @@ const browser = await puppeteer.launch({
   devtools: startWithDevtools,
 });
 
-let page: Page;
-const extraPages: Page[] = [];
-let currentInst: string | undefined;
+let lastInst: string;
 
-async function startPage() {
-  page = await browser.newPage();
-
-  // if (server && !server.context.page) {
-  //   server.context.page = page;
-  // }
+async function loadPage(
+  page: Page | null | undefined,
+  inst?: string,
+  collaborative = defaultCollaborative
+) {
+  if (!page) {
+    page = await browser.newPage();
+  }
 
   if (aoBot) {
     await Promise.all(["ao.bot"].map((pkg) => packageSingle(pkg, "ignore")));
-    currentInst = await loadAoBot(page);
+    await loadAoBot(page, inst);
   } else {
-    const allPackages = [
-      ...new Set([...DEFAULT_EXTENSIONS, ...extraExtensions]),
-    ];
-
-    await Promise.all(allPackages.map((pkg) => packageSingle(pkg, "ignore")));
-    currentInst = await loadSeedBible(
-      page,
-      extraExtensions,
-      undefined,
-      collaborative
-    );
-
-    const newTabPromises: Promise<void>[] = [];
-
-    for (let i = 0; i < extraPages.length; i++) {
-      const p = extraPages[i];
-
-      if (!p) {
-        continue;
-      }
-
-      newTabPromises.push(
-        p
-          .close()
-          .then(() => browser.newPage())
-          .then(async (p) => {
-            extraPages[i] = p;
-            await loadInst(p, currentInst!, collaborative);
-          })
-      );
-    }
-
-    await Promise.all(newTabPromises);
+    await uploadPackagesToPage(page, inst, collaborative);
   }
 }
 
-await startPage();
+async function uploadPackagesToPage(
+  page: Page,
+  inst?: string,
+  collaborative = defaultCollaborative
+) {
+  const allPackages = [...new Set([...DEFAULT_EXTENSIONS, ...extraExtensions])];
+
+  await Promise.all(allPackages.map((pkg) => packageSingle(pkg, "ignore")));
+  lastInst = await loadSeedBible(page, extraExtensions, inst, collaborative);
+
+  const newTabPromises: Promise<void>[] = [];
+
+  await Promise.all(newTabPromises);
+}
+
+const initialPages = await browser.pages();
+const firstPage = initialPages[0];
+await loadPage(firstPage);
 
 process.on("exit", async () => {
   if (browser.connected) {
     await browser.close();
   }
+});
+
+process.on("SIGINT", () => {
+  process.exit(0);
 });
 
 browser.on("disconnected", () => {
@@ -112,11 +103,32 @@ server.context.loadInst = loadInst;
 server.context.readPackage = readPackage;
 server.context.listPackages = listPackages;
 
+async function selectPage(): Promise<Page> {
+  const pages = await browser.pages();
+
+  if (pages.length === 1) {
+    return pages[0]!;
+  }
+
+  const response = await prompts({
+    type: "select",
+    name: "page",
+    message: "Select a page:",
+    choices: pages.map((p, i) => ({
+      title: `Page ${i + 1} - ${p.url()}`,
+      value: p,
+    })),
+  });
+
+  return response.page;
+}
+
 server.defineCommand("system", {
   help: "Open the system portal",
   action: async (name) => {
     server.clearBufferedCommand();
 
+    const page = await selectPage();
     const sim = await getPrimarySim(page);
     try {
       await sim.evaluate(async (s, name) => {
@@ -137,25 +149,54 @@ server.defineCommand("system", {
 server.defineCommand("newTab", {
   help: "Open a new tab",
   action: async (inst: string | undefined | null) => {
-    server.clearBufferedCommand();
-
     if (!inst) {
-      inst = currentInst!;
+      inst = await new Promise<string | undefined>((resolve) => {
+        server.question(
+          `Instance ID (leave blank for last used): `,
+          (answer) => {
+            resolve(answer || undefined);
+          }
+        );
+      });
     }
 
-    const newPage = await browser.newPage();
-    extraPages.push(newPage);
-    await loadInst(newPage, inst, collaborative);
+    if (!inst) {
+      inst = lastInst!;
+    }
 
-    server.displayPrompt();
+    const isCollaborative = await new Promise<boolean>((resolve) => {
+      server.question(
+        `Load in collaborative mode? (y/n, default n): `,
+        (answer) => {
+          resolve(answer.toLowerCase().startsWith("y"));
+        }
+      );
+    });
+
+    const uploadPackages = await new Promise<boolean>((resolve) => {
+      server.question(
+        `Upload packages to the new tab? (y/n, default y): `,
+        (answer) => {
+          resolve(answer.toLowerCase().startsWith("n") ? false : true);
+        }
+      );
+    });
+
+    // server.
+    const newPage = await browser.newPage();
+    if (uploadPackages) {
+      await uploadPackagesToPage(newPage, inst, isCollaborative);
+    } else {
+      await initPage(newPage);
+      await loadInst(newPage, inst, isCollaborative);
+    }
   },
 });
 
 server.defineCommand("save", {
   help: "Save the current state back to the repository",
   action: async (packageName: string) => {
-    server.clearBufferedCommand();
-
+    const page = await selectPage();
     const sim = await getPrimarySim(page);
     try {
       const state = cleanupAux(
@@ -282,11 +323,18 @@ server.defineCommand("save", {
 server.defineCommand("reload", {
   help: "Reload the page with changes from disk",
   action: async () => {
-    if (page) {
-      await page.close();
-    }
-    await startPage();
-    server.displayPrompt();
+    const page = await selectPage();
+    await loadPage(page);
+  },
+});
+
+server.defineCommand("upload", {
+  help: "Upload all the packages to the current tab",
+  action: async () => {
+    const page = await selectPage();
+
+    // find visible page
+    console.log("target: ", page.url());
   },
 });
 
@@ -316,6 +364,7 @@ server.defineCommand("download", {
   action: async () => {
     server.clearBufferedCommand();
 
+    const page = await selectPage();
     await shout(page, "onChat", null, {
       message: ".download",
     });
@@ -328,7 +377,7 @@ server.defineCommand("chat", {
   help: "Send a chat message",
   action: async (message: string) => {
     server.clearBufferedCommand();
-
+    const page = await selectPage();
     await shout(page, "onChat", null, {
       message,
     });
@@ -341,7 +390,7 @@ Object.defineProperty(server.context, "run", {
   configurable: false,
   writable: false,
   enumerable: false,
-  value: (script: string) => {
+  value: (page: Page, script: string) => {
     server.clearBufferedCommand();
     const result = execScript(page, script);
     server.displayPrompt();
@@ -353,7 +402,7 @@ Object.defineProperty(server.context, "shout", {
   configurable: false,
   writable: false,
   enumerable: false,
-  value: (name: string, arg: unknown) => {
+  value: (page: Page, name: string, arg: unknown) => {
     server.clearBufferedCommand();
     const result = shout(page, name, undefined, arg);
     server.displayPrompt();

--- a/script/lib/browser.ts
+++ b/script/lib/browser.ts
@@ -205,7 +205,8 @@ export async function registerPackage(page: Page, name: string) {
     page,
     `
         const packager = getBot('system', 'app.packager');
-        setTagMask(packager, '${name}-data', ${JSON.stringify(extensionData)}, 'local');
+        packager.tags.installSpace = 'shared';
+        setTagMask(packager, '${name}-data', ${JSON.stringify(extensionData)}, 'shared');
     `
   );
 
@@ -367,7 +368,7 @@ export async function loadSeedBible(
     page,
     `
         const packager = getBot('system', 'app.packager');
-        setTagMask(packager, 'installedPackages', ${JSON.stringify(installedPackages)}, 'local');
+        setTagMask(packager, 'installedPackages', ${JSON.stringify(installedPackages)}, 'shared');
     `
   );
 


### PR DESCRIPTION
This is so that it is easier to test collaboratively using `pnpm dev`, since loading a collaborative inst will install all the packages to the shared space and then any other device will see the same bots and code.