### PR TITLE
Remove "Show navigation arrows" mobile setting.

### DIFF
--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar.tsx
@@ -738,14 +738,13 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
           {isSmallScreen.value &&
             activeMobileTab.value === "bible" &&
             (() => {
-              const showNav = settings.settings.value.showNavArrows;
               const audio =
                 audioPlayTool.value && audioPlayTool.value.visible.value
                   ? audioPlayTool.value
                   : null;
-              const prev = showNav ? previousChapterTool.value : null;
-              const next = showNav ? nextChapterTool.value : null;
-              const selector = showNav ? openSelectorTool.value : null;
+              const prev = previousChapterTool.value;
+              const next = nextChapterTool.value;
+              const selector = openSelectorTool.value;
               if (!audio && !prev && !next && !selector) return null;
 
               const AudioIcon = audio?.icon;

--- a/packages/seed-bible/seed-bible/components/SettingsPage.tsx
+++ b/packages/seed-bible/seed-bible/components/SettingsPage.tsx
@@ -904,35 +904,6 @@ function DisplayAndThemeSettingsView(props: { state: SeedBibleState }) {
           </select>
         </div>
 
-        {isMobile && (
-          <>
-            <h3 className="sb-settings-subheading">
-              {t("mobile", { defaultValue: "Mobile" })}
-            </h3>
-
-            <div className="sb-settings-toggle-row">
-              <label
-                className="sb-settings-toggle-label"
-                htmlFor="sb-show-nav-arrows"
-              >
-                {t("show-nav-arrows", {
-                  defaultValue: "Show navigation arrows",
-                })}
-              </label>
-              <input
-                id="sb-show-nav-arrows"
-                type="checkbox"
-                checked={current.showNavArrows}
-                onChange={(event: Event) => {
-                  settings.setShowNavArrows(
-                    (event.currentTarget as HTMLInputElement).checked
-                  );
-                }}
-              />
-            </div>
-          </>
-        )}
-
         <h3 className="sb-settings-subheading">
           {t("selection-ui", { defaultValue: "Selection UI" })}
         </h3>

--- a/packages/seed-bible/seed-bible/managers/SettingsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SettingsManager.tsx
@@ -125,7 +125,6 @@ export const AppSettingsSchema = z.object({
   keepScreenAwake: z.boolean(),
   customHighlightColors: z.array(z.string()).max(3),
   scriptureMargin: z.number().min(0).max(45),
-  showNavArrows: z.boolean(),
 });
 
 export const DEFAULT_SCRIPTURE_MARGIN = 27;
@@ -142,7 +141,6 @@ const TAG_TOOLBAR = "app.toolbarConfig";
 const TAG_KEEP_AWAKE = "app.keepScreenAwake";
 const TAG_CUSTOM_HIGHLIGHT_COLORS = "app.customHighlightColors";
 const TAG_SCRIPTURE_MARGIN = "app.scriptureMargin";
-const TAG_SHOW_NAV_ARROWS = "app.showNavArrows";
 
 // Profile.config keys are stored unprefixed (matching the pattern set by
 // ConfigManager for `fontSize`, `lang`, `disablePanels`).
@@ -155,7 +153,6 @@ const PROFILE_TOOLBAR = "toolbarConfig";
 const PROFILE_KEEP_AWAKE = "keepScreenAwake";
 const PROFILE_CUSTOM_HIGHLIGHT_COLORS = "customHighlightColors";
 const PROFILE_SCRIPTURE_MARGIN = "scriptureMargin";
-const PROFILE_SHOW_NAV_ARROWS = "showNavArrows";
 
 export const TEXT_FONT_OPTIONS: { value: string; label: string }[] = [
   { value: "'Newsreader', serif", label: "Newsreader" },
@@ -263,7 +260,6 @@ const DEFAULT_SETTINGS: AppSettings = {
   keepScreenAwake: false,
   customHighlightColors: [],
   scriptureMargin: DEFAULT_SCRIPTURE_MARGIN,
-  showNavArrows: true,
 };
 
 function parseCustomHighlightColors(value: unknown): string[] {
@@ -567,7 +563,6 @@ export interface SettingsManager {
   setToolbarOrder: (order: string[]) => void;
   resetToolbarConfig: () => void;
   setKeepScreenAwake: (enabled: boolean) => void;
-  setShowNavArrows: (enabled: boolean) => void;
   addCustomHighlightColor: (color: string) => void;
   removeCustomHighlightColor: (color: string) => void;
   setAllSettings: (next: AppSettings) => void;
@@ -626,11 +621,6 @@ export function createSettings(login: LoginManager): SettingsManager {
           configBot.tags[TAG_SCRIPTURE_MARGIN],
         DEFAULT_SETTINGS.scriptureMargin
       ),
-      showNavArrows: parseBoolean(
-        getProfileConfigValue(profile, PROFILE_SHOW_NAV_ARROWS) ??
-          configBot.tags[TAG_SHOW_NAV_ARROWS],
-        DEFAULT_SETTINGS.showNavArrows
-      ),
     };
   };
 
@@ -666,8 +656,7 @@ export function createSettings(login: LoginManager): SettingsManager {
       changedTags.includes(TAG_TOOLBAR) ||
       changedTags.includes(TAG_KEEP_AWAKE) ||
       changedTags.includes(TAG_CUSTOM_HIGHLIGHT_COLORS) ||
-      changedTags.includes(TAG_SCRIPTURE_MARGIN) ||
-      changedTags.includes(TAG_SHOW_NAV_ARROWS)
+      changedTags.includes(TAG_SCRIPTURE_MARGIN)
     ) {
       syncFromBot();
     }
@@ -798,13 +787,6 @@ export function createSettings(login: LoginManager): SettingsManager {
     saveProfileConfigValue(login, PROFILE_KEEP_AWAKE, nextValue);
   };
 
-  const setShowNavArrows = (enabled: boolean) => {
-    if (settings.value.showNavArrows === enabled) return;
-    settings.value = { ...settings.value, showNavArrows: enabled };
-    configBot.tags[TAG_SHOW_NAV_ARROWS] = enabled;
-    saveProfileConfigValue(login, PROFILE_SHOW_NAV_ARROWS, enabled);
-  };
-
   const writeCustomHighlightColors = (colors: string[]) => {
     settings.value = { ...settings.value, customHighlightColors: colors };
     configBot.tags[TAG_CUSTOM_HIGHLIGHT_COLORS] =
@@ -863,7 +845,6 @@ export function createSettings(login: LoginManager): SettingsManager {
     configBot.tags[TAG_KEEP_AWAKE] = false;
     configBot.tags[TAG_CUSTOM_HIGHLIGHT_COLORS] = "";
     configBot.tags[TAG_SCRIPTURE_MARGIN] = DEFAULT_SETTINGS.scriptureMargin;
-    configBot.tags[TAG_SHOW_NAV_ARROWS] = DEFAULT_SETTINGS.showNavArrows;
     saveProfileConfigValue(
       login,
       PROFILE_BOOK_ORIENTATION,
@@ -900,11 +881,6 @@ export function createSettings(login: LoginManager): SettingsManager {
       login,
       PROFILE_SCRIPTURE_MARGIN,
       DEFAULT_SETTINGS.scriptureMargin
-    );
-    saveProfileConfigValue(
-      login,
-      PROFILE_SHOW_NAV_ARROWS,
-      DEFAULT_SETTINGS.showNavArrows
     );
   };
 
@@ -963,7 +939,6 @@ export function createSettings(login: LoginManager): SettingsManager {
     setToolbarOrder,
     resetToolbarConfig,
     setKeepScreenAwake,
-    setShowNavArrows,
     addCustomHighlightColor,
     removeCustomHighlightColor,
     setAllSettings,

--- a/packages/seed-bible/seed-bible/managers/SettingsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SettingsManager.tsx
@@ -63,8 +63,6 @@ export interface AppSettings {
   customHighlightColors: string[];
   /** Horizontal padding (px) applied to the bible reader container. */
   scriptureMargin: number;
-  /** Whether to show floating prev/next chapter arrows on mobile. */
-  showNavArrows: boolean;
 }
 
 export const AppSettingsSchema = z.object({


### PR DESCRIPTION
Fixes issue #1279 

Simply removing the `showNavBar` setting from `SettingsManager` and its use in the `BibleReaderToolbar` and `SettingsPage`. Removed the entire mobile only section of the settings page until a time that we need mobile-only settings again.