### PR TITLE
Fix scrolling issue on iOS

### DIFF
--- a/packages/seed-bible/seed-bible/app/init.tsx
+++ b/packages/seed-bible/seed-bible/app/init.tsx
@@ -37,21 +37,6 @@ os.syncConfigBotTagsToURL([
 configBot.tags.gridPortal = null;
 configBot.tags.mapPortal = null;
 
-// From https://rnwest.engineer/detect-webkit/
-function isWebKit() {
-  const ua = navigator.userAgent;
-  // As far as I can tell, Chromium-based desktop browsers are the only browsers
-  // that pretend to be WebKit-based but aren't.
-  return (
-    (/AppleWebKit/.test(ua) && !/Chrome/.test(ua)) ||
-    /\b(iPad|iPhone|iPod)\b/.test(ua)
-  );
-}
-
-if (isWebKit()) {
-  document.body.classList.add("is-webkit");
-}
-
 console.log("Starting APP");
 render(<Main />, document.body);
 

--- a/packages/seed-bible/seed-bible/app/init.tsx
+++ b/packages/seed-bible/seed-bible/app/init.tsx
@@ -37,6 +37,21 @@ os.syncConfigBotTagsToURL([
 configBot.tags.gridPortal = null;
 configBot.tags.mapPortal = null;
 
+// From https://rnwest.engineer/detect-webkit/
+function isWebKit() {
+  const ua = navigator.userAgent;
+  // As far as I can tell, Chromium-based desktop browsers are the only browsers
+  // that pretend to be WebKit-based but aren't.
+  return (
+    (/AppleWebKit/.test(ua) && !/Chrome/.test(ua)) ||
+    /\b(iPad|iPhone|iPod)\b/.test(ua)
+  );
+}
+
+if (isWebKit()) {
+  document.body.classList.add("is-webkit");
+}
+
 console.log("Starting APP");
 render(<Main />, document.body);
 

--- a/packages/seed-bible/seed-bible/app/main.css
+++ b/packages/seed-bible/seed-bible/app/main.css
@@ -2090,12 +2090,14 @@ h6 {
 /* For some reason, pointer-events doesn't get set properly on iOS sometimes */
 /* On mobile, we can just hide and show the selector anyways because we disable transitions for mobile devices */
 .is-webkit {
-  & .sb-selector-overlay {
+  & .sb-selector-overlay,
+  &.sb-selector-overlay {
     display: none;
     pointer-events: all;
   }
 
-  & .sb-selector-overlay.open {
+  & .sb-selector-overlay.open,
+  &.sb-selector-overlay.open {
     display: flex;
   }
 }

--- a/packages/seed-bible/seed-bible/app/main.css
+++ b/packages/seed-bible/seed-bible/app/main.css
@@ -2102,6 +2102,17 @@ h6 {
   }
 }
 
+@media (max-width: 768px) {
+  .sb-selector-overlay {
+    display: none;
+    pointer-events: all;
+  }
+
+  .sb-selector-overlay.open {
+    display: flex;
+  }
+}
+
 .sb-selector-panel {
   position: absolute;
   overflow: auto;

--- a/packages/seed-bible/seed-bible/app/main.css
+++ b/packages/seed-bible/seed-bible/app/main.css
@@ -2086,6 +2086,20 @@ h6 {
   /* background: rgba(0, 0, 0, 0.3); */
 }
 
+/* Fix for iOS devices */
+/* For some reason, pointer-events doesn't get set properly on iOS sometimes */
+/* On mobile, we can just hide and show the selector anyways because we disable transitions for mobile devices */
+.is-webkit {
+  & .sb-selector-overlay {
+    display: none;
+    pointer-events: all;
+  }
+
+  & .sb-selector-overlay.open {
+    display: flex;
+  }
+}
+
 .sb-selector-panel {
   position: absolute;
   overflow: auto;

--- a/packages/seed-bible/seed-bible/app/main.tsx
+++ b/packages/seed-bible/seed-bible/app/main.tsx
@@ -83,6 +83,20 @@ export function Main() {
   );
 }
 
+// From https://rnwest.engineer/detect-webkit/
+function isWebKit() {
+  const ua = navigator.userAgent;
+  // As far as I can tell, Chromium-based desktop browsers are the only browsers
+  // that pretend to be WebKit-based but aren't.
+  return (
+    (/AppleWebKit/.test(ua) && !/Chrome/.test(ua)) ||
+    /\b(iPad|iPhone|iPod)\b/.test(ua)
+  );
+}
+
+const isWebKitBrowser = isWebKit();
+const webkitClass = isWebKitBrowser ? "is-webkit" : "";
+
 function MainContent(props: {
   state: ReturnType<typeof createSeedBibleState>;
   fontSizeClass: string;
@@ -95,7 +109,7 @@ function MainContent(props: {
   return (
     <>
       <div
-        className={`sb-app-root ${fontSizeClass}`}
+        className={`sb-app-root ${fontSizeClass} ${webkitClass}`}
         dir={appDirection}
         onClick={(e) => {
           if (!e.defaultPrevented) {
@@ -125,7 +139,7 @@ function MainContent(props: {
               themeCssClasses={theme.themeCssClasses}
             />
             <BibleSelector
-              className={fontSizeClass}
+              className={`${fontSizeClass} ${webkitClass}`}
               isOpen={selector.isOpen.value}
               onClose={() => selector.setOpen(false)}
               selectorState={selector}


### PR DESCRIPTION
There was an issue where iOS (WebKit) browsers would sometimes not be able to scroll in the bible reader after selecting a chapter from the book selector. I tracked the issue down to being a weird CSS state thing in WebKit where the book selector would appear to be closed, but would still prevent pointer events from reaching the bible reader. The solution was to use the CSS display class instead of `pointer-events` and transparency for WebKit. Mobile devices don't use transitions for opening the book selector anyways.