### PR TITLE
Fix some issues with session highlighting

### DIFF
--- a/packages/seed-bible/seed-bible/app/main.css
+++ b/packages/seed-bible/seed-bible/app/main.css
@@ -75,9 +75,6 @@
   --sb-verse-words-of-jesus-font-family: inherit;
   --sb-verse-words-of-jesus-font-style: inherit;
 
-  --sb-selected-verse-font-family: inherit;
-  --sb-selected-verse-font-color: inherit;
-  --sb-selected-verse-background-color: inherit;
   --sb-selected-verse-border-bottom: 2px dashed currentColor;
   --sb-selected-verse-text-decoration: none;
   --sb-selected-verse-text-decoration-color: currentColor;
@@ -1328,9 +1325,6 @@ h6 {
 }
 
 .sb-verse-selected .sb-verse-decorator {
-  font-family: var(--sb-selected-verse-font-family);
-  color: var(--sb-selected-verse-font-color);
-  background-color: var(--sb-selected-verse-background-color);
   border-bottom: var(--sb-selected-verse-border-bottom);
   text-decoration: var(--sb-selected-verse-text-decoration);
   text-decoration-color: var(--sb-selected-verse-text-decoration-color);

--- a/packages/seed-bible/seed-bible/components/BibleReader.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReader.tsx
@@ -3,7 +3,7 @@ import {
   type ChapterVerse,
 } from "seed-bible.managers.FreeUseBibleAPI";
 import type { JSX } from "preact";
-import { computed } from "@preact/signals";
+import { useComputed } from "@preact/signals";
 import type {
   BibleReadingState,
   BibleSelectedVerse,
@@ -844,15 +844,15 @@ export function BibleReader(props: BibleReaderProps) {
     selectFootnote,
   } = readingState;
 
-  const currentBook = computed(
+  const currentBook = useComputed(
     () =>
       translationBooks.value?.books.find((book) => book.id === bookId.value) ??
       null
   );
-  const translationLicenseNotice = computed(
+  const translationLicenseNotice = useComputed(
     () => translation.value?.licenseNotice?.trim() ?? ""
   );
-  const translationWebsite = computed(
+  const translationWebsite = useComputed(
     () => translation.value?.website.trim() ?? ""
   );
 

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar.tsx
@@ -205,7 +205,7 @@ function sharedHighlightDecorationId(
 }
 
 /**
- * Broadcasts a highlight to the rest of a shared session by creating one
+ * Broadcasts a decoration to the rest of a shared session by creating one
  * `VerseDecoration` per selected verse. The decoration is synced through
  * `SessionsManager`'s existing decorations CRDT, so other connected clients
  * see the exact same visual styling.
@@ -214,7 +214,7 @@ function sharedHighlightDecorationId(
  * we schedule a local removal after that many seconds — the removal also
  * propagates through the CRDT so every client clears it at once.
  */
-function broadcastHighlightToSession(
+function broadcastDecorationToSession(
   session: BibleReadingSession | null,
   rs: BibleReadingState,
   details: {
@@ -253,6 +253,7 @@ function broadcastHighlightToSession(
         className,
         ...(style ? { style } : {}),
         preserveOnChapterChange: false,
+        removeAfterMs: duration ? duration * 1000 : undefined,
       },
       id
     );
@@ -275,7 +276,7 @@ function broadcastHighlightToSession(
  * Routes through the session's CRDT map so the removal propagates.
  */
 function removeSharedHighlightsFromSelection(
-  session: BibleReadingSession | null,
+  session: BibleReadingSession,
   rs: BibleReadingState
 ): void {
   for (const verse of rs.selectedVerses.value) {
@@ -328,7 +329,7 @@ function applyHighlightWithSession(
   //   void rs.highlightSelectedVerses(details);
   // }
 
-  broadcastHighlightToSession(session, rs, details);
+  broadcastDecorationToSession(session, rs, details);
 }
 
 interface BibleReaderToolbarProps {
@@ -583,12 +584,28 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
   const hasAnyHighlighted = useComputed(() => {
     const rs = readingState.value;
     if (!rs) return false;
-    return rs.selectedVerses.value.some((verse) => {
-      const existing = rs.highlights.value.highlights.find((h) =>
-        highlightContainsVerse(h, verse.verse.number)
+
+    if (sessionState.value) {
+      // Shared sessions use decorations, not highlights
+      const currentBookId = rs.bookId.value;
+      const currentChapterNumber = rs.chapterNumber.value;
+
+      return rs.selectedVerses.value.some((verse) =>
+        rs.decorations.value.some(
+          (d) =>
+            d.bookId === currentBookId &&
+            d.chapterNumber === currentChapterNumber &&
+            d.verses.includes(verse.verse.number)
+        )
       );
-      return !!existing;
-    });
+    } else {
+      return rs.selectedVerses.value.some((verse) => {
+        const existing = rs.highlights.value.highlights.find((h) =>
+          highlightContainsVerse(h, verse.verse.number)
+        );
+        return !!existing;
+      });
+    }
   });
 
   const selectedVersesReference = useComputed(() => {
@@ -1064,13 +1081,16 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                 onClick={() => {
                   const rs = readingState.value;
                   if (!rs) return;
-                  // Clean up the shared decoration first so the removal
-                  // propagates to other clients even if the local
-                  // unhighlight is a no-op (e.g. user isn't logged in
-                  // with HighlightsManager but the session had a
-                  // decoration broadcast earlier).
-                  removeSharedHighlightsFromSelection(sessionState.value, rs);
-                  rs.unhighlightSelectedVerses();
+                  if (sessionState.value) {
+                    // Clean up the shared decoration first so the removal
+                    // propagates to other clients even if the local
+                    // unhighlight is a no-op (e.g. user isn't logged in
+                    // with HighlightsManager but the session had a
+                    // decoration broadcast earlier).
+                    removeSharedHighlightsFromSelection(sessionState.value, rs);
+                  } else {
+                    rs.unhighlightSelectedVerses();
+                  }
                 }}
                 aria-label={t("clear-highlight", {
                   defaultValue: "Clear highlight",

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar.tsx
@@ -313,16 +313,20 @@ function applyHighlightWithSession(
     customFontColor?: string;
   }
 ): void {
-  const duration = session?.options.value.highlightDurationSeconds ?? null;
-  const isTransient = session !== null && duration !== null && duration > 0;
+  // const duration = session?.options.value.highlightDurationSeconds ?? null;
+  // const isTransient = session !== null && duration !== null && duration > 0;
 
-  if (isTransient) {
-    // Wipe any prior permanent highlight on these verses so the timer is
-    // the sole source of truth for how long the highlight shows.
-    void rs.unhighlightSelectedVerses();
-  } else {
+  if (!session) {
     void rs.highlightSelectedVerses(details);
   }
+
+  // if (isTransient) {
+  //   // Wipe any prior permanent highlight on these verses so the timer is
+  //   // the sole source of truth for how long the highlight shows.
+  //   void rs.unhighlightSelectedVerses();
+  // } else {
+  //   void rs.highlightSelectedVerses(details);
+  // }
 
   broadcastHighlightToSession(session, rs, details);
 }

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar.tsx
@@ -317,7 +317,7 @@ function applyHighlightWithSession(
   // const duration = session?.options.value.highlightDurationSeconds ?? null;
   // const isTransient = session !== null && duration !== null && duration > 0;
 
-  if (!session) {
+  if (!session || session.userCanDecorate(session.localSessionId.value)) {
     void rs.highlightSelectedVerses(details);
   }
 
@@ -585,7 +585,12 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
     const rs = readingState.value;
     if (!rs) return false;
 
-    if (sessionState.value) {
+    if (
+      sessionState.value &&
+      sessionState.value.userCanDecorate(
+        sessionState.value.localSessionId.value
+      )
+    ) {
       // Shared sessions use decorations, not highlights
       const currentBookId = rs.bookId.value;
       const currentChapterNumber = rs.chapterNumber.value;
@@ -1081,7 +1086,12 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                 onClick={() => {
                   const rs = readingState.value;
                   if (!rs) return;
-                  if (sessionState.value) {
+                  if (
+                    sessionState.value &&
+                    sessionState.value.userCanDecorate(
+                      sessionState.value.localSessionId.value
+                    )
+                  ) {
                     // Clean up the shared decoration first so the removal
                     // propagates to other clients even if the local
                     // unhighlight is a no-op (e.g. user isn't logged in
@@ -1214,6 +1224,8 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                 const bookmarkLabel = isSelectionBookmarked
                   ? t("remove-bookmark", { defaultValue: "Remove bookmark" })
                   : t("bookmark-verses", { defaultValue: "Bookmark" });
+
+                // const canHighlight = !sessionState.value || sessionState.value.userCanDecorate(sessionState.value.localSessionId.value);
                 return (
                   <>
                     {selectionUI.value.showHighlightColors && (

--- a/packages/seed-bible/seed-bible/managers/SessionsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SessionsManager.tsx
@@ -1,4 +1,4 @@
-import { effect, signal, type ReadonlySignal } from "@preact/signals";
+import { computed, effect, signal, type ReadonlySignal } from "@preact/signals";
 import {
   createBibleReadingState,
   type BibleReadingState,
@@ -316,6 +316,22 @@ export interface BibleReadingSession {
    */
   removeSharedDecoration: (decorationId: string) => void;
   dispose: () => void;
+
+  localSessionId: ReadonlySignal<string>;
+
+  /**
+   * Returns true if the given session ID (userId or connectionId) is
+   * permitted to navigate in this session. When `allowedNavigators` is
+   * null or empty every participant may navigate.
+   */
+  userCanNavigate: (sessionId: string) => boolean;
+
+  /**
+   * Returns true if the given session ID (userId or connectionId) is
+   * permitted to add decorations in this session. When `allowedDecorators`
+   * is null or empty every participant may decorate.
+   */
+  userCanDecorate: (sessionId: string) => boolean;
 }
 
 function createSessionId(): string {
@@ -384,6 +400,9 @@ async function createBibleReadingSession(
     (typeof configBot !== "undefined" ? toStringOrNull(configBot?.id) : null) ??
     "local";
   const decorationOwners = new Map<string, string>();
+  const localSessionId = computed(
+    () => loginManager.userId.value ?? localConnectionId
+  );
 
   if (defaultOptions) {
     document.transact(() => {
@@ -411,6 +430,22 @@ async function createBibleReadingSession(
   let pendingRemoteTarget: SessionData | null = null;
   let remoteClientsVersion = 0;
   let applyingRemoteDecorations = false;
+
+  const userCanNavigate = (sessionId: string): boolean => {
+    const { allowedNavigators } = options.value;
+    if (!allowedNavigators || allowedNavigators.length === 0) {
+      return true;
+    }
+    return allowedNavigators.includes(sessionId);
+  };
+
+  const userCanDecorate = (sessionId: string): boolean => {
+    const { allowedDecorators } = options.value;
+    if (!allowedDecorators || allowedDecorators.length === 0) {
+      return true;
+    }
+    return allowedDecorators.includes(sessionId);
+  };
 
   const getSharedDecorationEntries = () => {
     const entries = new Map<
@@ -671,18 +706,8 @@ async function createBibleReadingSession(
       return;
     }
 
-    if (
-      options.value.allowedNavigators &&
-      options.value.allowedNavigators.length > 0
-    ) {
-      // A logged-in user is identified by their userId; an anonymous user
-      // by their connectionId. Combining both into a single key avoids
-      // the bug where a logged-in user in the allow-list was still
-      // blocked because their connectionId wasn't *also* in the list.
-      const myKey = loginManager.userId.value ?? localConnectionId;
-      if (!options.value.allowedNavigators.includes(myKey)) {
-        return;
-      }
+    if (!userCanNavigate(localSessionId.value)) {
+      return;
     }
 
     const nextSessionData = getSessionDataSnapshot(readingState);
@@ -732,14 +757,8 @@ async function createBibleReadingSession(
       return;
     }
 
-    if (
-      options.value.allowedDecorators &&
-      options.value.allowedDecorators.length > 0
-    ) {
-      const myKey = loginManager.userId.value ?? localConnectionId;
-      if (!options.value.allowedDecorators.includes(myKey)) {
-        return;
-      }
+    if (!userCanDecorate(localSessionId.value)) {
+      return;
     }
 
     const localDecorations = currentDecorations.filter((decoration) => {
@@ -927,6 +946,9 @@ async function createBibleReadingSession(
     connectedUsers,
     removeSharedDecoration,
     dispose,
+    localSessionId,
+    userCanNavigate,
+    userCanDecorate,
   };
 }
 

--- a/packages/seed-bible/seed-bible/managers/SessionsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SessionsManager.tsx
@@ -471,7 +471,6 @@ async function createBibleReadingSession(
         if (currentDecorationIds.has(decorationId)) {
           readingState.removeDecoration(decorationId);
         }
-
         readingState.decorateVerses(
           entry.decoration.bookId,
           entry.decoration.chapterNumber,
@@ -725,6 +724,9 @@ async function createBibleReadingSession(
     void readingState.translationId.value;
     void readingState.bookId.value;
     void readingState.chapterNumber.value;
+    // We need to read the decorations signal before
+    // checking any early-exit conditions, so that this effect re-runs whenever decorations change
+    const currentDecorations = readingState.decorations.value;
 
     if (applyingRemoteDecorations) {
       return;
@@ -740,7 +742,6 @@ async function createBibleReadingSession(
       }
     }
 
-    const currentDecorations = readingState.decorations.value;
     const localDecorations = currentDecorations.filter((decoration) => {
       const owner = decorationOwners.get(decoration.id);
       if (!owner) {
@@ -762,6 +763,7 @@ async function createBibleReadingSession(
     const keysToDelete = localSharedDecorations
       .filter((entry) => !localDecorationIds.has(entry.decoration.id))
       .map((entry) => entry.key);
+
     const decorationsToUpsert = localDecorations.filter((decoration) => {
       const existingDecoration = sharedDecorationEntries.get(
         decoration.id

--- a/packages/seed-bible/seed-bible/managers/ThemeManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ThemeManager.tsx
@@ -121,21 +121,6 @@ export interface BibleThemeVariables {
   verseCursor?: string | null;
 
   /**
-   * The font family for selected verses. This can be used to differentiate selected verses from unselected verses, but can be customized as needed. If not set, it will default to the verseFontFamily.
-   */
-  selectedVerseFontFamily?: string | null;
-
-  /**
-   * The font color for selected verses. This can be used to differentiate selected verses from unselected verses, but should generally have good contrast against the readerBackground color for readability. If not set, it will default to the verseFontColor.
-   */
-  selectedVerseFontColor?: string | null;
-
-  /**
-   * The background color for selected verses. This can be used to highlight selected verses, but should generally be a light color with good contrast against the selectedVerseFontColor for readability. If not set, selected verses will not have a different background color than unselected verses.
-   */
-  selectedVerseBackgroundColor?: string | null;
-
-  /**
    * The text decoration for selected verses (e.g. "underline", "line-through", "none"). This can be used to further differentiate selected verses from unselected verses, but can be customized as needed. If not set, it will default to "none".
    */
   selectedVerseTextDecoration?: string | null;
@@ -520,9 +505,6 @@ const LIGHT_THEME: BibleTheme = {
     verseFontColor: "#333",
     verseCursor: "pointer",
 
-    selectedVerseFontFamily: "inherit",
-    selectedVerseFontColor: "inherit",
-    selectedVerseBackgroundColor: "inherit",
     selectedVerseBorderBottom: "2px dashed currentColor",
     selectedVerseTextDecoration: "none",
     selectedVerseTextDecorationColor: "currentColor",
@@ -663,9 +645,6 @@ const DARK_THEME: BibleTheme = {
     verseFontColor: "#d7deef",
     verseCursor: "pointer",
 
-    selectedVerseFontFamily: "inherit",
-    selectedVerseFontColor: "inherit",
-    selectedVerseBackgroundColor: "inherit",
     selectedVerseBorderBottom: "2px dashed currentColor",
     selectedVerseTextDecoration: "none",
     selectedVerseTextDecorationColor: "currentColor",

--- a/packages/seed-bible/seed-bible/managers/ThemeManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ThemeManager.tsx
@@ -766,8 +766,6 @@ export type ThemeColorKey =
   | "bookTitleFontColor"
   | "chapterHeadingFontColor"
   | "verseFontColor"
-  | "selectedVerseFontColor"
-  | "selectedVerseBackgroundColor"
   | "selectedVerseTextDecorationColor"
   | "hebrewSubtitleFontColor"
   | "readerToolbarBackground"
@@ -836,11 +834,6 @@ export const THEME_COLOR_GROUPS: ThemeColorGroup[] = [
     id: "selection",
     title: "Verse selection",
     fields: [
-      { key: "selectedVerseFontColor", label: "Selected verse text" },
-      {
-        key: "selectedVerseBackgroundColor",
-        label: "Selected verse background",
-      },
       {
         key: "selectedVerseTextDecorationColor",
         label: "Selected verse decoration",

--- a/test/unit/seed-bible/managers/TabsManager.test.ts
+++ b/test/unit/seed-bible/managers/TabsManager.test.ts
@@ -201,6 +201,9 @@ describe("createTabs", () => {
       removeSharedDecoration: jest.fn(),
       dispose: jest.fn(),
       connectedUsers: signal([]),
+      localSessionId: signal("session-123"),
+      userCanDecorate: jest.fn().mockReturnValue(true),
+      userCanNavigate: jest.fn().mockReturnValue(true),
     } as BibleReadingSession;
 
     const nextTab = manager.addTab(sharedSession);


### PR DESCRIPTION
Closes #1233 

- Fixed an issue where session hosts would be prompted for login when trying to highlight a verse.
  - Now it doesn't prompt for login. Other session users just see the highlight.
- Fixed a visual bug where highlights wouldn't show up for the host until the host deselected the verses.
- Fixed an issue where highlighting became broken after one was auto-deleted by the timer.