### PR TITLE
fix: verse numbers and footnote icons inherit highlight color

### DIFF
--- a/packages/seed-bible/seed-bible/app/main.css
+++ b/packages/seed-bible/seed-bible/app/main.css
@@ -1434,7 +1434,8 @@ h6 {
   vertical-align: middle;
   margin-inline-start: 6px;
   margin-inline-end: 3px;
-  color: color-mix(in srgb, currentColor, transparent 30%);
+  color: inherit;
+  opacity: 0.7;
 }
 
 .sb-poem-line-1 {

--- a/packages/seed-bible/seed-bible/app/main.css
+++ b/packages/seed-bible/seed-bible/app/main.css
@@ -966,7 +966,7 @@ h6 {
   margin-inline-end: 4px;
   border: none;
   background: transparent;
-  color: var(--sb-verse-font-color);
+  color: inherit;
   cursor: pointer;
   width: 18px;
   height: 18px;
@@ -1434,7 +1434,7 @@ h6 {
   vertical-align: middle;
   margin-inline-start: 6px;
   margin-inline-end: 3px;
-  color: color-mix(in srgb, var(--sb-verse-font-color), transparent 30%);
+  color: color-mix(in srgb, currentColor, transparent 30%);
 }
 
 .sb-poem-line-1 {


### PR DESCRIPTION
Verse numbers and footnote icons had a hard-coded color tied to the
default theme font color, so they didn't pick up the highlight's font
color even though they render inside the same highlighted wrapper span
that plain verse text correctly inherits color from.

Fixes #1289