### PR TITLE
Require extensions to export a default init function

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -48,7 +48,7 @@ This is a **monorepo** (pnpm workspaces) containing a Preact-based Bible reader.
 
 ### Extensions (`packages/*-extension/`)
 
-Separate packages that call `registerExtension({ id, init })`; the `init(context)` generator receives the `SeedBibleState` and yields cleanup functions. `seed-bible-refresh-example-extension` is the reference template.
+Separate packages that `export default` a function which, when called, calls `registerExtension({ id, init })`; the `init(context)` generator receives the `SeedBibleState` and yields cleanup functions. `ExtensionManager` invokes the default export on every install attempt (not just once at module load), which is what allows an extension to be uninstalled and reinstalled within the same session. `seed-bible-refresh-example-extension` is the reference template.
 
 ### Tests (`test/`)
 

--- a/packages/audio-reader-extension/ext_audioReader/host/init.tsx
+++ b/packages/audio-reader-extension/ext_audioReader/host/init.tsx
@@ -70,52 +70,54 @@ function PauseIcon() {
   );
 }
 
-registerExtension({
-  id: "ext_audioReader",
-  init: function* (context: SeedBibleState) {
-    // The play/pause control lives in the reader's top quick toolbar,
-    // beside the bookmark button. It only shows for chapters with audio.
-    yield context.tools.registerQuickTool({
-      id: "ext_audioReader-play",
-      priority: 250,
-      title: {
-        key: "toolbarTitle",
-        defaultValue: "Listen",
-        ns: "ext_audioReader",
-      },
-      icon: () => (isPlaying.value ? <PauseIcon /> : <PlayIcon />),
-      isVisible: (ctx) =>
-        computed(() => chapterAudioUrl(ctx.readingState) !== null),
-      onSelect: (ctx) => {
-        const url = chapterAudioUrl(ctx.readingState);
-        if (!url) {
-          context.app.toast("No audio is available for this chapter.");
-          return;
-        }
-        const el = ensureAudio();
-        if (!el) return;
-        if (currentUrl !== url) {
-          el.src = url;
-          currentUrl = url;
-        }
-        if (el.paused) {
-          void el.play();
-        } else {
-          el.pause();
-        }
-      },
-    });
+export default function initAudioReaderExtension() {
+  registerExtension({
+    id: "ext_audioReader",
+    init: function* (context: SeedBibleState) {
+      // The play/pause control lives in the reader's top quick toolbar,
+      // beside the bookmark button. It only shows for chapters with audio.
+      yield context.tools.registerQuickTool({
+        id: "ext_audioReader-play",
+        priority: 250,
+        title: {
+          key: "toolbarTitle",
+          defaultValue: "Listen",
+          ns: "ext_audioReader",
+        },
+        icon: () => (isPlaying.value ? <PauseIcon /> : <PlayIcon />),
+        isVisible: (ctx) =>
+          computed(() => chapterAudioUrl(ctx.readingState) !== null),
+        onSelect: (ctx) => {
+          const url = chapterAudioUrl(ctx.readingState);
+          if (!url) {
+            context.app.toast("No audio is available for this chapter.");
+            return;
+          }
+          const el = ensureAudio();
+          if (!el) return;
+          if (currentUrl !== url) {
+            el.src = url;
+            currentUrl = url;
+          }
+          if (el.paused) {
+            void el.play();
+          } else {
+            el.pause();
+          }
+        },
+      });
 
-    // Stop and rewind whenever the active chapter changes so a previous
-    // chapter's narration never keeps playing under a new one.
-    yield effect(() => {
-      // Reading `.value` subscribes this effect to chapter navigation.
-      void context.app.currentReadingState.value;
-      if (audioEl && !audioEl.paused) {
-        audioEl.pause();
-        audioEl.currentTime = 0;
-      }
-      isPlaying.value = false;
-    });
-  },
-});
+      // Stop and rewind whenever the active chapter changes so a previous
+      // chapter's narration never keeps playing under a new one.
+      yield effect(() => {
+        // Reading `.value` subscribes this effect to chapter navigation.
+        void context.app.currentReadingState.value;
+        if (audioEl && !audioEl.paused) {
+          audioEl.pause();
+          audioEl.currentTime = 0;
+        }
+        isPlaying.value = false;
+      });
+    },
+  });
+}

--- a/packages/audio-reader-extension/index.ts
+++ b/packages/audio-reader-extension/index.ts
@@ -1,1 +1,1 @@
-import "./ext_audioReader/host/init";
+export { default } from "./ext_audioReader/host/init";

--- a/packages/locations-extension/ext_locations/init.tsx
+++ b/packages/locations-extension/ext_locations/init.tsx
@@ -6,129 +6,132 @@ import locations from "./locations.json";
 import geoImporterPattern from "virtual:@pattern/geo-importer";
 import { v4 as uuid } from "uuid";
 
-console.log("Loaded locations extension", geoImporterPattern);
-
 interface PlaceData {
   place: string;
   geojson: string;
 }
 
-registerExtension({
-  id: "ext_locations",
-  init: function* (context) {
-    const findLocationsInText = (text: string) => {
-      text = text.toLowerCase();
-      const foundPlaces = [];
-      // const locations: Record<string, PlaceData> = tags.locations;
-      const words = text.split(/[^\w]+/);
-      for (const word of words) {
-        const place = (locations as Record<string, PlaceData>)[
-          word.toLowerCase()
-        ];
-        if (place) {
-          console.log("Found place:", place);
-          foundPlaces.push(place);
-        }
-      }
+export default function initLocationsExtension() {
+  console.log("Loaded locations extension", geoImporterPattern);
 
-      return foundPlaces;
-    };
-
-    const findLocationsInVerses = (verses: ChapterVerse[]): PlaceData[] => {
-      let text = "";
-      for (const verse of verses) {
-        for (const content of verse.content) {
-          if (typeof content === "string") {
-            text += content;
-          } else if ("text" in content) {
-            text += content.text;
+  registerExtension({
+    id: "ext_locations",
+    init: function* (context) {
+      const findLocationsInText = (text: string) => {
+        text = text.toLowerCase();
+        const foundPlaces = [];
+        // const locations: Record<string, PlaceData> = tags.locations;
+        const words = text.split(/[^\w]+/);
+        for (const word of words) {
+          const place = (locations as Record<string, PlaceData>)[
+            word.toLowerCase()
+          ];
+          if (place) {
+            console.log("Found place:", place);
+            foundPlaces.push(place);
           }
         }
-      }
 
-      return findLocationsInText(text);
-    };
+        return foundPlaces;
+      };
 
-    const getPlaceGeoJsonUrl = (place: PlaceData) => {
-      if (place.place === place.geojson) {
-        return [
-          `https://raw.githubusercontent.com/Bored-Wizard/isreal_geojson/main/${place.geojson}.geojson`,
-          true,
-        ] as const;
-      } else {
-        return [
-          `https://raw.githubusercontent.com/openbibleinfo/Bible-Geocoding-Data/main/geometry/${place.geojson}.geojson`,
-          false,
-        ] as const;
-      }
-    };
+      const findLocationsInVerses = (verses: ChapterVerse[]): PlaceData[] => {
+        let text = "";
+        for (const verse of verses) {
+          for (const content of verse.content) {
+            if (typeof content === "string") {
+              text += content;
+            } else if ("text" in content) {
+              text += content.text;
+            }
+          }
+        }
 
-    const foundPlaces = computed(() => {
-      const readingState = context.app.currentReadingState.value;
+        return findLocationsInText(text);
+      };
 
-      if (!readingState) {
-        return [];
-      }
+      const getPlaceGeoJsonUrl = (place: PlaceData) => {
+        if (place.place === place.geojson) {
+          return [
+            `https://raw.githubusercontent.com/Bored-Wizard/isreal_geojson/main/${place.geojson}.geojson`,
+            true,
+          ] as const;
+        } else {
+          return [
+            `https://raw.githubusercontent.com/openbibleinfo/Bible-Geocoding-Data/main/geometry/${place.geojson}.geojson`,
+            false,
+          ] as const;
+        }
+      };
 
-      const selectedVerses = readingState.tab.readingState.selectedVerses.value;
-      return findLocationsInVerses(selectedVerses.map((v) => v.verse));
-    });
+      const foundPlaces = computed(() => {
+        const readingState = context.app.currentReadingState.value;
 
-    const showPlaceOnMap = async (place: PlaceData) => {
-      console.log("Show place!", place);
+        if (!readingState) {
+          return [];
+        }
 
-      const [url] = getPlaceGeoJsonUrl(place);
-      const response = await fetch(url);
-
-      if (response.status !== 200) {
-        console.error(
-          "Failed to fetch geojson data for place:",
-          place,
-          response
-        );
-        return;
-      }
-
-      const data = await response.text();
-
-      context.panes.openPane({
-        type: "detached",
-        mapPortal: "map",
-        pattern: geoImporterPattern,
-        inst: uuid(),
-        query: {
-          mapData: data,
-        },
+        const selectedVerses =
+          readingState.tab.readingState.selectedVerses.value;
+        return findLocationsInVerses(selectedVerses.map((v) => v.verse));
       });
-    };
 
-    yield context.tools.registerVerseToolbarTool({
-      id: "show-locations",
-      title: { key: "title", ns: "ext_locations", defaultValue: "Locations" },
-      icon: () => <LocationIcon />,
-      isVisible: () => foundPlaces.value.length > 0,
-      getItems: () => {
-        return foundPlaces.value.map((place) => ({
-          id: `show-location-${place.place}`,
-          title: {
-            key: "show-location-place",
-            ns: "ext_locations",
-            defaultValue: `Show ${place.place} on map`,
-            options: { place: place.place },
-          },
-          icon: () => <span></span>,
-          onSelect: async () => {
-            await showPlaceOnMap(place);
-          },
-        }));
-      },
-      priority: 100,
-    });
+      const showPlaceOnMap = async (place: PlaceData) => {
+        console.log("Show place!", place);
 
-    return {
-      findLocationsInText,
-      findLocationsInVerses,
-      foundPlaces,
-    };
-  },
-});
+        const [url] = getPlaceGeoJsonUrl(place);
+        const response = await fetch(url);
+
+        if (response.status !== 200) {
+          console.error(
+            "Failed to fetch geojson data for place:",
+            place,
+            response
+          );
+          return;
+        }
+
+        const data = await response.text();
+
+        context.panes.openPane({
+          type: "detached",
+          mapPortal: "map",
+          pattern: geoImporterPattern,
+          inst: uuid(),
+          query: {
+            mapData: data,
+          },
+        });
+      };
+
+      yield context.tools.registerVerseToolbarTool({
+        id: "show-locations",
+        title: { key: "title", ns: "ext_locations", defaultValue: "Locations" },
+        icon: () => <LocationIcon />,
+        isVisible: () => foundPlaces.value.length > 0,
+        getItems: () => {
+          return foundPlaces.value.map((place) => ({
+            id: `show-location-${place.place}`,
+            title: {
+              key: "show-location-place",
+              ns: "ext_locations",
+              defaultValue: `Show ${place.place} on map`,
+              options: { place: place.place },
+            },
+            icon: () => <span></span>,
+            onSelect: async () => {
+              await showPlaceOnMap(place);
+            },
+          }));
+        },
+        priority: 100,
+      });
+
+      return {
+        findLocationsInText,
+        findLocationsInVerses,
+        foundPlaces,
+      };
+    },
+  });
+}

--- a/packages/locations-extension/index.ts
+++ b/packages/locations-extension/index.ts
@@ -1,1 +1,1 @@
-import "./ext_locations/init";
+export { default } from "./ext_locations/init";

--- a/packages/seed-bible-refresh-example-extension/ext_Example/init.tsx
+++ b/packages/seed-bible-refresh-example-extension/ext_Example/init.tsx
@@ -12,152 +12,156 @@ function OpenMapPortalIcon() {
   return <MaterialIcon>map</MaterialIcon>;
 }
 
-registerExtension({
-  id: "example-extension",
-  init: function* (context: SeedBibleState) {
-    console.log("Example extension initialized with context:", context);
+export default function initExampleExtension() {
+  registerExtension({
+    id: "example-extension",
+    init: function* (context: SeedBibleState) {
+      console.log("Example extension initialized with context:", context);
 
-    // register a new tool
-    yield context.tools.registerToolbarTool({
-      id: "my-example-tool",
-      title: {
-        key: "my-example-tool",
-        defaultValue: "My Example Tool",
-        ns: "example-extension",
-      },
-      icon: () => <span>TOOL!</span>,
-      onSelect: () => {
-        console.log("Example tool selected!");
-        context.panes.openPane({
-          type: "detached",
-          detachedAnchor: "side",
-          component: () => {
-            // You can use the useI18n hook in your tool component to get translated strings
-            const { t } = useI18n("example-extension");
-            return <div style={{ padding: 20 }}>{t("my-example-tool")}</div>;
-          },
-        });
-      },
-      priority: 100,
-    });
-
-    yield context.tools.registerVerseToolbarTool({
-      id: "my-verse-tool",
-      title: {
-        key: "my-verse-tool",
-        defaultValue: "My Verse Tool",
-        ns: "example-extension",
-      },
-      icon: () => <span>VERSE!</span>,
-      // You can use getItems to return the list of items for the toolbar dynamically based on the context
-      getItems: (context) => [
-        {
-          id: "item-1",
-          icon: () => <span>ITEM 1</span>,
-          title: {
-            key: "item-1",
-            defaultValue: "Item 1",
-            ns: "example-extension",
-          },
-          onSelect: () => {
-            console.log("Item 1 clicked with context:", context);
-            context.toast("Item 1 clicked!");
-          },
+      // register a new tool
+      yield context.tools.registerToolbarTool({
+        id: "my-example-tool",
+        title: {
+          key: "my-example-tool",
+          defaultValue: "My Example Tool",
+          ns: "example-extension",
         },
-        {
-          id: "item-2",
-          icon: () => <span>ITEM 2</span>,
-          title: {
-            key: "item-2",
-            defaultValue: "Item 2",
-            ns: "example-extension",
-          },
-          onSelect: () => {
-            console.log("Item 2 clicked with context:", context);
-            context.toast("Item 2 clicked!");
-          },
+        icon: () => <span>TOOL!</span>,
+        onSelect: () => {
+          console.log("Example tool selected!");
+          context.panes.openPane({
+            type: "detached",
+            detachedAnchor: "side",
+            component: () => {
+              // You can use the useI18n hook in your tool component to get translated strings
+              const { t } = useI18n("example-extension");
+              return <div style={{ padding: 20 }}>{t("my-example-tool")}</div>;
+            },
+          });
         },
-      ],
-      priority: 100,
-    });
+        priority: 100,
+      });
 
-    // Below reader tools are displayed in a toolbar below the bible reader
-    yield context.tools.registerBelowReaderTool({
-      id: "my-below-reader-tool",
-      title: {
-        key: "my-below-reader-tool",
-        defaultValue: "My Below Reader Tool",
-        ns: "example-extension",
-      },
-      icon: () => <span>BELOW!</span>,
-      priority: 100,
-    });
+      yield context.tools.registerVerseToolbarTool({
+        id: "my-verse-tool",
+        title: {
+          key: "my-verse-tool",
+          defaultValue: "My Verse Tool",
+          ns: "example-extension",
+        },
+        icon: () => <span>VERSE!</span>,
+        // You can use getItems to return the list of items for the toolbar dynamically based on the context
+        getItems: (context) => [
+          {
+            id: "item-1",
+            icon: () => <span>ITEM 1</span>,
+            title: {
+              key: "item-1",
+              defaultValue: "Item 1",
+              ns: "example-extension",
+            },
+            onSelect: () => {
+              console.log("Item 1 clicked with context:", context);
+              context.toast("Item 1 clicked!");
+            },
+          },
+          {
+            id: "item-2",
+            icon: () => <span>ITEM 2</span>,
+            title: {
+              key: "item-2",
+              defaultValue: "Item 2",
+              ns: "example-extension",
+            },
+            onSelect: () => {
+              console.log("Item 2 clicked with context:", context);
+              context.toast("Item 2 clicked!");
+            },
+          },
+        ],
+        priority: 100,
+      });
 
-    // Empty pane tools are shown in the empty state of a pane and can be used to open portals or other content in the pane
-    yield context.tools.registerEmptyPaneTool({
-      id: "open-grid-portal",
-      priority: 100,
-      title: {
-        key: "open-grid-portal",
-        defaultValue: "Open grid portal",
-        ns: "example-extension",
-      },
-      icon: OpenGridPortalIcon,
-      isDisabled: (context) =>
-        context.panesManager.panes.value.some(
-          (pane) =>
-            (pane.gridPortal !== null || pane.mapPortal !== null) &&
-            pane.id !== context.currentPane.id
-        ),
-      onSelect: (context) => {
-        context.panesManager.openInPane(context.currentPane.id, {
-          gridPortal: "home",
-        });
-      },
-    });
+      // Below reader tools are displayed in a toolbar below the bible reader
+      yield context.tools.registerBelowReaderTool({
+        id: "my-below-reader-tool",
+        title: {
+          key: "my-below-reader-tool",
+          defaultValue: "My Below Reader Tool",
+          ns: "example-extension",
+        },
+        icon: () => <span>BELOW!</span>,
+        priority: 100,
+      });
 
-    yield context.tools.registerEmptyPaneTool({
-      id: "open-map-portal",
-      priority: 110,
-      title: {
-        key: "open-map-portal",
-        defaultValue: "Open map portal",
-        ns: "example-extension",
-      },
-      icon: OpenMapPortalIcon,
-      isDisabled: (context) =>
-        context.panesManager.panes.value.some(
-          (pane) =>
-            (pane.gridPortal !== null || pane.mapPortal !== null) &&
-            pane.id !== context.currentPane.id
-        ),
-      onSelect: (context) => {
-        context.panesManager.closePane(context.currentPane.id);
-        context.panesManager.openPane({
-          type: "detached",
-          mapPortal: "map_portal",
-        });
-      },
-    });
+      // Empty pane tools are shown in the empty state of a pane and can be used to open portals or other content in the pane
+      yield context.tools.registerEmptyPaneTool({
+        id: "open-grid-portal",
+        priority: 100,
+        title: {
+          key: "open-grid-portal",
+          defaultValue: "Open grid portal",
+          ns: "example-extension",
+        },
+        icon: OpenGridPortalIcon,
+        isDisabled: (context) =>
+          context.panesManager.panes.value.some(
+            (pane) =>
+              (pane.gridPortal !== null || pane.mapPortal !== null) &&
+              pane.id !== context.currentPane.id
+          ),
+        onSelect: (context) => {
+          context.panesManager.openInPane(context.currentPane.id, {
+            gridPortal: "home",
+          });
+        },
+      });
 
-    // You can use effects in your extension to react to changes in the app state. For example, this effect will log the current reading state whenever it changes.
-    yield effect(() => {
-      if (context.app.currentReadingState.value) {
-        console.log(
-          "Current reading state in effect:",
-          context.app.currentReadingState.value.translationId,
-          context.app.currentReadingState.value.bookId,
-          context.app.currentReadingState.value.chapterNumber
-        );
-      }
-    });
+      yield context.tools.registerEmptyPaneTool({
+        id: "open-map-portal",
+        priority: 110,
+        title: {
+          key: "open-map-portal",
+          defaultValue: "Open map portal",
+          ns: "example-extension",
+        },
+        icon: OpenMapPortalIcon,
+        isDisabled: (context) =>
+          context.panesManager.panes.value.some(
+            (pane) =>
+              (pane.gridPortal !== null || pane.mapPortal !== null) &&
+              pane.id !== context.currentPane.id
+          ),
+        onSelect: (context) => {
+          context.panesManager.closePane(context.currentPane.id);
+          context.panesManager.openPane({
+            type: "detached",
+            mapPortal: "map_portal",
+          });
+        },
+      });
 
-    // You can return a value to export functions or data from your extension that can be used by other extensions.
-    // For example, this will export a function called "abc" that other extensions can call if they have a reference to this extension.
-    return {
-      abc: () => {
-        console.log("This is an exported function from the example extension!");
-      },
-    };
-  },
-});
+      // You can use effects in your extension to react to changes in the app state. For example, this effect will log the current reading state whenever it changes.
+      yield effect(() => {
+        if (context.app.currentReadingState.value) {
+          console.log(
+            "Current reading state in effect:",
+            context.app.currentReadingState.value.translationId,
+            context.app.currentReadingState.value.bookId,
+            context.app.currentReadingState.value.chapterNumber
+          );
+        }
+      });
+
+      // You can return a value to export functions or data from your extension that can be used by other extensions.
+      // For example, this will export a function called "abc" that other extensions can call if they have a reference to this extension.
+      return {
+        abc: () => {
+          console.log(
+            "This is an exported function from the example extension!"
+          );
+        },
+      };
+    },
+  });
+}

--- a/packages/seed-bible-refresh-example-extension/index.ts
+++ b/packages/seed-bible-refresh-example-extension/index.ts
@@ -1,1 +1,1 @@
-import "./ext_Example/init";
+export { default } from "./ext_Example/init";

--- a/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
@@ -80,11 +80,40 @@ export interface UploadedExtension {
 }
 
 export interface ImportExtension {
-  /** The function to dynamically import the extension module. */
+  /**
+   * The function to dynamically import the extension module. The resolved
+   * module must `export default` a function matching `ExtensionEntryPoint` —
+   * the loader calls it explicitly to (re)trigger registration on every
+   * install attempt, since ES module evaluation only runs once per
+   * specifier.
+   */
   import: () => Promise<unknown>;
 
   /** The metadata for this extension. */
   meta: ExtensionMeta;
+}
+
+/**
+ * The contract an extension module's default export must satisfy. Calling
+ * this function triggers the extension's registration (typically via a
+ * `registerExtension(...)` call). It must be safe to call more than once per
+ * page load: native ES module evaluation is cached per specifier, so after
+ * `unloadExtension()` a later `loadExtension()`/`loadExtensionFromUrl()` call
+ * re-invokes this cached function reference rather than re-running the
+ * module's top-level code.
+ */
+export type ExtensionEntryPoint = () =>
+  | void
+  | CleanupFunction
+  | Promise<void | CleanupFunction>;
+
+/**
+ * The expected shape of a dynamically-imported extension module: an ES
+ * module namespace object with a `default` export matching
+ * `ExtensionEntryPoint`.
+ */
+export interface ExtensionModule {
+  default: ExtensionEntryPoint;
 }
 
 export interface ExtensionSet {
@@ -326,6 +355,22 @@ export interface ExtensionManagerOptions {
   defaultExtensions?: ExtensionSet | null;
 }
 
+/**
+ * Runtime type guard for `ExtensionModule`. The actual shape of a
+ * dynamically-imported extension module can't be statically verified —
+ * `uploaded.import()` and `import(url)` both resolve to whatever the
+ * extension package actually exports — so this is checked at the call sites
+ * that invoke an extension's default export.
+ */
+function isExtensionModule(value: unknown): value is ExtensionModule {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "default" in value &&
+    typeof (value as { default: unknown }).default === "function"
+  );
+}
+
 export function createExtensionManager(
   login: LoginManager,
   options: ExtensionManagerOptions = {}
@@ -521,7 +566,15 @@ export function createExtensionManager(
     }
 
     try {
-      await import(/** @vite-ignore */ url);
+      const mod: unknown = await import(/** @vite-ignore */ url);
+      if (!isExtensionModule(mod)) {
+        refreshExtensionsSignal();
+        console.error(
+          `Failed to install extension '${id}': the module at '${url}' does not \`export default\` a function. Extensions must export a default function that triggers registration when called.`
+        );
+        return false;
+      }
+      await mod.default();
       installedExtensionIds.add(id);
       refreshExtensionsSignal();
       // shout("onExtensionInstalled", id);
@@ -600,7 +653,21 @@ export function createExtensionManager(
         installStack.delete(extensionId);
         return installed;
       } else if ("import" in uploaded && uploaded.import) {
-        await uploaded.import();
+        try {
+          const mod: unknown = await uploaded.import();
+          if (!isExtensionModule(mod)) {
+            console.error(
+              `Failed to install extension '${extensionId}': its module does not \`export default\` a function. Extensions must export a default function that triggers registration when called.`
+            );
+            installStack.delete(extensionId);
+            return false;
+          }
+          await mod.default();
+        } catch (err) {
+          installStack.delete(extensionId);
+          console.error("Failed to install extension:", extensionId, err);
+          return false;
+        }
         installStack.delete(extensionId);
         return true;
       } else {

--- a/packages/twitchPub-extension/ext_twitchPub/host/init.tsx
+++ b/packages/twitchPub-extension/ext_twitchPub/host/init.tsx
@@ -5,78 +5,80 @@ import initializeTwitchBot from "./initializeTwitchBot";
 import { closeInterface } from "./closeInterface";
 import { openInterface } from "./openInterface";
 
-registerExtension({
-  id: "ext_twitchPub",
-  init: function* (context: SeedBibleState) {
-    const twitchPubState = CreateTwitchPubState({
-      toast: context.app.toast,
-    });
+export default function initTwitchPubExtension() {
+  registerExtension({
+    id: "ext_twitchPub",
+    init: function* (context: SeedBibleState) {
+      const twitchPubState = CreateTwitchPubState({
+        toast: context.app.toast,
+      });
 
-    // register a new tool
-    yield context.tools.registerToolbarTool({
-      id: "ext_twitchPub",
-      title: {
-        key: "toolbarTitle",
-        defaultValue: "Twitch Panel",
-        ns: "ext_twitchPub",
-      },
-      icon: () => (
-        <img
-          src="https://res.cloudinary.com/dacw0qnpr/image/upload/v1774035767/Vector_6_if8usw.svg"
-          style={{
-            width: "24px",
-            height: "24px",
-            objectFit: "contain",
-          }}
-        />
-      ),
-      onSelect: () => {
-        if (!twitchPubState.interfaceEnabled.value) {
-          twitchPubState.interfaceEnabled.value = true;
-          openInterface({ state: twitchPubState, context });
-        } else {
-          twitchPubState.interfaceEnabled.value = false;
-          closeInterface();
-        }
-      },
-      priority: 950,
-    });
+      // register a new tool
+      yield context.tools.registerToolbarTool({
+        id: "ext_twitchPub",
+        title: {
+          key: "toolbarTitle",
+          defaultValue: "Twitch Panel",
+          ns: "ext_twitchPub",
+        },
+        icon: () => (
+          <img
+            src="https://res.cloudinary.com/dacw0qnpr/image/upload/v1774035767/Vector_6_if8usw.svg"
+            style={{
+              width: "24px",
+              height: "24px",
+              objectFit: "contain",
+            }}
+          />
+        ),
+        onSelect: () => {
+          if (!twitchPubState.interfaceEnabled.value) {
+            twitchPubState.interfaceEnabled.value = true;
+            openInterface({ state: twitchPubState, context });
+          } else {
+            twitchPubState.interfaceEnabled.value = false;
+            closeInterface();
+          }
+        },
+        priority: 950,
+      });
 
-    yield effect(() => {
-      if (context.app.currentReadingState.value) {
-        twitchPubState.handleSeedBibleUpdate(context);
-        const chapterHighlights = context.highlights.getChapterHighlights(
-          context.app.currentReadingState.value.translationId ?? "ABB",
-          context.app.currentReadingState.value.bookId ?? "GEN",
-          context.app.currentReadingState.value.chapterNumber ?? 1
-        );
-        if (chapterHighlights.value.highlights.length > 0) {
-          twitchPubState.handleHighlightUpdate(
-            chapterHighlights.value.highlights,
-            context.app.currentReadingState.value?.bookId || "GEN",
-            context.app.currentReadingState.value?.chapterNumber || 1
+      yield effect(() => {
+        if (context.app.currentReadingState.value) {
+          twitchPubState.handleSeedBibleUpdate(context);
+          const chapterHighlights = context.highlights.getChapterHighlights(
+            context.app.currentReadingState.value.translationId ?? "ABB",
+            context.app.currentReadingState.value.bookId ?? "GEN",
+            context.app.currentReadingState.value.chapterNumber ?? 1
           );
+          if (chapterHighlights.value.highlights.length > 0) {
+            twitchPubState.handleHighlightUpdate(
+              chapterHighlights.value.highlights,
+              context.app.currentReadingState.value?.bookId || "GEN",
+              context.app.currentReadingState.value?.chapterNumber || 1
+            );
+          }
         }
-      }
-    });
+      });
 
-    yield effect(() => {
-      const { broadcasterId, clientId, userAccessToken, senderId } =
-        twitchPubState.twitchConfig.value;
-      if (
-        broadcasterId.value &&
-        clientId.value &&
-        userAccessToken.value &&
-        senderId.value
-      ) {
-        initializeTwitchBot({
-          broadcasterId,
-          senderId,
-          userAccessToken,
-          clientId,
-          qrValue: twitchPubState.qrValue,
-        });
-      }
-    });
-  },
-});
+      yield effect(() => {
+        const { broadcasterId, clientId, userAccessToken, senderId } =
+          twitchPubState.twitchConfig.value;
+        if (
+          broadcasterId.value &&
+          clientId.value &&
+          userAccessToken.value &&
+          senderId.value
+        ) {
+          initializeTwitchBot({
+            broadcasterId,
+            senderId,
+            userAccessToken,
+            clientId,
+            qrValue: twitchPubState.qrValue,
+          });
+        }
+      });
+    },
+  });
+}

--- a/packages/twitchPub-extension/index.ts
+++ b/packages/twitchPub-extension/index.ts
@@ -1,1 +1,1 @@
-import "./ext_twitchPub/host/init";
+export { default } from "./ext_twitchPub/host/init";

--- a/packages/twitchSub-extension/ext_twitchSub/client/init.tsx
+++ b/packages/twitchSub-extension/ext_twitchSub/client/init.tsx
@@ -2,13 +2,15 @@ import { effect } from "@preact/signals";
 import { registerExtension, type SeedBibleState } from "seed-bible";
 import { CreateTwitchSubState } from "./twitchSubManager";
 
-registerExtension({
-  id: "ext_twitchSub",
-  init: function* (context: SeedBibleState) {
-    const twitchSubState = CreateTwitchSubState(context);
+export default function initTwitchSubExtension() {
+  registerExtension({
+    id: "ext_twitchSub",
+    init: function* (context: SeedBibleState) {
+      const twitchSubState = CreateTwitchSubState(context);
 
-    yield effect(() => {
-      console.log("Current Twitch Sub State:", twitchSubState);
-    });
-  },
-});
+      yield effect(() => {
+        console.log("Current Twitch Sub State:", twitchSubState);
+      });
+    },
+  });
+}

--- a/packages/twitchSub-extension/index.ts
+++ b/packages/twitchSub-extension/index.ts
@@ -1,1 +1,1 @@
-import "./ext_twitchSub/client/init";
+export { default } from "./ext_twitchSub/client/init";

--- a/test/unit/seed-bible/managers/ExtensionManager.test.ts
+++ b/test/unit/seed-bible/managers/ExtensionManager.test.ts
@@ -373,7 +373,7 @@ describe("createExtensionManager", () => {
   ) {
     vi.doMock(url, async () => {
       loadedModules.push(url);
-      return moduleFactory ? await moduleFactory() : {};
+      return moduleFactory ? await moduleFactory() : { default: vi.fn() };
     });
   }
 
@@ -710,7 +710,7 @@ describe("createExtensionManager", () => {
 
     mockExtensionModule("pkg://slow", async () => {
       await installGate;
-      return {};
+      return { default: vi.fn() };
     });
 
     const extension = {
@@ -903,6 +903,133 @@ describe("createExtensionManager", () => {
     expect(known).toHaveLength(1);
     expect(known[0]?.extension?.meta.id).toBe("ext.unload-known");
     expect(known[0]?.installed).toBe(false);
+  });
+
+  it("loadExtension() re-invokes a url-based module's default export so an extension can be reinstalled after being unloaded", async () => {
+    const manager = createExtensionManager(login);
+    const defaultFn = vi.fn(() => {
+      registerExtension({ id: "ext.reinstall", init: () => ({}) });
+    });
+    mockExtensionModule("pkg://reinstall", () => ({ default: defaultFn }));
+
+    const extension = {
+      url: "pkg://reinstall",
+      meta: {
+        id: "ext.reinstall",
+        translations: {
+          en: { title: "Reinstall", description: "Reinstall extension" },
+        },
+      },
+    };
+
+    expect(await manager.loadExtension(extension)).toBe(true);
+    expect(defaultFn).toHaveBeenCalledTimes(1);
+    expect(loadedModules).toEqual(["pkg://reinstall"]);
+    expect(
+      ExtensionInitalizer.getInstance().isExtensionRegistered("ext.reinstall")
+    ).toBe(true);
+
+    manager.unloadExtension("ext.reinstall");
+    expect(
+      ExtensionInitalizer.getInstance().isExtensionRegistered("ext.reinstall")
+    ).toBe(false);
+
+    expect(await manager.loadExtension(extension)).toBe(true);
+    // Called a second time even though the module body did NOT re-evaluate
+    // (loadedModules is still length 1) - this is the fix: ExtensionManager
+    // re-invokes the cached default export explicitly.
+    expect(defaultFn).toHaveBeenCalledTimes(2);
+    expect(loadedModules).toEqual(["pkg://reinstall"]);
+    expect(
+      ExtensionInitalizer.getInstance().isExtensionRegistered("ext.reinstall")
+    ).toBe(true);
+  });
+
+  it("loadExtension() re-invokes an ImportExtension's default export so an extension can be reinstalled after being unloaded", async () => {
+    const manager = createExtensionManager(login);
+    const defaultFn = vi.fn(() => {
+      registerExtension({ id: "ext.import-reinstall", init: () => ({}) });
+    });
+    const extension = {
+      import: () => Promise.resolve({ default: defaultFn }),
+      meta: {
+        id: "ext.import-reinstall",
+        translations: {
+          en: {
+            title: "Import Reinstall",
+            description: "Import reinstall extension",
+          },
+        },
+      },
+    };
+
+    expect(await manager.loadExtension(extension)).toBe(true);
+    expect(defaultFn).toHaveBeenCalledTimes(1);
+    expect(
+      ExtensionInitalizer.getInstance().isExtensionRegistered(
+        "ext.import-reinstall"
+      )
+    ).toBe(true);
+
+    manager.unloadExtension("ext.import-reinstall");
+    expect(
+      ExtensionInitalizer.getInstance().isExtensionRegistered(
+        "ext.import-reinstall"
+      )
+    ).toBe(false);
+
+    expect(await manager.loadExtension(extension)).toBe(true);
+    expect(defaultFn).toHaveBeenCalledTimes(2);
+    expect(
+      ExtensionInitalizer.getInstance().isExtensionRegistered(
+        "ext.import-reinstall"
+      )
+    ).toBe(true);
+  });
+
+  it("loadExtension() fails and logs when a url-based module has no default export function", async () => {
+    const manager = createExtensionManager(login);
+    mockExtensionModule("pkg://no-default", () => ({}));
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const loaded = await manager.loadExtension({
+      url: "pkg://no-default",
+      meta: {
+        id: "ext.no-default",
+        translations: { en: { title: "No default", description: "x" } },
+      },
+    });
+
+    expect(loaded).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(
+      ExtensionInitalizer.getInstance().isExtensionRegistered("ext.no-default")
+    ).toBe(false);
+  });
+
+  it("loadExtension() fails and logs when an ImportExtension module has no default export function", async () => {
+    const manager = createExtensionManager(login);
+    const errorSpy = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => undefined);
+
+    const loaded = await manager.loadExtension({
+      import: () => Promise.resolve({}),
+      meta: {
+        id: "ext.import-no-default",
+        translations: { en: { title: "No default", description: "x" } },
+      },
+    });
+
+    expect(loaded).toBe(false);
+    expect(errorSpy).toHaveBeenCalled();
+    expect(
+      ExtensionInitalizer.getInstance().isExtensionRegistered(
+        "ext.import-no-default"
+      )
+    ).toBe(false);
   });
 
   it("getAllExtensionsAsSet() returns undefined and warns when there are no extension packages", () => {


### PR DESCRIPTION
Extensions previously called registerExtension() as a top-level side
effect, which meant reinstalling an extension in the same session did
nothing: ES modules only evaluate once per specifier, so the second
import() never re-ran the registration call. ExtensionManager now
requires each extension module to export default a function and
invokes it explicitly on every install attempt, so an uninstalled
extension can be reinstalled without a page reload. All five
first-party extension packages are migrated to the new contract.

Fixes #1317

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01KonhfN8uDnqNDeQ8pNuBKL