### PR TITLE
fix: use reader background for detached pane body

### DIFF
--- a/packages/seed-bible/seed-bible/app/main.css
+++ b/packages/seed-bible/seed-bible/app/main.css
@@ -642,7 +642,7 @@ a:visited {
   flex: 1;
   overflow: auto;
 
-  background: var(--sb-detached-pane-body-background);
+  background: var(--sb-reader-background);
   color: var(--sb-detached-pane-body-font-color);
 }
 


### PR DESCRIPTION
The floating detached pane body used its own
--sb-detached-pane-body-background variable, which did not follow the active theme. Use --sb-reader-background so the pane matches the reader surface in both light and dark modes.

fixes #1340 