### PR TITLE
Only bundle extension title/description translations in the core app

### DIFF
--- a/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
@@ -74,9 +74,18 @@ export interface UploadedExtension {
   url: string;
 
   /**
-   * The metadata for this extension.
+   * The metadata for this extension. `meta.translations` may be trimmed down
+   * to just `title`/`description` per locale — see `loadFullTranslations`.
    */
   meta: ExtensionMeta;
+
+  /**
+   * Loads this extension's full per-locale translations (every key, not just
+   * `title`/`description`). Optional: extensions whose `meta.translations`
+   * is already complete (e.g. fetched over the network rather than bundled)
+   * don't need it, and callers fall back to `meta.translations`.
+   */
+  loadFullTranslations?: () => Promise<ExtensionMeta["translations"]>;
 }
 
 export interface ImportExtension {
@@ -89,8 +98,19 @@ export interface ImportExtension {
    */
   import: () => Promise<unknown>;
 
-  /** The metadata for this extension. */
+  /**
+   * The metadata for this extension. `meta.translations` may be trimmed down
+   * to just `title`/`description` per locale — see `loadFullTranslations`.
+   */
   meta: ExtensionMeta;
+
+  /**
+   * Loads this extension's full per-locale translations (every key, not just
+   * `title`/`description`). Bundled extensions (see `vite-plugin-extensions.ts`)
+   * defer everything but `title`/`description` to this dynamic import, so the
+   * full translation payload is only fetched once the extension is installed.
+   */
+  loadFullTranslations?: () => Promise<ExtensionMeta["translations"]>;
 }
 
 /**
@@ -691,7 +711,10 @@ export function createExtensionManager(
         }
       }
 
-      addTranslations(uploaded.meta.id, uploaded.meta.translations);
+      const translations = uploaded.loadFullTranslations
+        ? await uploaded.loadFullTranslations()
+        : uploaded.meta.translations;
+      addTranslations(uploaded.meta.id, translations);
 
       if ("url" in uploaded && uploaded.url) {
         const installed = await loadExtensionFromUrl(extensionId, uploaded.url);

--- a/script/lib/vite-plugin-extensions.ts
+++ b/script/lib/vite-plugin-extensions.ts
@@ -1,5 +1,5 @@
 import type { Plugin, ViteDevServer } from "vite";
-import { readdir } from "node:fs/promises";
+import { readdir, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
 
@@ -11,9 +11,13 @@ import path from "node:path";
 // `extension.json` at its root (the extension's `meta`). This matches every
 // extension and excludes the main `packages/seed-bible` app, which has none.
 //
-// The module is generated as source (static `extension.json` imports for the
-// meta + `() => import(...)` thunks for the code) so Vite still bundles the meta
-// statically and code-splits each extension's entry point.
+// The module is generated as source: the `meta` for each extension is inlined
+// as a JS literal, but trimmed down to just `title`/`description` per locale —
+// the only translations needed before an extension is installed (to render it
+// in the Settings extensions list). The full per-locale translations (every
+// other UI string the extension uses) and the extension's code are each
+// exposed as `() => import(...)` thunks, so Vite code-splits both into chunks
+// that are only fetched once the extension is actually installed.
 //
 // The `\0` prefix on the resolved id is the Rollup convention that tells other
 // plugins to leave the id alone.
@@ -40,24 +44,73 @@ async function discoverExtensionFolders(): Promise<string[]> {
     .sort();
 }
 
-function generateModuleSource(folders: string[]): string {
-  const imports = folders
-    .map(
-      (folder, i) =>
-        `import meta${i} from "@packages/${folder}/extension.json";`
-    )
-    .join("\n");
+interface ExtensionTranslationFile {
+  title: string;
+  description: string;
+  [key: string]: string;
+}
+
+interface ExtensionMetaFile {
+  id: string;
+  translations: Record<string, ExtensionTranslationFile>;
+  dependencies?: string[];
+  autoinstall?: boolean;
+}
+
+async function readExtensionMeta(folder: string): Promise<ExtensionMetaFile> {
+  const raw = await readFile(extensionJsonPath(folder), "utf-8");
+  return JSON.parse(raw);
+}
+
+/**
+ * Reduces an extension's meta to just what's needed before it's installed:
+ * `title`/`description` per locale (for the Settings extensions list), plus
+ * `id`/`dependencies`/`autoinstall` (needed to resolve install order and
+ * auto-install eligibility). Every other translation key is dropped — it's
+ * only available via the extension's `loadFullTranslations()` thunk.
+ */
+function trimMeta(meta: ExtensionMetaFile): ExtensionMetaFile {
+  const translations: Record<string, ExtensionTranslationFile> = {};
+  for (const [lang, translation] of Object.entries(meta.translations)) {
+    translations[lang] = {
+      title: translation.title,
+      description: translation.description,
+    };
+  }
+
+  return {
+    id: meta.id,
+    translations,
+    ...(meta.dependencies ? { dependencies: meta.dependencies } : {}),
+    ...(meta.autoinstall !== undefined
+      ? { autoinstall: meta.autoinstall }
+      : {}),
+  };
+}
+
+// U+2028/U+2029 are valid JSON string characters but, unescaped, are illegal
+// in JS string literals in some contexts — escape them before inlining.
+function toJsLiteral(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+async function generateModuleSource(folders: string[]): Promise<string> {
+  const metas = await Promise.all(folders.map(readExtensionMeta));
 
   const entries = folders
-    .map(
-      (folder, i) =>
-        `  { meta: meta${i}, import: () => import("@packages/${folder}/index") },`
-    )
+    .map((folder, i) => {
+      const trimmed = trimMeta(metas[i]!);
+      return `  {
+    meta: ${toJsLiteral(trimmed)},
+    loadFullTranslations: () => import("@packages/${folder}/extension.json").then((m) => m.default.translations),
+    import: () => import("@packages/${folder}/index"),
+  },`;
+    })
     .join("\n");
 
-  return `${imports}
-
-const extensions = [
+  return `const extensions = [
 ${entries}
 ];
 
@@ -93,7 +146,7 @@ export function extensionsPlugin(): Plugin {
         this.addWatchFile(extensionJsonPath(folder));
       }
 
-      return generateModuleSource(folders);
+      return await generateModuleSource(folders);
     },
 
     configureServer(server: ViteDevServer) {

--- a/test/unit/seed-bible/managers/ExtensionManager.test.ts
+++ b/test/unit/seed-bible/managers/ExtensionManager.test.ts
@@ -604,6 +604,46 @@ describe("createExtensionManager", () => {
     );
   });
 
+  it("loadExtension() adds the extension's full translations from loadFullTranslations(), not the (trimmed) meta.translations", async () => {
+    const manager = createExtensionManager(login);
+    mockExtensionModule("pkg://full-translations");
+
+    const trimmedTranslations = {
+      en: {
+        title: "Full Translations",
+        description: "Full Translations extension",
+      },
+    };
+    const fullTranslations = {
+      en: {
+        title: "Full Translations",
+        description: "Full Translations extension",
+        "extra-key": "Extra string",
+      },
+    };
+    const loadFullTranslations = vi.fn().mockResolvedValue(fullTranslations);
+
+    const loaded = await manager.loadExtension({
+      url: "pkg://full-translations",
+      meta: {
+        id: "ext.full-translations",
+        translations: trimmedTranslations,
+      },
+      loadFullTranslations,
+    });
+
+    expect(loaded).toBe(true);
+    expect(loadFullTranslations).toHaveBeenCalledTimes(1);
+    expect(addTranslationsMock).toHaveBeenCalledWith(
+      "ext.full-translations",
+      fullTranslations
+    );
+    expect(addTranslationsMock).not.toHaveBeenCalledWith(
+      "ext.full-translations",
+      trimmedTranslations
+    );
+  });
+
   it("loadDefaultExtensions() auto-installs extensions when the matching query param is true", async () => {
     const defaultExtensions = {
       id: "set.autoinstall",


### PR DESCRIPTION
Extension packages under packages/*-extension/ ship one translations
blob per locale containing title/description plus every other UI
string the extension uses. All of it was statically imported into the
virtual:@extensions module and baked into the main app bundle, even
for extensions no one installs (some extension.json files are 100-260
KB).

The vite-plugin-extensions generator now reads each extension.json
itself and inlines a trimmed meta (title/description per locale only,
still enough for the Settings extensions list) instead of statically
importing the file. The full translations are exposed via a
loadFullTranslations() thunk that dynamically imports the same file,
so Rollup code-splits it into a chunk that's only fetched when
ExtensionManager.loadExtension() actually installs the extension.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_014Hyzjw2Jdr4kaBEg9n2Sv9

Fixes #1366