### PR TITLE
fix: keep detached floating panes within the viewport when dragged

### DIFF
--- a/packages/seed-bible/seed-bible/components/PaneLayout.tsx
+++ b/packages/seed-bible/seed-bible/components/PaneLayout.tsx
@@ -973,6 +973,24 @@ export function PaneLayout(props: PaneLayoutProps) {
         startX: number;
         startY: number;
         anchor?: DetachedPaneAnchor;
+        /**
+         * Geometry captured at drag start, used to clamp a floating pane
+         * within the viewport against its *actual* rendered box. This keeps the
+         * math correct regardless of the UI `zoom` or the shell's positioned
+         * ancestor:
+         * - grabOffset: pointer position relative to the pane's top-left (px)
+         * - paneWidthPx/paneHeightPx: rendered footprint in real viewport px
+         * - originX/originY, scaleX/scaleY: the linear map from the pane's CSS
+         *   coordinate (left/top) to real viewport px, sampled from the element.
+         */
+        grabOffsetX?: number;
+        grabOffsetY?: number;
+        paneWidthPx?: number;
+        paneHeightPx?: number;
+        originX?: number;
+        originY?: number;
+        scaleX?: number;
+        scaleY?: number;
       }
     | {
         type: "attached-resize";
@@ -1193,7 +1211,35 @@ export function PaneLayout(props: PaneLayoutProps) {
           : event.clientY - dragState.startY;
 
       if (dragState.mode === "move") {
-        panesManager.movePane(dragState.paneId, deltaX, deltaY);
+        // Desired top-left of the pane in real viewport px, from the pointer
+        // and the offset where it grabbed the toolbar.
+        const grabOffsetX = dragState.grabOffsetX ?? 0;
+        const grabOffsetY = dragState.grabOffsetY ?? 0;
+        const paneWidthPx = dragState.paneWidthPx ?? 0;
+        const paneHeightPx = dragState.paneHeightPx ?? 0;
+        const scaleX = dragState.scaleX || 1;
+        const scaleY = dragState.scaleY || 1;
+        const originX = dragState.originX ?? 0;
+        const originY = dragState.originY ?? 0;
+
+        // Clamp so the whole pane — including its toolbar — stays on-screen.
+        const maxLeft = Math.max(0, window.innerWidth - paneWidthPx);
+        const maxTop = Math.max(0, window.innerHeight - paneHeightPx);
+        const viewportLeft = Math.min(
+          Math.max(0, event.clientX - grabOffsetX),
+          maxLeft
+        );
+        const viewportTop = Math.min(
+          Math.max(0, event.clientY - grabOffsetY),
+          maxTop
+        );
+
+        // Map the clamped viewport position back to the pane's CSS left/top.
+        panesManager.setPanePosition(
+          dragState.paneId,
+          (viewportLeft - originX) / scaleX,
+          (viewportTop - originY) / scaleY
+        );
       } else {
         panesManager.resizePane(dragState.paneId, deltaX, deltaY);
       }
@@ -1520,12 +1566,32 @@ export function PaneLayout(props: PaneLayoutProps) {
                 }
                 event.stopPropagation();
                 app.selectPane(pane.id);
+
+                // Sample the pane's actual rendered geometry so the drag can be
+                // clamped in real viewport pixels. `rect` already reflects the
+                // UI zoom and the shell's positioned ancestor; deriving the
+                // scale/origin from it lets us map back to the pane's CSS
+                // left/top exactly.
+                const element = paneElementMapRef.current.get(pane.id);
+                const rect = element?.getBoundingClientRect();
+                const scaleX = rect && pane.width ? rect.width / pane.width : 1;
+                const scaleY =
+                  rect && pane.height ? rect.height / pane.height : 1;
+
                 dragStateRef.current = {
                   type: "detached",
                   mode: "move",
                   paneId: pane.id,
                   startX: event.clientX,
                   startY: event.clientY,
+                  grabOffsetX: rect ? event.clientX - rect.left : 0,
+                  grabOffsetY: rect ? event.clientY - rect.top : 0,
+                  paneWidthPx: rect?.width ?? pane.width,
+                  paneHeightPx: rect?.height ?? pane.height,
+                  scaleX,
+                  scaleY,
+                  originX: rect ? rect.left - pane.x * scaleX : 0,
+                  originY: rect ? rect.top - pane.y * scaleY : 0,
                 };
               }}
             >

--- a/packages/seed-bible/seed-bible/managers/PanesManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/PanesManager.tsx
@@ -385,8 +385,8 @@ export interface PanesManager {
    */
   setDetachedAnchor: (paneId: string, anchor: DetachedPaneAnchor) => boolean;
 
-  /** Moves a floating detached pane by delta values. */
-  movePane: (paneId: string, deltaX: number, deltaY: number) => void;
+  /** Sets the absolute position (CSS left/top) of a floating detached pane. */
+  setPanePosition: (paneId: string, x: number, y: number) => void;
 
   /**
    * Resizes a detached pane by delta values.
@@ -883,7 +883,14 @@ export function createPanes(
     return true;
   };
 
-  const movePane = (paneId: string, deltaX: number, deltaY: number) => {
+  /**
+   * Sets the absolute position of a floating pane (in the pane's own CSS
+   * coordinate space, i.e. the `left`/`top` values). The caller is responsible
+   * for keeping the pane on-screen — the drag handler in PaneLayout clamps
+   * against the pane's actual rendered geometry so the result is correct even
+   * with the UI `zoom` and the shell's positioned ancestor in play.
+   */
+  const setPanePosition = (paneId: string, x: number, y: number) => {
     panes.value = panes.value.map((pane) => {
       if (pane.id !== paneId) {
         return pane;
@@ -895,8 +902,8 @@ export function createPanes(
 
       return {
         ...pane,
-        x: Math.max(0, pane.x + deltaX),
-        y: Math.max(0, pane.y + deltaY),
+        x: Math.max(0, x),
+        y: Math.max(0, y),
       };
     });
   };
@@ -949,7 +956,7 @@ export function createPanes(
     closePane,
     setDetached,
     setDetachedAnchor,
-    movePane,
+    setPanePosition,
     resizePane,
   };
 }

--- a/test/unit/seed-bible/managers/PanesManager.test.ts
+++ b/test/unit/seed-bible/managers/PanesManager.test.ts
@@ -541,7 +541,7 @@ describe("createPanes", () => {
     ).toHaveLength(1);
   });
 
-  it("supports moving detached panes", async () => {
+  it("supports positioning detached panes", async () => {
     const { panesManager } = await createManagers();
 
     panesManager.openPane({
@@ -552,13 +552,33 @@ describe("createPanes", () => {
       (pane) => pane.component?.() === "Detached Component"
     )!;
 
-    panesManager.movePane(detachedPane.id, 10, 20);
+    panesManager.setPanePosition(detachedPane.id, 120, 240);
 
     const movedPane = panesManager.panes.value.find(
       (pane) => pane.id === detachedPane.id
     );
-    expect(movedPane?.x).toBe(detachedPane.x + 10);
-    expect(movedPane?.y).toBe(detachedPane.y + 20);
+    expect(movedPane?.x).toBe(120);
+    expect(movedPane?.y).toBe(240);
+  });
+
+  it("never positions a detached pane above/left of the origin", async () => {
+    const { panesManager } = await createManagers();
+
+    panesManager.openPane({
+      type: "detached",
+      component: () => "Detached Component",
+    });
+    const detachedPane = panesManager.panes.value.find(
+      (pane) => pane.component?.() === "Detached Component"
+    )!;
+
+    panesManager.setPanePosition(detachedPane.id, -500, -500);
+
+    const movedPane = panesManager.panes.value.find(
+      (pane) => pane.id === detachedPane.id
+    )!;
+    expect(movedPane.x).toBe(0);
+    expect(movedPane.y).toBe(0);
   });
 
   it("supports resizing detached panes", async () => {


### PR DESCRIPTION
Dragging a floating pane to the bottom/right edge or corner slid its toolbar (the only drag handle) off-screen, leaving the pane un-interactable.

Clamp the drag against the pane's actual rendered geometry (getBoundingClientRect) so the result is correct despite the UI zoom and the shell's positioned ancestor. Replaces the delta-based movePane with an absolute setPanePosition, and positions the pane directly from the pointer so it tracks the cursor exactly at any zoom level.


fixes #1339 