### PR TITLE
fix: prevent profile wipe when profile load fails transiently

### DIFF
--- a/packages/seed-bible/seed-bible/managers/LoginManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/LoginManager.tsx
@@ -469,6 +469,28 @@ export function createLoginManager({
       return;
     }
 
+    // Make sure the profile has loaded before we upload anything. `updateProfile`
+    // refuses to write while the profile is null (to avoid wiping the account),
+    // so persisting the URL would silently no-op if we ran ahead of the load —
+    // and the caller would see a resolved promise and report a false success.
+    // Failing here, before the (billable) file upload, avoids paying for a file
+    // we couldn't attach to the profile anyway.
+    if (!profile.value) {
+      if (profilePromise) {
+        try {
+          await profilePromise;
+        } catch {
+          // Ignored; the guard below turns a failed load into a thrown error.
+        }
+      }
+
+      if (!profile.value) {
+        throw new Error(
+          "Failed to upload profile picture: profile has not loaded"
+        );
+      }
+    }
+
     const result = await os.recordFile(userId.value, file, {
       mimeType: file.type,
       marker: "publicRead",

--- a/packages/seed-bible/seed-bible/managers/LoginManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/LoginManager.tsx
@@ -158,21 +158,37 @@ export function createLoginManager({
     const data = await os.getData(userId, "profile");
 
     if (!data.success) {
-      console.log("[LoginManager] No profile data found for user:", userId);
-      // Return a default profile
-      return {
-        name: "",
-      };
+      if (data.errorCode === "data_not_found") {
+        // The account genuinely has no profile record yet (new user). A blank
+        // default is the correct, authoritative answer here — the user can
+        // start filling it in and writes should be allowed.
+        console.log("[LoginManager] No profile data found for user:", userId);
+        return {
+          name: "",
+        };
+      }
+
+      // Any other failure (server error, `not_authorized`, network blip — all
+      // common on mobile) is transient: the profile may well exist, we just
+      // couldn't read it right now. We must NOT fall back to a blank profile,
+      // because the caller stores it in `profile.value` and the next config
+      // write (`saveProfileConfigValue` / `updateProfile`) merges into it and
+      // persists it — permanently wiping the real name/location/picture and
+      // every other config key. Surface the failure instead so callers keep
+      // whatever profile they already had.
+      throw new Error(
+        `[LoginManager] Failed to load profile (${data.errorCode}): ${data.errorMessage}`
+      );
     }
 
     const parsed = userProfileSchema.safeParse(data.data);
 
     if (!parsed.success) {
+      // The record exists but doesn't match the expected shape. Returning a
+      // blank default here would also let the next write clobber the stored
+      // record, so treat it as a load failure rather than an empty profile.
       console.warn("Failed to parse user profile data:", parsed.error);
-      // Return a default profile
-      return {
-        name: "",
-      };
+      throw new Error("[LoginManager] Stored profile failed validation");
     }
     return parsed.data;
   };
@@ -366,10 +382,42 @@ export function createLoginManager({
       posthog.identify(userId.value);
     }
 
-    profilePromise = getUserProfile(userId.value).then((p) => {
-      profile.value = p;
-      return p;
-    });
+    const loadingForUserId = userId.value;
+    const loadPromise = getUserProfile(loadingForUserId)
+      .then((p) => {
+        // Guard against a stale load resolving after the user switched
+        // (e.g. logout, then a different login) — don't apply an old
+        // account's profile over the current one.
+        if (userId.value === loadingForUserId) {
+          profile.value = p;
+        }
+        return p;
+      })
+      .catch((err) => {
+        // A transient load failure must not disturb whatever profile we
+        // already hold. Leaving `profile.value` untouched (previous value or
+        // null) is what keeps a network blip from turning into an account
+        // wipe: writes only merge into a real, successfully-loaded profile,
+        // never into a blank fallback.
+        console.warn(
+          "[LoginManager] Failed to load user profile; keeping existing profile",
+          err
+        );
+        // If we already have a profile loaded, treat the promise as resolved
+        // with it so awaiters (e.g. saveProfileConfigValue) can proceed
+        // against the good data instead of hitting an unhandled rejection.
+        if (profile.value) {
+          return profile.value;
+        }
+        throw err;
+      });
+
+    // Attach a passive rejection handler so a load failure that nobody awaits
+    // doesn't surface as an unhandled promise rejection (which would fire on
+    // every transient failure). Real awaiters of `profilePromise` — e.g.
+    // `saveProfileConfigValue` — still receive the rejection.
+    loadPromise.catch(() => undefined);
+    profilePromise = loadPromise;
   });
 
   effect(() => {
@@ -396,8 +444,18 @@ export function createLoginManager({
       return;
     }
 
+    if (!profile.value) {
+      // The profile hasn't finished loading (or its load failed transiently).
+      // Writing now would merge `newData` into a bare `{ name: "" }` base and
+      // persist it, wiping whatever is actually stored on the account. Refuse
+      // rather than risk the wipe — the caller can retry once the profile is
+      // available.
+      console.warn("Cannot update profile: profile has not loaded yet");
+      return;
+    }
+
     const nextProfile: UserProfile = {
-      ...(profile.value ?? { name: "" }),
+      ...profile.value,
       ...newData,
     };
     profile.value = nextProfile;
@@ -430,7 +488,14 @@ export function createLoginManager({
     userInfo,
     authBot: userInfo,
     profile,
-    profilePromise,
+    // Exposed as a getter so external readers see the promise assigned by the
+    // profile-loading effect below. A plain property would capture the value
+    // at construction time (null), which stays null after a fresh login and
+    // silently defeats `saveProfileConfigValue`'s "wait for the profile to
+    // load" guard.
+    get profilePromise() {
+      return profilePromise;
+    },
 
     isLoginOpen,
 

--- a/packages/seed-bible/seed-bible/managers/LoginManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/LoginManager.tsx
@@ -153,6 +153,10 @@ export function createLoginManager({
   // const userId = os.userId;
   const profile = signal<UserProfile | null>(null);
   let profilePromise: Promise<UserProfile> | null = null;
+  // Tracks which account `profile.value` currently belongs to, so an account
+  // switch can never leave the previous account's profile in place (which a
+  // later write would then merge into the new account's record).
+  let profileUserId: string | null = null;
 
   const getUserProfile = async (userId: string): Promise<UserProfile> => {
     const data = await os.getData(userId, "profile");
@@ -371,7 +375,17 @@ export function createLoginManager({
   effect(() => {
     if (!userId.value) {
       profile.value = null;
+      profileUserId = null;
       return;
+    }
+
+    // If the profile we're holding belongs to a different account — i.e. the
+    // user switched accounts without a full logout clearing it first — drop it
+    // now so we never display, or (via a later write) merge, one account's
+    // profile under another's id.
+    if (profileUserId !== null && profileUserId !== userId.value) {
+      profile.value = null;
+      profileUserId = null;
     }
 
     if (typeof posthog !== "undefined" && posthog) {
@@ -390,6 +404,7 @@ export function createLoginManager({
         // account's profile over the current one.
         if (userId.value === loadingForUserId) {
           profile.value = p;
+          profileUserId = loadingForUserId;
         }
         return p;
       })
@@ -406,7 +421,11 @@ export function createLoginManager({
         // If we already have a profile loaded, treat the promise as resolved
         // with it so awaiters (e.g. saveProfileConfigValue) can proceed
         // against the good data instead of hitting an unhandled rejection.
-        if (profile.value) {
+        // Only do so when the load is still current and the held profile
+        // belongs to this account (the account-switch clear above guarantees a
+        // non-null profile.value here belongs to loadingForUserId). Otherwise
+        // rethrow so a stale/foreign profile is never handed back.
+        if (userId.value === loadingForUserId && profile.value) {
           return profile.value;
         }
         throw err;

--- a/packages/seed-bible/seed-bible/managers/ProfileConfigSync.tsx
+++ b/packages/seed-bible/seed-bible/managers/ProfileConfigSync.tsx
@@ -41,7 +41,14 @@ export async function saveProfileConfigValue(
 
   if (!login.profile.value) {
     if (login.profilePromise) {
-      await login.profilePromise;
+      // The load may reject (transient/server/auth failure). Swallow it here —
+      // the `profile.value` re-check below is what decides whether it's safe
+      // to write, and a rejected load simply means "not safe yet".
+      try {
+        await login.profilePromise;
+      } catch {
+        // Intentionally ignored; handled by the guard below.
+      }
     }
 
     if (!login.profile.value) {

--- a/test/unit/seed-bible/managers/LoginManager.test.ts
+++ b/test/unit/seed-bible/managers/LoginManager.test.ts
@@ -267,6 +267,76 @@ describe("createLoginManager", () => {
 
       expect(getDataMock).toHaveBeenCalledWith(USER_ID, "profile");
     });
+
+    it("keeps profile null (does not fabricate a blank) when the load fails transiently", async () => {
+      // A server/network error is NOT the same as "no profile exists". If we
+      // collapsed it to `{ name: "" }`, the next config write would merge into
+      // that blank and wipe the real stored account (the mobile wipe bug).
+      getDataMock.mockResolvedValue({
+        success: false,
+        errorCode: "server_error",
+        errorMessage: "boom",
+      });
+
+      const manager = createAuthenticatedManager();
+
+      await waitFor(() => manager.userId.value === USER_ID);
+      await flush();
+
+      expect(manager.profile.value).toBeNull();
+    });
+
+    it("does not overwrite an already-loaded profile when a later reload fails", async () => {
+      getDataMock.mockResolvedValueOnce({
+        success: true,
+        data: { name: "Alice", location: "Earth" },
+      });
+
+      const manager = createAuthenticatedManager();
+      await waitFor(() => manager.profile.value?.name === "Alice");
+
+      // A subsequent reload (e.g. triggered by a session refresh) fails. The
+      // good profile must survive so writes don't merge into a blank.
+      getDataMock.mockResolvedValue({
+        success: false,
+        errorCode: "not_authorized",
+        errorMessage: "stale key",
+      });
+
+      await manager.getUserProfile(USER_ID).catch(() => undefined);
+      await flush();
+
+      expect(manager.profile.value).toEqual({
+        name: "Alice",
+        location: "Earth",
+      });
+    });
+
+    it("returns a blank default only when the profile genuinely does not exist", async () => {
+      getDataMock.mockResolvedValue({
+        success: false,
+        errorCode: "data_not_found",
+        errorMessage: "No data found for the given key.",
+      });
+
+      const manager = createLoginManager({ os });
+
+      await expect(manager.getUserProfile(USER_ID)).resolves.toEqual({
+        name: "",
+      });
+    });
+
+    it("throws instead of returning a blank when the load fails transiently", async () => {
+      getDataMock.mockResolvedValue({
+        success: false,
+        errorCode: "server_error",
+        errorMessage: "boom",
+      });
+
+      const manager = createLoginManager({ os });
+
+      await expect(manager.getUserProfile(USER_ID)).rejects.toThrow();
+    });
   });
 
   describe("session refresh on init", () => {
@@ -479,6 +549,24 @@ describe("createLoginManager", () => {
       expect(recordDataMock).not.toHaveBeenCalled();
       expect(warnSpy).toHaveBeenCalledWith(
         "Cannot update profile: no authenticated user"
+      );
+    });
+
+    it("updateProfile() does not persist while the profile is still loading", async () => {
+      // Authenticated, but the profile fetch is still pending (or failed), so
+      // `profile.value` is null. Writing now would persist a bare `{ name: "" }`
+      // base over the real stored profile — refuse instead.
+      getDataMock.mockReturnValue(new Promise(() => undefined));
+
+      const manager = createAuthenticatedManager();
+      await waitFor(() => manager.userId.value === USER_ID);
+      expect(manager.profile.value).toBeNull();
+
+      manager.updateProfile({ name: "Updated" });
+
+      expect(recordDataMock).not.toHaveBeenCalled();
+      expect(warnSpy).toHaveBeenCalledWith(
+        "Cannot update profile: profile has not loaded yet"
       );
     });
 

--- a/test/unit/seed-bible/managers/LoginManager.test.ts
+++ b/test/unit/seed-bible/managers/LoginManager.test.ts
@@ -685,6 +685,32 @@ describe("createLoginManager", () => {
 
       expect(manager.profile.value?.pictureUrl).toBeUndefined();
     });
+
+    it("throws (and skips the file upload) when the profile never loads", async () => {
+      // The profile load fails transiently, so profile.value stays null.
+      // updateProfile would refuse to persist the URL, so uploading first would
+      // report a false success and burn a real file upload. Fail loudly, and
+      // before recordFile is ever called.
+      getDataMock.mockResolvedValue({
+        success: false,
+        errorCode: "server_error",
+        errorMessage: "boom",
+      });
+      recordFileMock.mockResolvedValue({
+        success: true,
+        url: "https://example.com/avatar.png",
+      });
+
+      const manager = createAuthenticatedManager();
+      await waitFor(() => manager.userId.value === USER_ID);
+
+      await expect(manager.uploadProfilePicture(makeFile())).rejects.toThrow(
+        "profile has not loaded"
+      );
+
+      expect(recordFileMock).not.toHaveBeenCalled();
+      expect(manager.profile.value).toBeNull();
+    });
   });
 });
 

--- a/test/unit/seed-bible/managers/LoginManager.test.ts
+++ b/test/unit/seed-bible/managers/LoginManager.test.ts
@@ -325,6 +325,39 @@ describe("createLoginManager", () => {
       }
     });
 
+    it("drops the previous account's profile when switching accounts and the new load fails", async () => {
+      // Switch userId A -> B directly (without logging out, which would clear
+      // the profile). If B's profile load then fails transiently, A's profile
+      // must NOT linger under B — otherwise a later write would merge A's data
+      // into B's record.
+      getDataMock.mockResolvedValue({
+        success: true,
+        data: { name: "Alice", location: "Earth" },
+      });
+
+      const manager = createAuthenticatedManager();
+      await waitFor(() => manager.profile.value?.name === "Alice");
+
+      getDataMock.mockResolvedValue({
+        success: false,
+        errorCode: "not_authorized",
+        errorMessage: "stale key",
+      });
+
+      // Swap the session key to a different account's key. userId is derived
+      // from it, so this moves A -> B without passing through a logged-out null.
+      os.sessionKey.value = formatV1SessionKey(
+        "user-2",
+        "session-2",
+        "secret-2",
+        Date.now() + 1000 * 60 * 60 * 24 * 14
+      );
+      await waitFor(() => manager.userId.value === "user-2");
+      await flush();
+
+      expect(manager.profile.value).toBeNull();
+    });
+
     it("returns a blank default only when the profile genuinely does not exist", async () => {
       getDataMock.mockResolvedValue({
         success: false,

--- a/test/unit/seed-bible/managers/LoginManager.test.ts
+++ b/test/unit/seed-bible/managers/LoginManager.test.ts
@@ -287,29 +287,42 @@ describe("createLoginManager", () => {
     });
 
     it("does not overwrite an already-loaded profile when a later reload fails", async () => {
-      getDataMock.mockResolvedValueOnce({
-        success: true,
-        data: { name: "Alice", location: "Earth" },
-      });
+      // posthog being present makes the profile-loading effect depend on
+      // userInfo, which is exactly how a session refresh re-triggers a profile
+      // reload in production. We drive that same path here.
+      const posthogStub = { identify: vi.fn(), setPersonProperties: vi.fn() };
+      (globalThis as any).posthog = posthogStub;
 
-      const manager = createAuthenticatedManager();
-      await waitFor(() => manager.profile.value?.name === "Alice");
+      try {
+        getDataMock.mockResolvedValue({
+          success: true,
+          data: { name: "Alice", location: "Earth" },
+        });
 
-      // A subsequent reload (e.g. triggered by a session refresh) fails. The
-      // good profile must survive so writes don't merge into a blank.
-      getDataMock.mockResolvedValue({
-        success: false,
-        errorCode: "not_authorized",
-        errorMessage: "stale key",
-      });
+        const manager = createAuthenticatedManager();
+        await waitFor(() => manager.profile.value?.name === "Alice");
 
-      await manager.getUserProfile(USER_ID).catch(() => undefined);
-      await flush();
+        // A subsequent reload (e.g. triggered by a session refresh updating
+        // userInfo) fails. The good profile must survive so writes don't merge
+        // into a blank.
+        getDataMock.mockResolvedValue({
+          success: false,
+          errorCode: "not_authorized",
+          errorMessage: "stale key",
+        });
 
-      expect(manager.profile.value).toEqual({
-        name: "Alice",
-        location: "Earth",
-      });
+        // Bump userInfo to a new reference to re-run the loading effect, the
+        // same way a session refresh does.
+        manager.userInfo.value = { id: USER_ID, email: EMAIL };
+        await flush();
+
+        expect(manager.profile.value).toEqual({
+          name: "Alice",
+          location: "Earth",
+        });
+      } finally {
+        delete (globalThis as any).posthog;
+      }
     });
 
     it("returns a blank default only when the profile genuinely does not exist", async () => {


### PR DESCRIPTION
## Summary

Fixes intermittent profile data wipes (reported on mobile). A transient failure reading the profile record was being treated the same as "no profile exists," which let the next config write overwrite the real stored profile with a blank.

## The bug

Every records call — the profile **read** (`getData`) and **write** (`recordData`) — is a `POST` to `…/api/v3/callProcedure`. When the server returned a structured error for the *read* (`server_error` or `not_authorized` — plausible on flaky mobile links, or during a session-refresh/token race), the wipe chain was:

1. `getUserProfile` collapsed **any** failure to a blank `{ name: "" }` — it only distinguished `data_not_found`.
2. The profile-loading effect stored that blank in `profile.value` (an in-memory wipe).
3. The existing `saveProfileConfigValue` guard checks `if (!profile.value)`, but `{ name: "" }` is *truthy*, so it passed.
4. The next auto-save — theme, font size, a tutorial-seen flag, an extension install, etc. — merged its key into the blank base and persisted it, **permanently overwriting the stored name, location, picture, and every other config key.**

This was intermittent and hard to reproduce because it needs a *server-returned* read error at load time followed by any successful write. A plain dropped connection makes `fetch` throw, which was already handled and did **not** trigger the wipe.

## Changes

- **`getUserProfile`** returns a blank default only for `data_not_found` (a genuinely new account). All other failures throw, so a transient read error can no longer masquerade as an empty profile. A malformed stored record is likewise treated as a load failure. (`SessionsManager` already wraps this call in try/catch.)
- **Profile-loading effect** keeps the existing in-memory profile when a reload fails instead of clobbering it, ignores a stale load that resolves after an account switch, and has a passive rejection handler so an unawaited failed load doesn't surface as an unhandled rejection.
- **`updateProfile`** refuses to write while the profile hasn't loaded, rather than merging into a bare `{ name: "" }` base.
- **`profilePromise`** is exposed via a getter so external readers (the `saveProfileConfigValue` wait guard) see the promise assigned by the effect, instead of the `null` captured at construction time (which silently defeated the guard for fresh logins).

Local (logged-out) settings persistence is unaffected — the local `configBot.tags` writes and the `profile ?? local ?? default` read precedence are unchanged.

## Testing

- Added regression tests covering transient-failure handling, the reload-doesn't-clobber path (driven through the effect the way a session refresh does in production), and the `updateProfile` loading guard. Verified these fail against the pre-fix source and pass with the fix.
- Full suite green (2524 tests), `pnpm check:ts` clean.

### Reproduce it yourself

The wipe needs the *server* to return an error for the profile read (a dropped connection won't do it — that throws and is handled). This forces exactly one profile read to fail, no rebuild required:

1. Log into an account and populate the profile so a wipe is obvious: set a display name, upload a picture, change a couple of settings (theme + font size). Note the values.
2. **Log out.**
3. Open DevTools → Console and paste:

    ```js
    // Fail ONLY the first profile read with a server-style error, then behave normally.
    const _origFetch = window.fetch;
    let _failedProfileOnce = false;
    window.fetch = async (input, init) => {
      try {
        if (!_failedProfileOnce && typeof init?.body === "string") {
          const b = JSON.parse(init.body);
          if (b.procedure === "getData" && b.input?.address === "profile") {
            _failedProfileOnce = true;
            console.warn("[repro] Forcing profile read to fail (server_error)");
            return new Response(
              JSON.stringify({ success: false, errorCode: "server_error", errorMessage: "forced repro" }),
              { status: 200, headers: { "Content-Type": "application/json" } }
            );
          }
        }
      } catch {}
      return _origFetch(input, init);
    };
    console.log("[repro] fetch patch installed — now log in");
    ```

4. **Log in** (email code). The app loads your profile — the patch fails that read once.
5. **Change one setting** (font size or theme).
6. **Reload the page** (clears the patch, shows what's actually stored).

**Pre-fix:** name and picture are gone, settings reset. In the Network tab, the `callProcedure` POST with `"procedure":"recordData"` after step 5 has body `"data":{"name":"","config":{…}}` — that blank `name` overwriting the record is the wipe.

**With this fix:** name, picture, and settings are all intact. Console shows `Failed to load user profile; keeping existing profile` and `Cannot save profile config value: profile has not loaded yet`, and no `recordData` write goes out for that setting change. (Expected nuance: the setting changed during the failed-load window won't sync to the cloud until the next successful profile load — it stays in the local cache. That's the intended trade-off: don't write until the base profile is trustworthy.)

The bug is logic-level, not platform-specific, so desktop is enough to prove it. To confirm on a phone, use remote debugging (`chrome://inspect`) and paste the same snippet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)