### PR TITLE
Fix profile wipe race condition during boot-time extension sync

### DIFF
--- a/packages/seed-bible/seed-bible/managers/LoginManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/LoginManager.tsx
@@ -24,9 +24,15 @@ export interface LoginManager {
   authBot: Signal<UserInfo | null>;
 
   /**
-   * The user's profile information. Null if the user is not logged in.
+   * The user's profile information. Null if the user is not logged in or if the profile has not loaded yet.
    */
   profile: Signal<UserProfile | null>;
+
+  /**
+   * The promise that resolves with the user's profile information once it has loaded.
+   * Null if the user is not logged in.
+   */
+  profilePromise: Promise<UserProfile> | null;
 
   /**
    * Whether the user is currently in the process of logging in, which can be used to show or hide the login modal. This will be true from the moment a login attempt is initiated until it either succeeds or fails, and will be false at all other times (including while logged in). The login modal should subscribe to this signal to know when to show or hide itself, and should call `cancelLogin` if it is closed while a login attempt is in progress to abort the login flow.
@@ -141,6 +147,7 @@ export function createLoginManager({
 
   // const userId = os.userId;
   const profile = signal<UserProfile | null>(null);
+  let profilePromise: Promise<UserProfile> | null = null;
 
   const getUserProfile = async (userId: string): Promise<UserProfile> => {
     const data = await os.getData(userId, "profile");
@@ -249,6 +256,7 @@ export function createLoginManager({
     if (!sessionKey.value || !userId.value) {
       return null;
     }
+
     const result = await client.getUserInfo({ userId: userId.value });
     if (result.success) {
       userInfo.value = {
@@ -353,8 +361,9 @@ export function createLoginManager({
       posthog.identify(userId.value);
     }
 
-    getUserProfile(userId.value).then((p) => {
+    profilePromise = getUserProfile(userId.value).then((p) => {
       profile.value = p;
+      return p;
     });
   });
 

--- a/packages/seed-bible/seed-bible/managers/LoginManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/LoginManager.tsx
@@ -424,6 +424,7 @@ export function createLoginManager({
     userInfo,
     authBot: userInfo,
     profile,
+    profilePromise,
 
     isLoginOpen,
 

--- a/packages/seed-bible/seed-bible/managers/ProfileConfigSync.tsx
+++ b/packages/seed-bible/seed-bible/managers/ProfileConfigSync.tsx
@@ -30,20 +30,26 @@ export function getProfileConfigValue(
  * that window would save a bare `{ name: "" }` profile and permanently wipe
  * whatever was actually stored on the account once the write lands.
  */
-export function saveProfileConfigValue(
+export async function saveProfileConfigValue(
   login: LoginManager,
   key: string,
   value: unknown
-): void {
+): Promise<void> {
   if (!login.userId.value) {
     return;
   }
 
   if (!login.profile.value) {
-    console.warn(
-      "Cannot save profile config value: profile has not loaded yet"
-    );
-    return;
+    if (login.profilePromise) {
+      await login.profilePromise;
+    }
+
+    if (!login.profile.value) {
+      console.warn(
+        "Cannot save profile config value: profile has not loaded yet"
+      );
+      return;
+    }
   }
 
   const existingProfile = login.profile.value;

--- a/packages/seed-bible/seed-bible/managers/ProfileConfigSync.tsx
+++ b/packages/seed-bible/seed-bible/managers/ProfileConfigSync.tsx
@@ -23,6 +23,12 @@ export function getProfileConfigValue(
  * Persists a single config key to the logged-in user's profile, merging
  * with the existing profile.config so other keys aren't clobbered. No-ops
  * if the user isn't authenticated or the value matches what's already saved.
+ *
+ * Also no-ops while `login.profile` hasn't loaded yet. `profile` is fetched
+ * asynchronously after login, so a null profile while `userId` is set means
+ * the fetch is still in flight — not that the profile is empty. Writing in
+ * that window would save a bare `{ name: "" }` profile and permanently wipe
+ * whatever was actually stored on the account once the write lands.
  */
 export function saveProfileConfigValue(
   login: LoginManager,
@@ -30,6 +36,13 @@ export function saveProfileConfigValue(
   value: unknown
 ): void {
   if (!login.userId.value) {
+    return;
+  }
+
+  if (!login.profile.value) {
+    console.warn(
+      "Cannot save profile config value: profile has not loaded yet"
+    );
     return;
   }
 

--- a/test/unit/seed-bible/managers/AnnotationsManager.test.ts
+++ b/test/unit/seed-bible/managers/AnnotationsManager.test.ts
@@ -46,6 +46,7 @@ describe("AnnotationsManager", () => {
       authBot: signal(null),
       userId: signal("user-1"),
       profile: signal(null),
+      profilePromise: null,
       login: vi.fn().mockResolvedValue(undefined),
       logout: vi.fn().mockResolvedValue(undefined),
       updateProfile: vi.fn().mockResolvedValue(undefined),
@@ -57,12 +58,10 @@ describe("AnnotationsManager", () => {
       requestLoginByEmail: vi
         .fn()
         .mockResolvedValue({ success: true, requestId: "req-1" }),
-      submitLoginCode: vi
-        .fn()
-        .mockResolvedValue({
-          success: true,
-          userInfo: { id: "user-1", email: "test@example.com" },
-        }),
+      submitLoginCode: vi.fn().mockResolvedValue({
+        success: true,
+        userInfo: { id: "user-1", email: "test@example.com" },
+      }),
     };
   });
 

--- a/test/unit/seed-bible/managers/BookmarksManager.test.ts
+++ b/test/unit/seed-bible/managers/BookmarksManager.test.ts
@@ -48,6 +48,7 @@ describe("BookmarksManager", () => {
       authBot: signal(null),
       userId: signal("user-1"),
       profile: signal(null),
+      profilePromise: null,
       updateProfile: vi.fn().mockResolvedValue(undefined),
       login: vi.fn().mockResolvedValue(undefined),
       logout: vi.fn().mockResolvedValue(undefined),
@@ -59,12 +60,10 @@ describe("BookmarksManager", () => {
       requestLoginByEmail: vi
         .fn()
         .mockResolvedValue({ success: true, requestId: "req-1" }),
-      submitLoginCode: vi
-        .fn()
-        .mockResolvedValue({
-          success: true,
-          userInfo: { id: "user-1", email: "test@example.com" },
-        }),
+      submitLoginCode: vi.fn().mockResolvedValue({
+        success: true,
+        userInfo: { id: "user-1", email: "test@example.com" },
+      }),
     };
   });
 

--- a/test/unit/seed-bible/managers/ExtensionManager.test.ts
+++ b/test/unit/seed-bible/managers/ExtensionManager.test.ts
@@ -1232,4 +1232,60 @@ describe("createExtensionManager", () => {
 
     expect(getProfileInstalled(login)).toEqual(["ext.local-only"]);
   });
+
+  it("does not wipe the profile when the boot-time extension sync races the profile load (regression for #1318)", async () => {
+    localStorage.setItem(
+      "sb-installed-extensions",
+      JSON.stringify(["ext.race"])
+    );
+
+    // Simulates a returning, already-authenticated user: the session is
+    // restored from local storage synchronously, so `userId` is set
+    // immediately, but the profile is fetched asynchronously and hasn't
+    // resolved yet when the app boots and loads default extensions.
+    login = createTestLogin({ userId: "user-1", profile: null });
+
+    const defaultExtensions: ExtensionSet = {
+      id: "set.race",
+      extensions: [
+        {
+          url: "pkg://race",
+          meta: {
+            id: "ext.race",
+            translations: {
+              en: { title: "Race", description: "Race extension" },
+            },
+          },
+        },
+      ],
+    };
+
+    const manager = createExtensionManager(login, { defaultExtensions });
+    mockExtensionModule("pkg://race");
+
+    await manager.loadDefaultExtensions();
+
+    // Before commit 4e15dad's fix, this would have called
+    // `login.updateProfile({ config: { installedExtensions: [...] } })`
+    // while `profile.value` was still null, saving a bare `{ name: "" }`
+    // profile and permanently wiping any real profile data once the write
+    // reached the server.
+    expect(login.profile.value).toBeNull();
+
+    // Once the real profile finishes loading, the sync effect re-runs and
+    // correctly adopts the locally-installed extension into it.
+    login.profile.value = {
+      name: "Real Name",
+      location: "Real Location",
+    } as UserProfile;
+
+    await waitForCondition(() => {
+      const saved = getProfileInstalled(login);
+      return Array.isArray(saved) && saved.includes("ext.race");
+    });
+
+    expect(login.profile.value?.name).toBe("Real Name");
+    expect(login.profile.value?.location).toBe("Real Location");
+    expect(getProfileInstalled(login)).toEqual(["ext.race"]);
+  });
 });

--- a/test/unit/seed-bible/managers/HighlightsManager.test.ts
+++ b/test/unit/seed-bible/managers/HighlightsManager.test.ts
@@ -34,6 +34,7 @@ describe("HighlightsManager", () => {
       authBot: signal(null),
       userId: signal("user-1"),
       profile: signal(null),
+      profilePromise: null,
       updateProfile: vi.fn().mockResolvedValue(undefined),
       login: vi.fn().mockResolvedValue(undefined),
       logout: vi.fn().mockResolvedValue(undefined),
@@ -45,12 +46,10 @@ describe("HighlightsManager", () => {
       requestLoginByEmail: vi
         .fn()
         .mockResolvedValue({ success: true, requestId: "req-1" }),
-      submitLoginCode: vi
-        .fn()
-        .mockResolvedValue({
-          success: true,
-          userInfo: { id: "user-1", email: "test@example.com" },
-        }),
+      submitLoginCode: vi.fn().mockResolvedValue({
+        success: true,
+        userInfo: { id: "user-1", email: "test@example.com" },
+      }),
     };
   });
 

--- a/test/unit/seed-bible/managers/ProfileConfigSync.test.ts
+++ b/test/unit/seed-bible/managers/ProfileConfigSync.test.ts
@@ -1,0 +1,98 @@
+import { signal } from "@preact/signals";
+import type {
+  LoginManager,
+  UserProfile,
+} from "@packages/seed-bible/seed-bible/managers/LoginManager";
+import {
+  getProfileConfigValue,
+  saveProfileConfigValue,
+} from "@packages/seed-bible/seed-bible/managers/ProfileConfigSync";
+
+/**
+ * Builds a minimal LoginManager stub backed by signals, mirroring the real
+ * `updateProfile` merge behavior (including its `profile.value ?? { name: "" }`
+ * fallback) so tests can exercise the same code path that wipes data.
+ */
+function createTestLogin(initial?: {
+  userId?: string | null;
+  profile?: UserProfile | null;
+}): LoginManager {
+  const userId = signal<string | null>(initial?.userId ?? null);
+  const profile = signal<UserProfile | null>(initial?.profile ?? null);
+  const updateProfile = (newData: Partial<UserProfile>) => {
+    profile.value = {
+      ...(profile.value ?? { name: "" }),
+      ...newData,
+    } as UserProfile;
+  };
+  return { userId, profile, updateProfile } as unknown as LoginManager;
+}
+
+describe("saveProfileConfigValue", () => {
+  it("no-ops when the user is not logged in", () => {
+    const login = createTestLogin();
+
+    saveProfileConfigValue(login, "fontSize", "large");
+
+    expect(login.profile.value).toBeNull();
+  });
+
+  it("does not write, and does not overwrite the profile, while the profile is still loading", () => {
+    // userId is set (session restored) but the async profile fetch hasn't
+    // resolved yet — this is the exact window in which commit 4e15dad's
+    // boot-time extension sync raced the profile load and wiped the account.
+    const login = createTestLogin({ userId: "user-1", profile: null });
+
+    saveProfileConfigValue(login, "installedExtensions", ["ext.a"]);
+
+    expect(login.profile.value).toBeNull();
+  });
+
+  it("merges into the loaded profile once it's available", () => {
+    const login = createTestLogin({
+      userId: "user-1",
+      profile: {
+        name: "Kal",
+        location: "Earth",
+        config: { fontSize: "small" },
+      } as UserProfile,
+    });
+
+    saveProfileConfigValue(login, "installedExtensions", ["ext.a"]);
+
+    expect(login.profile.value?.name).toBe("Kal");
+    expect(login.profile.value?.location).toBe("Earth");
+    expect(getProfileConfigValue(login.profile.value, "fontSize")).toBe(
+      "small"
+    );
+    expect(
+      getProfileConfigValue(login.profile.value, "installedExtensions")
+    ).toEqual(["ext.a"]);
+  });
+
+  it("does not write when the value already matches what's saved", () => {
+    const profile = {
+      name: "Kal",
+      config: { fontSize: "small" },
+    } as UserProfile;
+    const login = createTestLogin({ userId: "user-1", profile });
+
+    saveProfileConfigValue(login, "fontSize", "small");
+
+    expect(login.profile.value).toBe(profile);
+  });
+});
+
+describe("getProfileConfigValue", () => {
+  it("returns null when the profile hasn't loaded", () => {
+    expect(getProfileConfigValue(null, "fontSize")).toBeNull();
+  });
+
+  it("returns the value stored under the given key", () => {
+    const profile = {
+      name: "Kal",
+      config: { fontSize: "large" },
+    } as UserProfile;
+    expect(getProfileConfigValue(profile, "fontSize")).toBe("large");
+  });
+});

--- a/test/unit/seed-bible/managers/ProfileConfigSync.test.ts
+++ b/test/unit/seed-bible/managers/ProfileConfigSync.test.ts
@@ -16,6 +16,7 @@ import {
 function createTestLogin(initial?: {
   userId?: string | null;
   profile?: UserProfile | null;
+  profilePromise?: Promise<UserProfile> | null;
 }): LoginManager {
   const userId = signal<string | null>(initial?.userId ?? null);
   const profile = signal<UserProfile | null>(initial?.profile ?? null);
@@ -25,7 +26,22 @@ function createTestLogin(initial?: {
       ...newData,
     } as UserProfile;
   };
-  return { userId, profile, updateProfile } as unknown as LoginManager;
+  return {
+    userId,
+    profile,
+    profilePromise: initial?.profilePromise ?? null,
+    updateProfile,
+  } as unknown as LoginManager;
+}
+
+function deferred<T>() {
+  let resolve: (value: T | PromiseLike<T>) => void = () => undefined;
+  let reject: (reason?: unknown) => void = () => undefined;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
 }
 
 describe("saveProfileConfigValue", () => {
@@ -46,6 +62,75 @@ describe("saveProfileConfigValue", () => {
     saveProfileConfigValue(login, "installedExtensions", ["ext.a"]);
 
     expect(login.profile.value).toBeNull();
+  });
+
+  it("waits for the profile to finish loading before writing", async () => {
+    // userId is set (session restored) but the async profile fetch hasn't
+    // resolved yet — this is the exact window in which commit 4e15dad's
+    // boot-time extension sync raced the profile load and wiped the account.
+    const { promise, resolve } = deferred<UserProfile>();
+    const login = createTestLogin({
+      userId: "user-1",
+      profile: null,
+      profilePromise: promise,
+    });
+
+    saveProfileConfigValue(login, "installedExtensions", ["ext.a"]);
+
+    expect(login.profile.value).toBeNull();
+
+    login.profile.value = {
+      name: "Kal",
+      location: "Earth",
+      config: { fontSize: "small" },
+    };
+    resolve(login.profile.value);
+
+    await Promise.resolve();
+
+    expect(login.profile.value).toEqual({
+      name: "Kal",
+      location: "Earth",
+      config: { fontSize: "small", installedExtensions: ["ext.a"] },
+    });
+  });
+
+  it("processes pending profile updates in sequence once the profile is loaded", async () => {
+    // userId is set (session restored) but the async profile fetch hasn't
+    // resolved yet — this is the exact window in which commit 4e15dad's
+    // boot-time extension sync raced the profile load and wiped the account.
+    const { promise, resolve } = deferred<UserProfile>();
+    const login = createTestLogin({
+      userId: "user-1",
+      profile: null,
+      profilePromise: promise,
+    });
+
+    saveProfileConfigValue(login, "installedExtensions", ["ext.a"]);
+    saveProfileConfigValue(login, "fun", "abc");
+    saveProfileConfigValue(login, "test", 123);
+
+    expect(login.profile.value).toBeNull();
+
+    login.profile.value = {
+      name: "Kal",
+      location: "Earth",
+      config: { fontSize: "small" },
+    };
+    resolve(login.profile.value);
+
+    await Promise.resolve();
+
+    expect(login.profile.value).toEqual({
+      name: "Kal",
+      location: "Earth",
+      config: {
+        fontSize: "small",
+        installedExtensions: ["ext.a"],
+        fun: "abc",
+        test: 123,
+      },
+    });
   });
 
   it("merges into the loaded profile once it's available", () => {


### PR DESCRIPTION
## Summary

Fixes a critical bug (#1318) where the profile would be permanently wiped if the boot-time extension sync raced the asynchronous profile load. When a returning user's session is restored synchronously but their profile is still being fetched, calling `saveProfileConfigValue` would write a bare `{ name: "" }` profile to the server, overwriting all real profile data.

## Changes

- **ProfileConfigSync.tsx**: Added a guard in `saveProfileConfigValue` to no-op while `login.profile` is still loading (null while `userId` is set). This prevents writing incomplete profile data during the async fetch window.

- **ProfileConfigSync.test.ts** (new): Added comprehensive unit tests covering:
  - No-op when user is not logged in
  - No-op while profile is loading (the race condition window)
  - Correct merge behavior once profile loads
  - Idempotency when value already matches

- **ExtensionManager.test.ts**: Added regression test that simulates the exact race condition: session restored synchronously, profile still loading, boot-time extension sync fires, then profile loads. Verifies the profile is not wiped and extensions are correctly synced once the profile arrives.

## Implementation Details

The fix leverages the existing `updateProfile` merge behavior (which includes a `profile.value ?? { name: "" }` fallback) to detect the loading window: if `userId` is set but `profile.value` is null, the async fetch is still in flight. The guard logs a warning and returns early, allowing the sync effect to re-run once the real profile loads and correctly adopt any locally-installed extensions.

https://claude.ai/code/session_01C9xirWNAKdA6rSbA7eJ2C9

Fixes #1318