### PR TITLE
Refactor extensions to export init functions instead of auto-registering

### DIFF
--- a/packages/apologist-extension/ext_Apologist/main/init.tsx
+++ b/packages/apologist-extension/ext_Apologist/main/init.tsx
@@ -32,189 +32,77 @@ const shareSchema = z.object({
 
 const PROVIDER_ID = "apologist-chat-provider";
 
-registerExtension({
-  id: "ext_Apologist",
-  init: function* (context: SeedBibleState) {
-    console.log("Apologist extension initialized with context:", context);
+export default function initApologistExtension() {
+  registerExtension({
+    id: "ext_Apologist",
+    init: function* (context: SeedBibleState) {
+      console.log("Apologist extension initialized with context:", context);
 
-    const url = context.navigation.currentUrl.value;
-    const apologistName = url.searchParams.get("apologistName") ?? null;
-    const apologistIconUrl =
-      url.searchParams.get("apologistIconUrl") ?? undefined;
-    const customApologistDomain =
-      url.searchParams.get("apologistDomain") ?? null;
-    const apologistDomain = customApologistDomain ?? "apologist.ao.bot";
-    const apologistApiKey = url.searchParams.get("apologistApiKey") ?? null;
-    const apologistShareToken =
-      url.searchParams.get("apologistShareToken") ?? null;
-    const apologistModel =
-      url.searchParams.get("apologistModel") ?? "openai/gpt/5-mini";
-    const apologistConversationId: string | null =
-      url.searchParams.get("apologistConversation") ?? null;
+      const url = context.navigation.currentUrl.value;
+      const apologistName = url.searchParams.get("apologistName") ?? null;
+      const apologistIconUrl =
+        url.searchParams.get("apologistIconUrl") ?? undefined;
+      const customApologistDomain =
+        url.searchParams.get("apologistDomain") ?? null;
+      const apologistDomain = customApologistDomain ?? "apologist.ao.bot";
+      const apologistApiKey = url.searchParams.get("apologistApiKey") ?? null;
+      const apologistShareToken =
+        url.searchParams.get("apologistShareToken") ?? null;
+      const apologistModel =
+        url.searchParams.get("apologistModel") ?? "openai/gpt/5-mini";
+      const apologistConversationId: string | null =
+        url.searchParams.get("apologistConversation") ?? null;
 
-    if (customApologistDomain && !apologistApiKey) {
-      console.error(
-        "[Apologist] Using a custom domain requires an API key to be set."
-      );
-      return;
-    }
-
-    // TODO: Add logo for apologist
-    yield context.chats.registerProvider({
-      id: PROVIDER_ID,
-      name: apologistName ?? {
-        key: "title",
-        defaultValue: "Apologist",
-        ns: "ext_Apologist",
-      },
-      iconUrl: apologistIconUrl,
-      supportsSharedChats: true,
-      generateResponse: async (chatContext) => {
-        const lastMessage =
-          chatContext.messages[chatContext.messages.length - 1];
-        console.log("Generating response for message:", lastMessage);
-
-        const contextMessage = {
-          role: "user",
-          content: `Currently reading: ${context.app.selectedTab.value?.readingState.bookId} ${context.app.selectedTab.value?.readingState.chapterNumber}`,
-        };
-
-        const response = await fetch(
-          `https://${apologistDomain}/api/v1/chat/completions`,
-          {
-            method: "POST",
-            body: JSON.stringify({
-              model: apologistModel,
-              stream: false,
-              metadata: {
-                bible: "bsb",
-                language: i18n.language,
-              },
-              messages: [
-                contextMessage,
-                ...chatContext.messages.map((m) => ({
-                  role: m.authors.some((a) => a === chatContext.participant.id)
-                    ? "user"
-                    : "assistant",
-                  content: m.text,
-                })),
-              ],
-            }),
-            headers: apologistApiKey
-              ? {
-                  Authorization: `Bearer ${apologistApiKey}`,
-                }
-              : {},
-          }
+      if (customApologistDomain && !apologistApiKey) {
+        console.error(
+          "[Apologist] Using a custom domain requires an API key to be set."
         );
+        return;
+      }
 
-        const responseData = await response.json();
-        const message = responseData.choices[0].message;
+      // TODO: Add logo for apologist
+      yield context.chats.registerProvider({
+        id: PROVIDER_ID,
+        name: apologistName ?? {
+          key: "title",
+          defaultValue: "Apologist",
+          ns: "ext_Apologist",
+        },
+        iconUrl: apologistIconUrl,
+        supportsSharedChats: true,
+        generateResponse: async (chatContext) => {
+          const lastMessage =
+            chatContext.messages[chatContext.messages.length - 1];
+          console.log("Generating response for message:", lastMessage);
 
-        if (message) {
-          return {
-            type: "text",
-            text: message.content,
+          const contextMessage = {
+            role: "user",
+            content: `Currently reading: ${context.app.selectedTab.value?.readingState.bookId} ${context.app.selectedTab.value?.readingState.chapterNumber}`,
           };
-        }
 
-        return null;
-      },
-    });
-
-    if (apologistShareToken) {
-      // init conversation
-      const initConversation = async () => {
-        try {
-          console.log(
-            "[Apologist] Getting conversation history for share token:",
-            apologistShareToken
-          );
           const response = await fetch(
-            `https://${apologistDomain}/api/v1/shares/${encodeURIComponent(apologistShareToken)}`
-          );
-
-          const responseData = await response.json();
-
-          console.log("Share response:", responseData);
-          const shareData = shareSchema.parse(responseData);
-
-          // TODO: Support detecting langauge from share data.
-          // const lastLanguage =
-          //   shareData.messages[shareData.messages.length - 1]?.language;
-          // if (lastLanguage) {
-          //   console.log(
-          //     `[Apologist] Setting language to ${lastLanguage} based on conversation history.`
-          //   );
-          //   i18n.changeLanguage(lastLanguage);
-          // }
-
-          // build conversation
-          const messages = [];
-          for (const message of shareData.messages) {
-            const content = message.parts
-              .map((part) => {
-                if (part.type === "text") {
-                  return part.text;
-                }
-                return "";
-              })
-              .join("");
-
-            messages.push({
-              role: message.role,
-              content,
-              // TODO: Load actual timestamp from messages when available
-              timeMs: Date.now(),
-              // DateTime.fromSQL(completion.response_completed_at, {
-              //   zone: "utc",
-              // }).toMillis(),
-            });
-          }
-
-          const session = context.chats.createLocalSession({
-            messages: messages.map((m) => ({
-              type: "text",
-              id: uuid(),
-              text: m.content,
-              authors: [
-                m.role === "user"
-                  ? (context.login.userId.value ?? "local-user")
-                  : PROVIDER_ID,
-              ],
-              targets: [],
-              timeMs: m.timeMs,
-            })),
-            providerIds: [PROVIDER_ID],
-          });
-
-          session.markAsRead();
-          context.sidebar.openChatPanel();
-          context.chats.selectChat(session.id);
-
-          console.log("[Apologist] Conversation history:", messages);
-        } catch (err) {
-          console.error("[Apologist] Failed to initialize conversation:", err);
-
-          // TODO: Consider whether to initialize chat if conversation history fails to load
-          // const session = context.chats.createLocalSession();
-          // context.sidebar.openChatPanel();
-          // context.chats.selectChat(session.id);
-        }
-      };
-
-      initConversation();
-    } else if (apologistConversationId) {
-      // init conversation
-      const initConversation = async () => {
-        try {
-          console.log(
-            "[Apologist] Getting conversation history for conversation ID:",
-            apologistConversationId
-          );
-          const response = await fetch(
-            `https://${apologistDomain}/api/v1/chat/completions?conversation_id=${encodeURIComponent(apologistConversationId)}`,
+            `https://${apologistDomain}/api/v1/chat/completions`,
             {
+              method: "POST",
+              body: JSON.stringify({
+                model: apologistModel,
+                stream: false,
+                metadata: {
+                  bible: "bsb",
+                  language: i18n.language,
+                },
+                messages: [
+                  contextMessage,
+                  ...chatContext.messages.map((m) => ({
+                    role: m.authors.some(
+                      (a) => a === chatContext.participant.id
+                    )
+                      ? "user"
+                      : "assistant",
+                    content: m.text,
+                  })),
+                ],
+              }),
               headers: apologistApiKey
                 ? {
                     Authorization: `Bearer ${apologistApiKey}`,
@@ -224,70 +112,192 @@ registerExtension({
           );
 
           const responseData = await response.json();
-          const completions = completionsSchema.parse(responseData);
+          const message = responseData.choices[0].message;
 
-          const lastLanguage =
-            completions.data[completions.data.length - 1]?.language;
-          if (lastLanguage) {
-            console.log(
-              `[Apologist] Setting language to ${lastLanguage} based on conversation history.`
-            );
-            i18n.changeLanguage(lastLanguage);
-          }
-
-          // build conversation
-          const messages = [];
-          for (const completion of completions.data) {
-            messages.push({
-              role: "user",
-              content: completion.prompt,
-              timeMs: DateTime.fromSQL(completion.prompted_at, {
-                zone: "utc",
-              }).toMillis(),
-            });
-            messages.push({
-              role: "assistant",
-              content: completion.response,
-              timeMs: DateTime.fromSQL(completion.response_completed_at, {
-                zone: "utc",
-              }).toMillis(),
-            });
-          }
-
-          const session = context.chats.createLocalSession({
-            messages: messages.map((m) => ({
+          if (message) {
+            return {
               type: "text",
-              id: uuid(),
-              text: m.content,
-              authors: [
-                m.role === "user"
-                  ? (context.login.userId.value ?? "local-user")
-                  : PROVIDER_ID,
-              ],
-              targets: [],
-              timeMs: m.timeMs,
-            })),
-            providerIds: [PROVIDER_ID],
-          });
+              text: message.content,
+            };
+          }
 
-          session.markAsRead();
-          context.sidebar.openChatPanel();
-          context.chats.selectChat(session.id);
+          return null;
+        },
+      });
 
-          console.log("[Apologist] Conversation history:", messages);
-        } catch (err) {
-          console.error("[Apologist] Failed to initialize conversation:", err);
+      if (apologistShareToken) {
+        // init conversation
+        const initConversation = async () => {
+          try {
+            console.log(
+              "[Apologist] Getting conversation history for share token:",
+              apologistShareToken
+            );
+            const response = await fetch(
+              `https://${apologistDomain}/api/v1/shares/${encodeURIComponent(apologistShareToken)}`
+            );
 
-          // TODO: Consider whether to initialize chat if conversation history fails to load
-          // const session = context.chats.createLocalSession();
-          // context.sidebar.openChatPanel();
-          // context.chats.selectChat(session.id);
-        }
-      };
+            const responseData = await response.json();
 
-      initConversation();
-    }
+            console.log("Share response:", responseData);
+            const shareData = shareSchema.parse(responseData);
 
-    return {};
-  },
-});
+            // TODO: Support detecting langauge from share data.
+            // const lastLanguage =
+            //   shareData.messages[shareData.messages.length - 1]?.language;
+            // if (lastLanguage) {
+            //   console.log(
+            //     `[Apologist] Setting language to ${lastLanguage} based on conversation history.`
+            //   );
+            //   i18n.changeLanguage(lastLanguage);
+            // }
+
+            // build conversation
+            const messages = [];
+            for (const message of shareData.messages) {
+              const content = message.parts
+                .map((part) => {
+                  if (part.type === "text") {
+                    return part.text;
+                  }
+                  return "";
+                })
+                .join("");
+
+              messages.push({
+                role: message.role,
+                content,
+                // TODO: Load actual timestamp from messages when available
+                timeMs: Date.now(),
+                // DateTime.fromSQL(completion.response_completed_at, {
+                //   zone: "utc",
+                // }).toMillis(),
+              });
+            }
+
+            const session = context.chats.createLocalSession({
+              messages: messages.map((m) => ({
+                type: "text",
+                id: uuid(),
+                text: m.content,
+                authors: [
+                  m.role === "user"
+                    ? (context.login.userId.value ?? "local-user")
+                    : PROVIDER_ID,
+                ],
+                targets: [],
+                timeMs: m.timeMs,
+              })),
+              providerIds: [PROVIDER_ID],
+            });
+
+            session.markAsRead();
+            context.sidebar.openChatPanel();
+            context.chats.selectChat(session.id);
+
+            console.log("[Apologist] Conversation history:", messages);
+          } catch (err) {
+            console.error(
+              "[Apologist] Failed to initialize conversation:",
+              err
+            );
+
+            // TODO: Consider whether to initialize chat if conversation history fails to load
+            // const session = context.chats.createLocalSession();
+            // context.sidebar.openChatPanel();
+            // context.chats.selectChat(session.id);
+          }
+        };
+
+        initConversation();
+      } else if (apologistConversationId) {
+        // init conversation
+        const initConversation = async () => {
+          try {
+            console.log(
+              "[Apologist] Getting conversation history for conversation ID:",
+              apologistConversationId
+            );
+            const response = await fetch(
+              `https://${apologistDomain}/api/v1/chat/completions?conversation_id=${encodeURIComponent(apologistConversationId)}`,
+              {
+                headers: apologistApiKey
+                  ? {
+                      Authorization: `Bearer ${apologistApiKey}`,
+                    }
+                  : {},
+              }
+            );
+
+            const responseData = await response.json();
+            const completions = completionsSchema.parse(responseData);
+
+            const lastLanguage =
+              completions.data[completions.data.length - 1]?.language;
+            if (lastLanguage) {
+              console.log(
+                `[Apologist] Setting language to ${lastLanguage} based on conversation history.`
+              );
+              i18n.changeLanguage(lastLanguage);
+            }
+
+            // build conversation
+            const messages = [];
+            for (const completion of completions.data) {
+              messages.push({
+                role: "user",
+                content: completion.prompt,
+                timeMs: DateTime.fromSQL(completion.prompted_at, {
+                  zone: "utc",
+                }).toMillis(),
+              });
+              messages.push({
+                role: "assistant",
+                content: completion.response,
+                timeMs: DateTime.fromSQL(completion.response_completed_at, {
+                  zone: "utc",
+                }).toMillis(),
+              });
+            }
+
+            const session = context.chats.createLocalSession({
+              messages: messages.map((m) => ({
+                type: "text",
+                id: uuid(),
+                text: m.content,
+                authors: [
+                  m.role === "user"
+                    ? (context.login.userId.value ?? "local-user")
+                    : PROVIDER_ID,
+                ],
+                targets: [],
+                timeMs: m.timeMs,
+              })),
+              providerIds: [PROVIDER_ID],
+            });
+
+            session.markAsRead();
+            context.sidebar.openChatPanel();
+            context.chats.selectChat(session.id);
+
+            console.log("[Apologist] Conversation history:", messages);
+          } catch (err) {
+            console.error(
+              "[Apologist] Failed to initialize conversation:",
+              err
+            );
+
+            // TODO: Consider whether to initialize chat if conversation history fails to load
+            // const session = context.chats.createLocalSession();
+            // context.sidebar.openChatPanel();
+            // context.chats.selectChat(session.id);
+          }
+        };
+
+        initConversation();
+      }
+
+      return {};
+    },
+  });
+}

--- a/packages/apologist-extension/index.ts
+++ b/packages/apologist-extension/index.ts
@@ -1,1 +1,1 @@
-import "./ext_Apologist/main/init";
+export { default } from "./ext_Apologist/main/init";

--- a/packages/bonfire-extension/ext_Bonfire/main/init.tsx
+++ b/packages/bonfire-extension/ext_Bonfire/main/init.tsx
@@ -1,34 +1,36 @@
 import { registerExtension, type SeedBibleState } from "seed-bible";
 import { registerBonfireChatProvider } from "./bonfire";
 
-registerExtension({
-  id: "ext_Bonfire",
-  init: function* (context: SeedBibleState) {
-    console.log("Bonfire extension initialized with context:", context);
+export default function initBonfireExtension() {
+  registerExtension({
+    id: "ext_Bonfire",
+    init: function* (context: SeedBibleState) {
+      console.log("Bonfire extension initialized with context:", context);
 
-    const url = context.navigation.currentUrl.value;
-    const orgId = url.searchParams.get("bonfireOrgId");
-    const aiId = url.searchParams.get("bonfireAiId");
-    const apiKey = url.searchParams.get("bonfireApiKey");
+      const url = context.navigation.currentUrl.value;
+      const orgId = url.searchParams.get("bonfireOrgId");
+      const aiId = url.searchParams.get("bonfireAiId");
+      const apiKey = url.searchParams.get("bonfireApiKey");
 
-    if (!orgId || !aiId || !apiKey) {
-      console.error(
-        "Bonfire extension requires bonfireOrgId, bonfireAiId, and bonfireApiKey to be set in configBot tags"
-      );
-      return;
-    }
+      if (!orgId || !aiId || !apiKey) {
+        console.error(
+          "Bonfire extension requires bonfireOrgId, bonfireAiId, and bonfireApiKey to be set in configBot tags"
+        );
+        return;
+      }
 
-    const name = url.searchParams.get("bonfireName") ?? "Bonfire AI";
-    const iconUrl = url.searchParams.get("bonfireIconUrl") ?? undefined;
+      const name = url.searchParams.get("bonfireName") ?? "Bonfire AI";
+      const iconUrl = url.searchParams.get("bonfireIconUrl") ?? undefined;
 
-    yield* registerBonfireChatProvider(context, {
-      orgId,
-      aiId,
-      apiKey,
-      name,
-      iconUrl,
-    });
+      yield* registerBonfireChatProvider(context, {
+        orgId,
+        aiId,
+        apiKey,
+        name,
+        iconUrl,
+      });
 
-    return {};
-  },
-});
+      return {};
+    },
+  });
+}

--- a/packages/bonfire-extension/index.ts
+++ b/packages/bonfire-extension/index.ts
@@ -1,1 +1,1 @@
-import "./ext_Bonfire/main/init";
+export { default } from "./ext_Bonfire/main/init";


### PR DESCRIPTION
## Summary

Changed the Apologist and Bonfire extensions to export their initialization functions as default exports instead of immediately registering themselves at module load time. This allows `ExtensionManager` to control when and how many times extensions are initialized, enabling proper install/uninstall/reinstall cycles within a single session.

## Key Changes

- **Apologist extension** (`packages/apologist-extension/ext_Apologist/main/init.tsx`):
  - Wrapped the entire `registerExtension()` call in a new `initApologistExtension()` function
  - Exported this function as the default export
  - Updated `index.ts` to export the function instead of importing the side effect

- **Bonfire extension** (`packages/bonfire-extension/ext_Bonfire/main/init.tsx`):
  - Wrapped the entire `registerExtension()` call in a new `initBonfireExtension()` function
  - Exported this function as the default export
  - Updated `index.ts` to export the function instead of importing the side effect

## Implementation Details

Previously, both extensions called `registerExtension()` at the module level, which meant registration happened once when the module was first imported. Now, the registration is deferred until `ExtensionManager` explicitly calls the exported function. This aligns with the extension architecture pattern described in the project conventions, where `ExtensionManager` invokes the default export on every install attempt (not just once at module load), allowing extensions to be uninstalled and reinstalled within the same session.

The logic inside each extension remains unchanged—only the wrapping and export mechanism was modified.

https://claude.ai/code/session_017uk8cQghETzHxZiXoXNRkj

Fixes #1322 