### PR TITLE
ci: report build output sizes in the job summary

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -21,6 +21,8 @@ concurrency:
 permissions:
   contents: read
   id-token: write # for AWS OIDC
+  issues: write # for posting/updating the deployment-link PR comment
+  pull-requests: write
 
 jobs:
   deploy:
@@ -175,6 +177,68 @@ jobs:
             --branch "$BRANCH" \
             --url "$URL" \
             --version "$BUILD_ID"
+
+      # ─── Comment the deployment link on the associated PR (if any) ──────────
+      # The preview URL changes on every push (buildId = commit sha), so this
+      # updates the same comment in place (via a hidden marker) rather than
+      # posting a new one each time. Branches with no associated PR (e.g. a
+      # personal branch that hasn't been opened as a PR yet) simply resolve to
+      # zero PRs and this no-ops.
+      - name: Comment on pull request with deployment link
+        continue-on-error: true
+        env:
+          BRANCH: ${{ steps.ids.outputs.branch }}
+          BUILD_ID: ${{ steps.ids.outputs.build_id }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const branch = process.env.BRANCH;
+            const buildId = process.env.BUILD_ID;
+            const marker = "<!-- deployment-link -->";
+
+            try {
+              const url =
+                branch === "main"
+                  ? "https://prod.seedbible.org"
+                  : `https://alpha.seedbible.org/b/${branch}/${buildId}`;
+              const summary =
+                branch === "main"
+                  ? `Deployed **main** to the site root → ${url}`
+                  : `Deployed branch **${branch}** → ${url}`;
+              const body = `${marker}\n## 🚀 Deployment\n\n${summary}\n\nCommit: \`${buildId}\``;
+
+              const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: context.sha,
+              });
+
+              for (const pr of prs) {
+                const { data: comments } = await github.rest.issues.listComments({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: pr.number,
+                });
+                const existing = comments.find((c) => c.body && c.body.includes(marker));
+                if (existing) {
+                  await github.rest.issues.updateComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    comment_id: existing.id,
+                    body,
+                  });
+                } else {
+                  await github.rest.issues.createComment({
+                    owner: context.repo.owner,
+                    repo: context.repo.repo,
+                    issue_number: pr.number,
+                    body,
+                  });
+                }
+              }
+            } catch (error) {
+              core.warning(`Failed to post deployment comment: ${error}`);
+            }
       - name: Summary
         env:
           BRANCH: ${{ steps.ids.outputs.branch }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,8 +72,8 @@ jobs:
             echo ""
             echo "#### Client Chunks"
             echo ""
-            echo "| Chunk | Size |"
-            echo "| --- | --- |"
+            echo "| Chunk | Raw | Gzip |"
+            echo "| --- | --- | --- |"
 
             shopt -s nullglob
             CHUNKS=(
@@ -86,12 +86,29 @@ jobs:
               files=($pattern)
               if [ "${#files[@]}" -gt 0 ]; then
                 bytes=$(du -cb "${files[@]}" | tail -1 | cut -f1)
-                echo "| $label | $(numfmt --to=iec --suffix=B "$bytes") |"
+                gzip_bytes=$(cat "${files[@]}" | gzip -c | wc -c)
+                echo "| $label | $(numfmt --to=iec --suffix=B "$bytes") | $(numfmt --to=iec --suffix=B "$gzip_bytes") |"
               else
-                echo "| $label | _not found_ |"
+                echo "| $label | _not found_ | _not found_ |"
               fi
             done
             shopt -u nullglob
+
+            echo ""
+            echo "#### Top 5 Largest Files (client build)"
+            echo ""
+            echo "| File | Raw | Gzip |"
+            echo "| --- | --- | --- |"
+
+            if [ -d standalone/dist/client ]; then
+              find standalone/dist/client -type f ! -name "*.map" -printf '%s\t%p\n' | sort -rn | head -5 | while IFS=$'\t' read -r bytes file; do
+                gzip_bytes=$(gzip -c "$file" | wc -c)
+                rel="${file#standalone/dist/client/}"
+                echo "| \`$rel\` | $(numfmt --to=iec --suffix=B "$bytes") | $(numfmt --to=iec --suffix=B "$gzip_bytes") |"
+              done
+            else
+              echo "| _not found_ | | |"
+            fi
           } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -68,6 +68,30 @@ jobs:
             done
 
             echo "| **Total** | **$(numfmt --to=iec --suffix=B "$total")** |"
+
+            echo ""
+            echo "#### Client Chunks"
+            echo ""
+            echo "| Chunk | Size |"
+            echo "| --- | --- |"
+
+            shopt -s nullglob
+            CHUNKS=(
+              "Vendor (\`vendor-*.js\`)|standalone/dist/client/assets/vendor-*.js"
+              "Index (\`index-*.js\`)|standalone/dist/client/assets/index-*.js"
+            )
+            for entry in "${CHUNKS[@]}"; do
+              label="${entry%%|*}"
+              pattern="${entry##*|}"
+              files=($pattern)
+              if [ "${#files[@]}" -gt 0 ]; then
+                bytes=$(du -cb "${files[@]}" | tail -1 | cut -f1)
+                echo "| $label | $(numfmt --to=iec --suffix=B "$bytes") |"
+              else
+                echo "| $label | _not found_ |"
+              fi
+            done
+            shopt -u nullglob
           } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v7
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,36 @@ jobs:
       - name: Build
         run: |
           pnpm build
+      - name: Report build sizes
+        run: |
+          {
+            echo "### Build Output Sizes"
+            echo ""
+            echo "| Output | Size |"
+            echo "| --- | --- |"
+
+            OUTPUTS=(
+              "Client bundle (\`standalone/dist/client\`)|standalone/dist/client"
+              "SSR bundle (\`standalone/dist/server\`)|standalone/dist/server"
+              "Server bundle (\`server/dist/index.js\`)|server/dist/index.js"
+              "Patterns (\`pattern-dist\`)|pattern-dist"
+            )
+
+            total=0
+            for entry in "${OUTPUTS[@]}"; do
+              label="${entry%%|*}"
+              path="${entry##*|}"
+              if [ -e "$path" ]; then
+                bytes=$(du -sb "$path" | cut -f1)
+                total=$((total + bytes))
+                echo "| $label | $(numfmt --to=iec --suffix=B "$bytes") |"
+              else
+                echo "| $label | _not found_ |"
+              fi
+            done
+
+            echo "| **Total** | **$(numfmt --to=iec --suffix=B "$total")** |"
+          } >> "$GITHUB_STEP_SUMMARY"
       - uses: actions/upload-artifact@v7
         with:
           name: "client-stats.html"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,9 +7,24 @@ on:
   push:
   pull_request:
 
+# Cancel a superseded run for the same branch/PR — the base-branch build below
+# makes each run meaningfully more expensive, so rapid pushes shouldn't pile up.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ubuntu-latest
+
+    # `issues: write` is load-bearing for the PR comment step below — PR
+    # comment endpoints are `/issues/{n}/comments` under the hood, scoped
+    # under `issues`, not `pull-requests`. `pull-requests: write` is kept for
+    # clarity/future use but isn't sufficient alone.
+    permissions:
+      contents: read
+      issues: write
+      pull-requests: write
 
     strategy:
       matrix:
@@ -39,77 +54,97 @@ jobs:
       - name: Build
         run: |
           pnpm build
-      - name: Report build sizes
+      - name: Measure build sizes (head)
+        run: pnpm build-size-report measure --out size-head.json
+
+      # ─── PR-only: build the target branch too, so sizes can be diffed ──────
+      # Sibling-checked-out into base-branch/ rather than a separate job/cache
+      # lookup — the build is fast (~10-15s) and pnpm's content-addressable
+      # store is already warm from the head install above, so this doesn't
+      # meaningfully slow the job down. continue-on-error is set on all three
+      # steps so a broken base branch can't fail every PR's CI — the report
+      # step below just notes the comparison was unavailable instead.
+      - name: Checkout base branch
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+          path: base-branch
+
+      # No deploy-related env vars (ASSET_BASE_URL/DEPLOY_BRANCH/DEPLOY_BUILD_ID)
+      # are set here, matching the head Build step above exactly — setting them
+      # on only one side would change Vite's `base`/`isRootBuild` and pollute
+      # the size diff with unrelated churn.
+      - name: Build base branch
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
         run: |
-          {
-            echo "### Build Output Sizes"
-            echo ""
-            echo "| Output | Size |"
-            echo "| --- | --- |"
+          if [ ! -d base-branch ]; then
+            echo "base branch checkout missing, skipping base build" >&2
+            exit 0
+          fi
+          cd base-branch
+          pnpm install
+          pnpm build
+      - name: Measure build sizes (base branch)
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        run: |
+          if [ -d base-branch/standalone/dist/client ] || [ -d base-branch/standalone/dist/server ]; then
+            pnpm build-size-report measure --root base-branch --out size-base.json
+          else
+            echo "base branch build output missing, skipping size measurement" >&2
+          fi
 
-            OUTPUTS=(
-              "Client bundle (\`standalone/dist/client\`)|standalone/dist/client"
-              "SSR bundle (\`standalone/dist/server\`)|standalone/dist/server"
-              "Server bundle (\`server/dist/index.js\`)|server/dist/index.js"
-              "Patterns (\`pattern-dist\`)|pattern-dist"
-            )
+      - name: Generate build size report
+        run: |
+          ARGS=(report --head size-head.json --out size-report.md --threshold-kb 300)
+          if [ -f size-base.json ]; then
+            ARGS+=(--base size-base.json)
+          elif [ "${{ github.event_name }}" = "pull_request" ]; then
+            ARGS+=(--base-unavailable)
+          fi
+          pnpm build-size-report "${ARGS[@]}"
+          cat size-report.md >> "$GITHUB_STEP_SUMMARY"
 
-            total=0
-            for entry in "${OUTPUTS[@]}"; do
-              label="${entry%%|*}"
-              path="${entry##*|}"
-              if [ -e "$path" ]; then
-                bytes=$(du -sb "$path" | cut -f1)
-                total=$((total + bytes))
-                echo "| $label | $(numfmt --to=iec --suffix=B "$bytes") |"
-              else
-                echo "| $label | _not found_ |"
-              fi
-            done
-
-            echo "| **Total** | **$(numfmt --to=iec --suffix=B "$total")** |"
-
-            echo ""
-            echo "#### Client Chunks"
-            echo ""
-            echo "| Chunk | Raw | Gzip |"
-            echo "| --- | --- | --- |"
-
-            shopt -s nullglob
-            CHUNKS=(
-              "Vendor (\`vendor-*.js\`)|standalone/dist/client/assets/vendor-*.js"
-              "Index (\`index-*.js\`)|standalone/dist/client/assets/index-*.js"
-            )
-            for entry in "${CHUNKS[@]}"; do
-              label="${entry%%|*}"
-              pattern="${entry##*|}"
-              files=($pattern)
-              if [ "${#files[@]}" -gt 0 ]; then
-                bytes=$(du -cb "${files[@]}" | tail -1 | cut -f1)
-                gzip_bytes=$(cat "${files[@]}" | gzip -c | wc -c)
-                echo "| $label | $(numfmt --to=iec --suffix=B "$bytes") | $(numfmt --to=iec --suffix=B "$gzip_bytes") |"
-              else
-                echo "| $label | _not found_ | _not found_ |"
-              fi
-            done
-            shopt -u nullglob
-
-            echo ""
-            echo "#### Top 5 Largest Files (client build)"
-            echo ""
-            echo "| File | Raw | Gzip |"
-            echo "| --- | --- | --- |"
-
-            if [ -d standalone/dist/client ]; then
-              find standalone/dist/client -type f ! -name "*.map" -printf '%s\t%p\n' | sort -rn | head -5 | while IFS=$'\t' read -r bytes file; do
-                gzip_bytes=$(gzip -c "$file" | wc -c)
-                rel="${file#standalone/dist/client/}"
-                echo "| \`$rel\` | $(numfmt --to=iec --suffix=B "$bytes") | $(numfmt --to=iec --suffix=B "$gzip_bytes") |"
-              done
-            else
-              echo "| _not found_ | | |"
-            fi
-          } >> "$GITHUB_STEP_SUMMARY"
+      # Only one matrix leg exists today, so exactly one job instance posts
+      # this comment. If the matrix ever grows, multiple legs would race to
+      # create/update the same PR comment via the same marker.
+      - name: Comment on pull request
+        if: github.event_name == 'pull_request'
+        continue-on-error: true
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require("fs");
+            const marker = "<!-- build-size-report -->";
+            try {
+              const body = `${marker}\n## 📦 Build Size Report\n\n${fs.readFileSync("size-report.md", "utf8")}`;
+              const { data: comments } = await github.rest.issues.listComments({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: context.issue.number,
+              });
+              const existing = comments.find((c) => c.body && c.body.includes(marker));
+              if (existing) {
+                await github.rest.issues.updateComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  comment_id: existing.id,
+                  body,
+                });
+              } else {
+                await github.rest.issues.createComment({
+                  owner: context.repo.owner,
+                  repo: context.repo.repo,
+                  issue_number: context.issue.number,
+                  body,
+                });
+              }
+            } catch (error) {
+              core.warning(`Failed to post build size comment: ${error}`);
+            }
       - uses: actions/upload-artifact@v7
         with:
           name: "client-stats.html"

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,10 @@
 node_modules
 dist
 pattern-dist
+/base-branch
+size-head.json
+size-base.json
+size-report.md
 .DS_Store
 package-lock.json
 .claude

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "check:patterns": "tsc --project ./patterns/tsconfig.json",
     "pattern": "tsx script/pattern.ts",
     "notify": "tsx script/notify.ts",
+    "build-size-report": "tsx script/build-size-report.ts",
     "i18n": "tsx script/i18n.ts",
     "list-bible-translations": "tsx script/list-bible-translations.ts",
     "format": "prettier --write \"packages/**/*.{js,jsx,ts,tsx,css}\"",

--- a/script/build-size-report.ts
+++ b/script/build-size-report.ts
@@ -1,0 +1,64 @@
+import { program } from "commander";
+import { readFile, writeFile } from "node:fs/promises";
+import {
+  measureRoot,
+  renderReport,
+  type SizeSnapshot,
+} from "./lib/buildSizeReport";
+
+program
+  .name("build-size-report")
+  .description("Measures and reports build output sizes.");
+
+program
+  .command("measure")
+  .description(
+    "Measures the build output sizes for a repo checkout and writes a JSON snapshot."
+  )
+  .option(
+    "--root <dir>",
+    "The repo checkout to measure build outputs from.",
+    "."
+  )
+  .requiredOption("--out <file>", "Path to write the JSON snapshot to.")
+  .action(async (options) => {
+    const snapshot = await measureRoot(options.root);
+    await writeFile(options.out, JSON.stringify(snapshot, null, 2), "utf-8");
+  });
+
+program
+  .command("report")
+  .description(
+    "Renders a markdown build-size report from one or two JSON snapshots."
+  )
+  .requiredOption("--head <file>", "Path to the head snapshot JSON.")
+  .option(
+    "--base <file>",
+    "Path to the base snapshot JSON. Omit to render a single-snapshot report."
+  )
+  .option(
+    "--threshold-kb <n>",
+    "Flag bundles whose size changes by more than this many KB.",
+    "300"
+  )
+  .option(
+    "--base-unavailable",
+    "Notes that a base comparison was expected but could not be produced (e.g. the base branch build failed).",
+    false
+  )
+  .requiredOption("--out <file>", "Path to write the markdown report to.")
+  .action(async (options) => {
+    const head: SizeSnapshot = JSON.parse(
+      await readFile(options.head, "utf-8")
+    );
+    const base: SizeSnapshot | undefined = options.base
+      ? JSON.parse(await readFile(options.base, "utf-8"))
+      : undefined;
+    const thresholdBytes = Number(options.thresholdKb) * 1024;
+    const markdown = renderReport(head, base, thresholdBytes, {
+      baseUnavailable: !base && !!options.baseUnavailable,
+    });
+    await writeFile(options.out, markdown, "utf-8");
+  });
+
+program.parse();

--- a/script/lib/buildSizeReport.ts
+++ b/script/lib/buildSizeReport.ts
@@ -1,0 +1,524 @@
+import { existsSync, readFileSync } from "node:fs";
+import { promises as fsp } from "node:fs";
+import * as path from "node:path";
+import { gzipSync } from "node:zlib";
+
+/** A single top-level build output (a directory or a single file) and its total size. */
+export interface OutputEntry {
+  label: string;
+  path: string;
+  bytes: number;
+}
+
+/** A client asset file (JS/CSS under `standalone/dist/client/assets`), keyed by a hash-stable label. */
+export interface AssetFileEntry {
+  label: string;
+  relPath: string;
+  bytes: number;
+  gzipBytes: number;
+}
+
+/** One of the largest files found anywhere in the client build. */
+export interface TopFileEntry {
+  relPath: string;
+  bytes: number;
+  gzipBytes: number;
+}
+
+/** A full size measurement of one build (one branch/checkout). */
+export interface SizeSnapshot {
+  outputs: OutputEntry[];
+  totalBytes: number;
+  assetFiles: AssetFileEntry[];
+  topFiles: TopFileEntry[];
+}
+
+const OUTPUT_TARGETS: { label: string; relPath: string }[] = [
+  {
+    label: "Client bundle (`standalone/dist/client`)",
+    relPath: "standalone/dist/client",
+  },
+  {
+    label: "SSR bundle (`standalone/dist/server`)",
+    relPath: "standalone/dist/server",
+  },
+  {
+    label: "Server bundle (`server/dist/index.js`)",
+    relPath: "server/dist/index.js",
+  },
+  { label: "Patterns (`pattern-dist`)", relPath: "pattern-dist" },
+];
+
+const CLIENT_DIR = "standalone/dist/client";
+const ASSETS_DIR = `${CLIENT_DIR}/assets`;
+const MANIFEST_PATH = `${CLIENT_DIR}/.vite/manifest.json`;
+const TOP_FILES_COUNT = 5;
+
+/** The canonical, hash-stable name for the two chunks called out explicitly in reports. */
+export const VENDOR_LABEL = "assets/vendor.js";
+export const INDEX_LABEL = "assets/index.js";
+
+// Vite/Rollup content hashes observed in this build are 8 base64url-ish
+// characters, but a few extra characters of slack keeps this from breaking on
+// a minor hash-length change.
+const HASH_SUFFIX_RE = /-[A-Za-z0-9_-]{6,12}(\.[^./]+)$/;
+
+/** Strips a trailing content-hash segment (e.g. `vendor-DCGzEOOr.js` -> `vendor.js`). */
+export function stripHash(filename: string): string {
+  return filename.replace(HASH_SUFFIX_RE, "$1");
+}
+
+interface ManifestEntry {
+  file?: string;
+  name?: string;
+  css?: string[];
+  assets?: string[];
+}
+
+type ViteManifest = Record<string, ManifestEntry>;
+
+/** Derives a hash-stable label for a manifest-listed file, e.g. `assets/vendor-DCGzEOOr.js` -> `assets/vendor.js`. */
+export function canonicalLabelFor(
+  file: string,
+  name: string | undefined
+): string {
+  const dir = path.posix.dirname(file);
+  const base = name
+    ? `${name}${path.posix.extname(file)}`
+    : stripHash(path.posix.basename(file));
+  return dir === "." ? base : `${dir}/${base}`;
+}
+
+/**
+ * Builds a `hashed file path -> canonical label` map from a Vite client
+ * manifest. CSS files inherit their owning entry's name since they don't get
+ * their own top-level manifest key. Plain assets (images, icons) are left
+ * unmapped — callers should fall back to `stripHash` for those.
+ */
+export function buildCanonicalMap(manifest: ViteManifest): Map<string, string> {
+  const map = new Map<string, string>();
+  for (const entry of Object.values(manifest)) {
+    if (entry.file) {
+      map.set(entry.file, canonicalLabelFor(entry.file, entry.name));
+    }
+    for (const cssFile of entry.css ?? []) {
+      map.set(cssFile, canonicalLabelFor(cssFile, entry.name));
+    }
+  }
+  return map;
+}
+
+async function readManifest(root: string): Promise<ViteManifest> {
+  try {
+    const raw = await fsp.readFile(path.join(root, MANIFEST_PATH), "utf-8");
+    return JSON.parse(raw) as ViteManifest;
+  } catch {
+    return {};
+  }
+}
+
+interface WalkedFile {
+  absPath: string;
+  relPath: string;
+}
+
+/** Recursively lists every file under `dir`, with `relPath` using forward slashes. */
+async function walkFiles(dir: string): Promise<WalkedFile[]> {
+  const results: WalkedFile[] = [];
+
+  async function walk(current: string, relPrefix: string): Promise<void> {
+    const entries = await fsp.readdir(current, { withFileTypes: true });
+    for (const entry of entries) {
+      const abs = path.join(current, entry.name);
+      const rel = relPrefix ? `${relPrefix}/${entry.name}` : entry.name;
+      if (entry.isDirectory()) {
+        await walk(abs, rel);
+      } else if (entry.isFile()) {
+        results.push({ absPath: abs, relPath: rel });
+      }
+    }
+  }
+
+  await walk(dir, "");
+  return results;
+}
+
+async function dirTotalBytes(dir: string): Promise<number> {
+  const files = await walkFiles(dir);
+  let total = 0;
+  for (const file of files) {
+    total += (await fsp.stat(file.absPath)).size;
+  }
+  return total;
+}
+
+async function outputBytes(
+  root: string,
+  relPath: string
+): Promise<number | null> {
+  const absPath = path.join(root, relPath);
+  if (!existsSync(absPath)) {
+    return null;
+  }
+  const stat = await fsp.stat(absPath);
+  return stat.isDirectory() ? dirTotalBytes(absPath) : stat.size;
+}
+
+function gzipBytesOf(absPath: string): number {
+  return gzipSync(readFileSync(absPath)).length;
+}
+
+/**
+ * Measures the known build outputs under `root` (a repo checkout — `.` for
+ * the current checkout, or a sibling directory for a second branch's
+ * checkout). Missing outputs are simply omitted, not an error.
+ */
+export async function measureRoot(root: string): Promise<SizeSnapshot> {
+  const outputs: OutputEntry[] = [];
+  let totalBytes = 0;
+  for (const target of OUTPUT_TARGETS) {
+    const bytes = await outputBytes(root, target.relPath);
+    if (bytes !== null) {
+      outputs.push({ label: target.label, path: target.relPath, bytes });
+      totalBytes += bytes;
+    }
+  }
+
+  const assetFiles: AssetFileEntry[] = [];
+  const assetsDirAbs = path.join(root, ASSETS_DIR);
+  if (existsSync(assetsDirAbs)) {
+    const canonicalMap = buildCanonicalMap(await readManifest(root));
+    const entries = await fsp.readdir(assetsDirAbs, { withFileTypes: true });
+    for (const entry of entries) {
+      if (!entry.isFile() || entry.name.endsWith(".map")) {
+        continue;
+      }
+      const relPath = `assets/${entry.name}`;
+      const absPath = path.join(assetsDirAbs, entry.name);
+      const bytes = (await fsp.stat(absPath)).size;
+      const label = canonicalMap.get(relPath) ?? stripHash(relPath);
+      assetFiles.push({
+        label,
+        relPath,
+        bytes,
+        gzipBytes: gzipBytesOf(absPath),
+      });
+    }
+  }
+
+  const topFiles: TopFileEntry[] = [];
+  const clientDirAbs = path.join(root, CLIENT_DIR);
+  if (existsSync(clientDirAbs)) {
+    const candidates = (await walkFiles(clientDirAbs)).filter(
+      (f) => !f.relPath.endsWith(".map")
+    );
+    const withSizes = await Promise.all(
+      candidates.map(async (f) => ({
+        relPath: f.relPath,
+        absPath: f.absPath,
+        bytes: (await fsp.stat(f.absPath)).size,
+      }))
+    );
+    withSizes.sort((a, b) => b.bytes - a.bytes);
+    for (const f of withSizes.slice(0, TOP_FILES_COUNT)) {
+      topFiles.push({
+        relPath: f.relPath,
+        bytes: f.bytes,
+        gzipBytes: gzipBytesOf(f.absPath),
+      });
+    }
+  }
+
+  return { outputs, totalBytes, assetFiles, topFiles };
+}
+
+const UNITS = ["B", "KB", "MB", "GB", "TB"];
+
+/** Formats a byte count in the same style as `numfmt --to=iec --suffix=B` (e.g. `1.2MB`). */
+export function formatBytes(
+  bytes: number,
+  options: { signed?: boolean } = {}
+): string {
+  const sign = options.signed ? (bytes > 0 ? "+" : bytes < 0 ? "-" : "") : "";
+  let value = Math.abs(bytes);
+  let unitIndex = 0;
+  while (value >= 1024 && unitIndex < UNITS.length - 1) {
+    value /= 1024;
+    unitIndex++;
+  }
+  const formatted =
+    unitIndex === 0
+      ? String(value)
+      : value.toFixed(value < 10 ? 1 : 0).replace(/\.0$/, "");
+  return `${sign}${formatted}${UNITS[unitIndex]}`;
+}
+
+export interface OutputDiffRow {
+  label: string;
+  baseBytes: number | null;
+  headBytes: number | null;
+  deltaBytes: number;
+  flagged: boolean;
+}
+
+export interface AssetDiffRow {
+  label: string;
+  baseBytes: number | null;
+  headBytes: number | null;
+  baseGzipBytes: number | null;
+  headGzipBytes: number | null;
+  deltaBytes: number;
+  deltaGzipBytes: number;
+  flagged: boolean;
+  status: "added" | "removed" | "changed" | "unchanged";
+}
+
+export interface SnapshotDiff {
+  outputs: OutputDiffRow[];
+  totalDelta: number;
+  totalFlagged: boolean;
+  assetFiles: AssetDiffRow[];
+}
+
+/** Orders labels head-first (preserving head's natural order), appending any base-only labels. */
+function orderedLabels(headLabels: string[], baseLabels: string[]): string[] {
+  const headSet = new Set(headLabels);
+  return [...headLabels, ...baseLabels.filter((l) => !headSet.has(l))];
+}
+
+/** Diffs two snapshots, flagging any output/asset whose absolute size delta exceeds the threshold. */
+export function diffSnapshots(
+  head: SizeSnapshot,
+  base: SizeSnapshot,
+  thresholdBytes: number
+): SnapshotDiff {
+  const baseOutputs = new Map(base.outputs.map((o) => [o.label, o.bytes]));
+  const headOutputs = new Map(head.outputs.map((o) => [o.label, o.bytes]));
+  const outputs: OutputDiffRow[] = orderedLabels(
+    head.outputs.map((o) => o.label),
+    base.outputs.map((o) => o.label)
+  ).map((label) => {
+    const baseBytes = baseOutputs.get(label) ?? null;
+    const headBytes = headOutputs.get(label) ?? null;
+    const deltaBytes = (headBytes ?? 0) - (baseBytes ?? 0);
+    return {
+      label,
+      baseBytes,
+      headBytes,
+      deltaBytes,
+      flagged: Math.abs(deltaBytes) > thresholdBytes,
+    };
+  });
+
+  const totalDelta = head.totalBytes - base.totalBytes;
+
+  const baseAssets = new Map(base.assetFiles.map((f) => [f.label, f]));
+  const headAssets = new Map(head.assetFiles.map((f) => [f.label, f]));
+  const assetFiles: AssetDiffRow[] = orderedLabels(
+    head.assetFiles.map((f) => f.label),
+    base.assetFiles.map((f) => f.label)
+  ).map((label) => {
+    const baseFile = baseAssets.get(label);
+    const headFile = headAssets.get(label);
+    const baseBytes = baseFile?.bytes ?? null;
+    const headBytes = headFile?.bytes ?? null;
+    const baseGzipBytes = baseFile?.gzipBytes ?? null;
+    const headGzipBytes = headFile?.gzipBytes ?? null;
+    const deltaBytes = (headBytes ?? 0) - (baseBytes ?? 0);
+    const deltaGzipBytes = (headGzipBytes ?? 0) - (baseGzipBytes ?? 0);
+    const status: AssetDiffRow["status"] = !baseFile
+      ? "added"
+      : !headFile
+        ? "removed"
+        : deltaBytes === 0
+          ? "unchanged"
+          : "changed";
+    return {
+      label,
+      baseBytes,
+      headBytes,
+      baseGzipBytes,
+      headGzipBytes,
+      deltaBytes,
+      deltaGzipBytes,
+      flagged: Math.abs(deltaBytes) > thresholdBytes,
+      status,
+    };
+  });
+
+  return {
+    outputs,
+    totalDelta,
+    totalFlagged: Math.abs(totalDelta) > thresholdBytes,
+    assetFiles,
+  };
+}
+
+const NOISE_FLOOR_BYTES = 1024;
+const MAX_CHANGED_FILES_ROWS = 15;
+
+function sizeCell(bytes: number | null): string {
+  return bytes === null ? "_missing_" : formatBytes(bytes);
+}
+
+function renderAssetDiffRow(
+  label: string,
+  row: AssetDiffRow | undefined
+): string {
+  if (!row) {
+    return `| \`${label}\` | _not found_ | _not found_ | _n/a_ |`;
+  }
+  const deltaGzip =
+    row.baseGzipBytes === null || row.headGzipBytes === null
+      ? ""
+      : `, gzip ${formatBytes(row.deltaGzipBytes, { signed: true })}`;
+  return `| \`${label}\` | ${sizeCell(row.baseBytes)} | ${sizeCell(row.headBytes)} | ${formatBytes(row.deltaBytes, { signed: true })}${deltaGzip}${row.flagged ? " ⚠️" : ""} |`;
+}
+
+/**
+ * Renders the full markdown build-size report. Single-snapshot mode (no
+ * `base`) is used for plain pushes; diff mode (with `base`) is used for pull
+ * requests and adds Base/Head/Δ columns plus a Flagged Bundles callout.
+ */
+export function renderReport(
+  head: SizeSnapshot,
+  base: SizeSnapshot | undefined,
+  thresholdBytes: number,
+  options: { baseUnavailable?: boolean } = {}
+): string {
+  const lines: string[] = [];
+  lines.push("### Build Output Sizes", "");
+
+  if (base) {
+    const diff = diffSnapshots(head, base, thresholdBytes);
+    lines.push("| Output | Base | Head | Δ |", "| --- | --- | --- | --- |");
+    for (const row of diff.outputs) {
+      lines.push(
+        `| ${row.label} | ${sizeCell(row.baseBytes)} | ${sizeCell(row.headBytes)} | ${formatBytes(row.deltaBytes, { signed: true })}${row.flagged ? " ⚠️" : ""} |`
+      );
+    }
+    lines.push(
+      `| **Total** | **${formatBytes(base.totalBytes)}** | **${formatBytes(head.totalBytes)}** | **${formatBytes(diff.totalDelta, { signed: true })}**${diff.totalFlagged ? " ⚠️" : ""} |`
+    );
+
+    lines.push(
+      "",
+      "#### Client Chunks",
+      "",
+      "| Chunk | Base | Head | Δ (gzip Δ) |",
+      "| --- | --- | --- | --- |"
+    );
+    const byLabel = new Map(diff.assetFiles.map((f) => [f.label, f]));
+    for (const label of [VENDOR_LABEL, INDEX_LABEL]) {
+      lines.push(renderAssetDiffRow(label, byLabel.get(label)));
+    }
+
+    const otherChanged = diff.assetFiles
+      .filter((f) => f.label !== VENDOR_LABEL && f.label !== INDEX_LABEL)
+      .filter((f) => Math.abs(f.deltaBytes) >= NOISE_FLOOR_BYTES)
+      .sort((a, b) => Math.abs(b.deltaBytes) - Math.abs(a.deltaBytes));
+
+    if (otherChanged.length > 0) {
+      lines.push(
+        "",
+        "#### Other Changed Files",
+        "",
+        "| File | Base | Head | Δ (gzip Δ) |",
+        "| --- | --- | --- | --- |"
+      );
+      for (const row of otherChanged.slice(0, MAX_CHANGED_FILES_ROWS)) {
+        lines.push(renderAssetDiffRow(row.label, row));
+      }
+      if (otherChanged.length > MAX_CHANGED_FILES_ROWS) {
+        lines.push(
+          "",
+          `_+${otherChanged.length - MAX_CHANGED_FILES_ROWS} more changed file(s) not shown._`
+        );
+      }
+    }
+
+    const flagged = [
+      ...diff.outputs
+        .filter((o) => o.flagged)
+        .map((o) => ({
+          label: o.label,
+          base: o.baseBytes,
+          head: o.headBytes,
+          delta: o.deltaBytes,
+        })),
+      ...diff.assetFiles
+        .filter((f) => f.flagged)
+        .map((f) => ({
+          label: `\`${f.label}\``,
+          base: f.baseBytes,
+          head: f.headBytes,
+          delta: f.deltaBytes,
+        })),
+    ];
+    lines.push("", "#### Flagged Bundles", "");
+    if (flagged.length === 0) {
+      lines.push(
+        `✅ No bundles changed by more than ${formatBytes(thresholdBytes)}.`
+      );
+    } else {
+      lines.push(
+        `⚠️ **${flagged.length} bundle(s) changed by more than ${formatBytes(thresholdBytes)}:**`,
+        ""
+      );
+      for (const f of flagged) {
+        lines.push(
+          `- ${f.label}: ${sizeCell(f.base)} → ${sizeCell(f.head)} (${formatBytes(f.delta, { signed: true })})`
+        );
+      }
+    }
+  } else {
+    lines.push("| Output | Size |", "| --- | --- |");
+    for (const o of head.outputs) {
+      lines.push(`| ${o.label} | ${formatBytes(o.bytes)} |`);
+    }
+    lines.push(`| **Total** | **${formatBytes(head.totalBytes)}** |`);
+
+    lines.push(
+      "",
+      "#### Client Chunks",
+      "",
+      "| Chunk | Raw | Gzip |",
+      "| --- | --- | --- |"
+    );
+    const byLabel = new Map(head.assetFiles.map((f) => [f.label, f]));
+    for (const label of [VENDOR_LABEL, INDEX_LABEL]) {
+      const file = byLabel.get(label);
+      lines.push(
+        file
+          ? `| \`${label}\` | ${formatBytes(file.bytes)} | ${formatBytes(file.gzipBytes)} |`
+          : `| \`${label}\` | _not found_ | _not found_ |`
+      );
+    }
+
+    if (options.baseUnavailable) {
+      lines.push(
+        "",
+        "_Base branch build unavailable — size comparison skipped._"
+      );
+    }
+  }
+
+  lines.push(
+    "",
+    "#### Top 5 Largest Files (client build)",
+    "",
+    "| File | Raw | Gzip |",
+    "| --- | --- | --- |"
+  );
+  if (head.topFiles.length === 0) {
+    lines.push("| _not found_ | | |");
+  } else {
+    for (const f of head.topFiles) {
+      lines.push(
+        `| \`${f.relPath}\` | ${formatBytes(f.bytes)} | ${formatBytes(f.gzipBytes)} |`
+      );
+    }
+  }
+
+  return lines.join("\n") + "\n";
+}

--- a/test/unit/script/lib/buildSizeReport.test.ts
+++ b/test/unit/script/lib/buildSizeReport.test.ts
@@ -1,0 +1,277 @@
+import {
+  canonicalLabelFor,
+  buildCanonicalMap,
+  stripHash,
+  formatBytes,
+  diffSnapshots,
+  renderReport,
+  VENDOR_LABEL,
+  INDEX_LABEL,
+  type SizeSnapshot,
+} from "../../../../script/lib/buildSizeReport";
+
+function snapshot(overrides: Partial<SizeSnapshot> = {}): SizeSnapshot {
+  return {
+    outputs: [],
+    totalBytes: 0,
+    assetFiles: [],
+    topFiles: [],
+    ...overrides,
+  };
+}
+
+describe("stripHash", () => {
+  it("strips a trailing content hash before the extension", () => {
+    expect(stripHash("vendor-DCGzEOOr.js")).toBe("vendor.js");
+  });
+
+  it("handles hashes containing hyphens/underscores", () => {
+    expect(stripHash("locations-extension-1EVP_A0l.js")).toBe(
+      "locations-extension.js"
+    );
+    expect(stripHash("en-BCa6xvG-.js")).toBe("en.js");
+  });
+
+  it("leaves unhashed filenames untouched", () => {
+    expect(stripHash("sw.js")).toBe("sw.js");
+  });
+});
+
+describe("canonicalLabelFor", () => {
+  it("prefers the manifest name over the hashed filename", () => {
+    expect(canonicalLabelFor("assets/vendor-DCGzEOOr.js", "vendor")).toBe(
+      "assets/vendor.js"
+    );
+  });
+
+  it("falls back to hash-stripping when no name is given", () => {
+    expect(canonicalLabelFor("assets/foo-AbCdEfGh.js", undefined)).toBe(
+      "assets/foo.js"
+    );
+  });
+});
+
+describe("buildCanonicalMap", () => {
+  it("maps each entry's file to its manifest name", () => {
+    const map = buildCanonicalMap({
+      "_vendor-DCGzEOOr.js": {
+        file: "assets/vendor-DCGzEOOr.js",
+        name: "vendor",
+      },
+    });
+    expect(map.get("assets/vendor-DCGzEOOr.js")).toBe("assets/vendor.js");
+  });
+
+  it("propagates the owning entry's name to its css files", () => {
+    const map = buildCanonicalMap({
+      "index.html": {
+        file: "assets/index-5Jw90a8k.js",
+        name: "index",
+        css: ["assets/index-Bo2RveBp.css"],
+      },
+    });
+    expect(map.get("assets/index-5Jw90a8k.js")).toBe("assets/index.js");
+    expect(map.get("assets/index-Bo2RveBp.css")).toBe("assets/index.css");
+  });
+
+  it("does not map plain assets (left for the hash-stripping fallback)", () => {
+    const map = buildCanonicalMap({
+      "index.html": {
+        file: "assets/index-5Jw90a8k.js",
+        name: "index",
+        assets: ["assets/logo-B6X9kU6O.png"],
+      },
+    });
+    expect(map.has("assets/logo-B6X9kU6O.png")).toBe(false);
+  });
+});
+
+describe("formatBytes", () => {
+  it("formats bytes below 1KB as-is", () => {
+    expect(formatBytes(512)).toBe("512B");
+  });
+
+  it("formats KB/MB with one decimal below 10 units", () => {
+    expect(formatBytes(1536)).toBe("1.5KB");
+    expect(formatBytes(1258291)).toBe("1.2MB");
+  });
+
+  it("formats larger values without a decimal", () => {
+    expect(formatBytes(12 * 1024 * 1024)).toBe("12MB");
+  });
+
+  it("only signs deltas when requested", () => {
+    expect(formatBytes(1024, { signed: true })).toBe("+1KB");
+    expect(formatBytes(-1024, { signed: true })).toBe("-1KB");
+    expect(formatBytes(1024)).toBe("1KB");
+  });
+});
+
+describe("diffSnapshots", () => {
+  const THRESHOLD = 300 * 1024;
+
+  it("flags an output whose size grows by more than the threshold", () => {
+    const base = snapshot({
+      outputs: [{ label: "Client bundle", path: "x", bytes: 1_000_000 }],
+      totalBytes: 1_000_000,
+    });
+    const head = snapshot({
+      outputs: [
+        { label: "Client bundle", path: "x", bytes: 1_000_000 + 400 * 1024 },
+      ],
+      totalBytes: 1_000_000 + 400 * 1024,
+    });
+
+    const diff = diffSnapshots(head, base, THRESHOLD);
+    expect(diff.outputs[0]!.flagged).toBe(true);
+    expect(diff.totalFlagged).toBe(true);
+  });
+
+  it("does not flag a change right at the threshold boundary", () => {
+    const base = snapshot({
+      outputs: [{ label: "Client bundle", path: "x", bytes: 1_000_000 }],
+      totalBytes: 1_000_000,
+    });
+    const head = snapshot({
+      outputs: [
+        { label: "Client bundle", path: "x", bytes: 1_000_000 + THRESHOLD },
+      ],
+      totalBytes: 1_000_000 + THRESHOLD,
+    });
+
+    const diff = diffSnapshots(head, base, THRESHOLD);
+    expect(diff.outputs[0]!.flagged).toBe(false);
+  });
+
+  it("flags a change one byte over the threshold", () => {
+    const base = snapshot({
+      outputs: [{ label: "Client bundle", path: "x", bytes: 1_000_000 }],
+      totalBytes: 1_000_000,
+    });
+    const head = snapshot({
+      outputs: [
+        {
+          label: "Client bundle",
+          path: "x",
+          bytes: 1_000_000 + THRESHOLD + 1,
+        },
+      ],
+      totalBytes: 1_000_000 + THRESHOLD + 1,
+    });
+
+    const diff = diffSnapshots(head, base, THRESHOLD);
+    expect(diff.outputs[0]!.flagged).toBe(true);
+  });
+
+  it("marks a head-only asset file as added and a base-only file as removed", () => {
+    const base = snapshot({
+      assetFiles: [
+        {
+          label: "assets/old.js",
+          relPath: "assets/old-a.js",
+          bytes: 100,
+          gzipBytes: 50,
+        },
+      ],
+    });
+    const head = snapshot({
+      assetFiles: [
+        {
+          label: "assets/new.js",
+          relPath: "assets/new-b.js",
+          bytes: 100,
+          gzipBytes: 50,
+        },
+      ],
+    });
+
+    const diff = diffSnapshots(head, base, THRESHOLD);
+    const byLabel = new Map(diff.assetFiles.map((f) => [f.label, f]));
+    expect(byLabel.get("assets/new.js")?.status).toBe("added");
+    expect(byLabel.get("assets/old.js")?.status).toBe("removed");
+  });
+});
+
+describe("renderReport", () => {
+  it("renders a single-column table when no base snapshot is given", () => {
+    const head = snapshot({
+      outputs: [{ label: "Client bundle", path: "x", bytes: 1024 }],
+      totalBytes: 1024,
+      assetFiles: [
+        {
+          label: VENDOR_LABEL,
+          relPath: "assets/vendor-x.js",
+          bytes: 2048,
+          gzipBytes: 512,
+        },
+      ],
+    });
+
+    const markdown = renderReport(head, undefined, 300 * 1024);
+    expect(markdown).toContain("| Output | Size |");
+    expect(markdown).not.toContain("Flagged Bundles");
+    expect(markdown).toContain(VENDOR_LABEL);
+  });
+
+  it("renders a diff table and calls out flagged bundles", () => {
+    const base = snapshot({
+      outputs: [{ label: "Client bundle", path: "x", bytes: 1_000_000 }],
+      totalBytes: 1_000_000,
+      assetFiles: [
+        {
+          label: VENDOR_LABEL,
+          relPath: "assets/vendor-a.js",
+          bytes: 1_000_000,
+          gzipBytes: 200_000,
+        },
+      ],
+    });
+    const head = snapshot({
+      outputs: [
+        { label: "Client bundle", path: "x", bytes: 1_000_000 + 400 * 1024 },
+      ],
+      totalBytes: 1_000_000 + 400 * 1024,
+      assetFiles: [
+        {
+          label: VENDOR_LABEL,
+          relPath: "assets/vendor-b.js",
+          bytes: 1_000_000 + 400 * 1024,
+          gzipBytes: 250_000,
+        },
+      ],
+    });
+
+    const markdown = renderReport(head, base, 300 * 1024);
+    expect(markdown).toContain("| Output | Base | Head | Δ |");
+    expect(markdown).toContain("Flagged Bundles");
+    expect(markdown).toContain(`${VENDOR_LABEL}\`: `);
+    expect(markdown).not.toContain("No bundles changed by more than");
+  });
+
+  it("reassures when nothing is flagged", () => {
+    const base = snapshot({
+      outputs: [{ label: "Client bundle", path: "x", bytes: 1_000_000 }],
+      totalBytes: 1_000_000,
+    });
+    const head = snapshot({
+      outputs: [{ label: "Client bundle", path: "x", bytes: 1_000_100 }],
+      totalBytes: 1_000_100,
+    });
+
+    const markdown = renderReport(head, base, 300 * 1024);
+    expect(markdown).toContain("No bundles changed by more than");
+  });
+
+  it("notes when the base branch build was unavailable", () => {
+    const head = snapshot();
+    const markdown = renderReport(head, undefined, 300 * 1024, {
+      baseUnavailable: true,
+    });
+    expect(markdown).toContain("Base branch build unavailable");
+  });
+
+  it("always renders vendor/index rows for the client chunk labels", () => {
+    expect(VENDOR_LABEL).toBe("assets/vendor.js");
+    expect(INDEX_LABEL).toBe("assets/index.js");
+  });
+});


### PR DESCRIPTION
Adds a step after `pnpm build` that computes the size of each build
output (client bundle, SSR bundle, server bundle, packaged patterns)
and writes them as a markdown table to GITHUB_STEP_SUMMARY, so bundle
size regressions are visible on every CI run.