### PR TITLE
fix: stop spamming redundant profile writes on app load (#1357)

### DIFF
--- a/packages/seed-bible/seed-bible/managers/ConfigManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ConfigManager.tsx
@@ -171,6 +171,12 @@ export function createConfig(
 
   const config = signal<AppConfig>(readConfig());
 
+  // Set while `syncConfigFromBot` is applying a language it just read from the
+  // profile, so the `languageChanged` listener below doesn't mistake that
+  // profile-to-i18n sync for a user-driven change and write the same value
+  // straight back to the profile it came from.
+  let isApplyingProfileLanguage = false;
+
   const syncConfigFromBot = (
     profile: UserProfile | null = login.profile.value
   ) => {
@@ -184,7 +190,10 @@ export function createConfig(
         : url.searchParams.get("lang");
 
     if (nextLanguage && nextLanguage !== i18n.language) {
-      i18n.changeLanguage(nextLanguage);
+      isApplyingProfileLanguage = true;
+      void i18n.changeLanguage(nextLanguage).finally(() => {
+        isApplyingProfileLanguage = false;
+      });
     }
   };
 
@@ -214,6 +223,9 @@ export function createConfig(
   };
 
   i18n.on("languageChanged", (language: string) => {
+    if (isApplyingProfileLanguage) {
+      return;
+    }
     console.log("languageChanged event received from i18n:", language);
     saveProfileConfigValue(login, "lang", language);
   });

--- a/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
@@ -427,6 +427,26 @@ export function createExtensionManager(
   const INSTALLED_EXTENSIONS_CONFIG_KEY = "installedExtensions";
 
   /**
+   * Waits for an in-flight profile load to settle, if the user is logged in
+   * and the profile hasn't resolved yet. Without this, a read of
+   * `login.profile.value` taken while the profile is still loading sees an
+   * empty profile, and any merge computed from it (e.g. the installed
+   * extensions list) then overwrites the real, not-yet-arrived profile data
+   * once the pending write actually lands. Resolves synchronously (no
+   * microtask hop) when the profile has already loaded or there's nothing to
+   * wait for, so callers that don't need to wait aren't forced through an
+   * extra async tick.
+   */
+  const awaitProfileLoaded = (): Promise<void> | void => {
+    if (login.userId.value && !login.profile.value && login.profilePromise) {
+      return login.profilePromise.then(
+        () => undefined,
+        () => undefined
+      );
+    }
+  };
+
+  /**
    * Reads the set of installed extension IDs from the logged-in user's profile
    * config. Returns an empty set when logged out, the profile hasn't loaded yet,
    * or the stored value isn't a string array.
@@ -452,32 +472,57 @@ export function createExtensionManager(
   };
 
   /** Records that the extension with the given ID has been installed. */
-  const persistInstalledExtensionId = (id: string) => {
+  const persistInstalledExtensionId = (id: string): void | Promise<void> => {
     const ids = readPersistedExtensionIds();
     if (!ids.has(id)) {
       ids.add(id);
       writePersistedExtensionIds(ids);
     }
+
     // Mirror the install into the user's profile config so it follows them
     // across devices. Reads the profile set independently of local storage in
     // case the two have diverged.
-    const profileIds = readProfileExtensionIds();
-    if (!profileIds.has(id)) {
-      profileIds.add(id);
-      writeProfileExtensionIds(profileIds);
+    const mirrorToProfile = () => {
+      const profileIds = readProfileExtensionIds();
+      if (!profileIds.has(id)) {
+        profileIds.add(id);
+        writeProfileExtensionIds(profileIds);
+      }
+    };
+
+    // Wait for the profile load first when it's still in flight, so this
+    // doesn't compute against an empty profile and clobber the real list.
+    // When the profile has already loaded, run synchronously — most call
+    // sites don't await this, and deferring the write through an extra
+    // microtask would make it observable a tick later than the caller.
+    const pendingLoad = awaitProfileLoaded();
+    if (!pendingLoad) {
+      mirrorToProfile();
+      return;
     }
+    return pendingLoad.then(mirrorToProfile);
   };
 
   /** Removes the extension with the given ID from the persisted set. */
-  const forgetInstalledExtensionId = (id: string) => {
+  const forgetInstalledExtensionId = (id: string): void | Promise<void> => {
     const ids = readPersistedExtensionIds();
     if (ids.delete(id)) {
       writePersistedExtensionIds(ids);
     }
-    const profileIds = readProfileExtensionIds();
-    if (profileIds.delete(id)) {
-      writeProfileExtensionIds(profileIds);
+
+    const forgetFromProfile = () => {
+      const profileIds = readProfileExtensionIds();
+      if (profileIds.delete(id)) {
+        writeProfileExtensionIds(profileIds);
+      }
+    };
+
+    const pendingLoad = awaitProfileLoaded();
+    if (!pendingLoad) {
+      forgetFromProfile();
+      return;
     }
+    return pendingLoad.then(forgetFromProfile);
   };
 
   const computeExtensions = (): ExtensionListEntry[] => {
@@ -685,7 +730,7 @@ export function createExtensionManager(
     try {
       const result = await installationPromise;
       if (result) {
-        persistInstalledExtensionId(extensionId);
+        await persistInstalledExtensionId(extensionId);
       }
       return result;
     } finally {
@@ -736,6 +781,7 @@ export function createExtensionManager(
    * but skipped for now.
    */
   const loadSavedExtensions = async () => {
+    await awaitProfileLoaded();
     const localIds = readPersistedExtensionIds();
     const profileIds = readProfileExtensionIds();
     const savedIds = new Set([...localIds, ...profileIds]);
@@ -797,7 +843,7 @@ export function createExtensionManager(
   const unloadExtension = (id: string) => {
     unregisterExtension(id);
     installedExtensionIds.delete(id);
-    forgetInstalledExtensionId(id);
+    void forgetInstalledExtensionId(id);
     refreshExtensionsSignal();
   };
 

--- a/test/unit/seed-bible/managers/ExtensionManager.test.ts
+++ b/test/unit/seed-bible/managers/ExtensionManager.test.ts
@@ -27,6 +27,7 @@ import type { Mock } from "vitest";
 function createTestLogin(initial?: {
   userId?: string | null;
   profile?: UserProfile | null;
+  profilePromise?: Promise<UserProfile> | null;
 }): LoginManager {
   const userId = signal<string | null>(initial?.userId ?? null);
   const profile = signal<UserProfile | null>(initial?.profile ?? null);
@@ -36,7 +37,12 @@ function createTestLogin(initial?: {
       ...newData,
     } as UserProfile;
   };
-  return { userId, profile, updateProfile } as unknown as LoginManager;
+  return {
+    userId,
+    profile,
+    updateProfile,
+    profilePromise: initial?.profilePromise ?? null,
+  } as unknown as LoginManager;
 }
 
 describe("ExtensionInitalizer", () => {
@@ -1208,6 +1214,26 @@ describe("createExtensionManager", () => {
     }
   });
 
+  /**
+   * Builds an `import()`-style extension module whose resolution is
+   * controlled by the caller via `resolve()`, instead of resolving as soon
+   * as it's awaited. Useful for deterministically interleaving an
+   * extension's install with other async work in a test.
+   */
+  function createDeferredExtensionModule(): {
+    promise: Promise<unknown>;
+    resolve: () => void;
+  } {
+    let resolvePromise: (value: unknown) => void = () => undefined;
+    const promise = new Promise<unknown>((resolve) => {
+      resolvePromise = resolve;
+    });
+    return {
+      promise,
+      resolve: () => resolvePromise({ default: vi.fn() }),
+    };
+  }
+
   /** Reads the installed-extension IDs persisted to a login's profile config. */
   function getProfileInstalled(l: LoginManager): unknown {
     const config = l.profile.value?.config as
@@ -1414,5 +1440,93 @@ describe("createExtensionManager", () => {
     expect(login.profile.value?.name).toBe("Real Name");
     expect(login.profile.value?.location).toBe("Real Location");
     expect(getProfileInstalled(login)).toEqual(["ext.race"]);
+  });
+
+  it("does not spam-overwrite the profile when multiple extensions load while the profile fetch is still in flight (regression for #1357)", async () => {
+    let resolveProfile: (profile: UserProfile) => void = () => undefined;
+    const profilePromise = new Promise<UserProfile>((resolve) => {
+      resolveProfile = resolve;
+    });
+
+    // Simulates a returning, already-authenticated user whose session is
+    // restored synchronously but whose profile fetch (`login.profilePromise`)
+    // is still pending when extension loading kicks off at boot.
+    login = createTestLogin({
+      userId: "user-1",
+      profile: null,
+      profilePromise,
+    });
+
+    const manager = createExtensionManager(login);
+
+    // Use `import`-based (not `url`-based) extensions, each backed by a
+    // deferred promise, so each one's install resolves under direct,
+    // synchronous test control instead of racing real
+    // dynamic-import/module-mock timing.
+    const moduleA = createDeferredExtensionModule();
+    const moduleB = createDeferredExtensionModule();
+    const extensionA = {
+      import: () => moduleA.promise,
+      meta: {
+        id: "ext.spam-a",
+        translations: {
+          en: { title: "Spam A", description: "Spam A extension" },
+        },
+      },
+    };
+    const extensionB = {
+      import: () => moduleB.promise,
+      meta: {
+        id: "ext.spam-b",
+        translations: {
+          en: { title: "Spam B", description: "Spam B extension" },
+        },
+      },
+    };
+
+    const updateProfileSpy = vi.spyOn(login, "updateProfile");
+
+    const loadAPromise = manager.loadExtension(extensionA);
+    const loadBPromise = manager.loadExtension(extensionB);
+
+    // Finish extension A's install while the profile is still null — this is
+    // the exact moment the old, unguarded code would compute its profile
+    // write against an empty profile and capture a stale single-ID value.
+    moduleA.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Finish extension B's install, still before the profile resolves.
+    moduleB.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Now let the profile fetch resolve, exactly as `LoginManager` would:
+    // `profile.value` is set before/at the point awaiters of `profilePromise`
+    // resume.
+    const realProfile = { name: "Real Name" } as UserProfile;
+    login.profile.value = realProfile;
+    resolveProfile(realProfile);
+
+    await Promise.all([loadAPromise, loadBPromise]);
+    // Let each install's post-`await installationPromise` continuation
+    // (which awaits the now-resolved profile before writing) finish too.
+    await Promise.resolve();
+    await Promise.resolve();
+    await Promise.resolve();
+
+    // Both extensions should have merged into a single, complete list — not
+    // overwritten each other down to just the last one to resolve.
+    expect(getProfileInstalled(login)).toEqual(
+      expect.arrayContaining(["ext.spam-a", "ext.spam-b"])
+    );
+    expect((getProfileInstalled(login) as string[]).length).toBe(2);
+
+    // This is the actual bug report (#1357): loading the app was writing the
+    // profile repeatedly with no user action. Merging both extensions should
+    // take exactly one write, not one per extension racing the profile load.
+    expect(updateProfileSpy).toHaveBeenCalledTimes(1);
   });
 });


### PR DESCRIPTION
Loading the app kicked off extension installs before the user's profile finished its async fetch. Each extension that persisted itself into the profile's installedExtensions list read the profile while it was still null, computed a value against that empty snapshot, and only wrote once the profile arrived — so N installed extensions produced N separate, mutually-clobbering writes instead of one merged write. ExtensionManager now waits for an in-flight profile load before reading/writing the installed-extensions list, collapsing this to a single write.

ConfigManager had a related issue: syncing the profile's saved language into i18n on load could bounce back through the "languageChanged" listener and write that same value straight back to the profile it came from. That listener now ignores changes it triggered itself.

Fixes #1357 