### PR TITLE
Auto-open Today screen on boot when there's no deep link

### DIFF
--- a/packages/seed-bible/seed-bible/managers/NavigationManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/NavigationManager.tsx
@@ -40,6 +40,15 @@ export function createNavigationManager(
       : "http://localhost/");
   const currentUrl = signal<URL>(new URL(initialHref));
 
+  // A frozen snapshot of the URL exactly as the page was first loaded, before
+  // any in-app navigation — including the reader's own book/chapter -> URL
+  // echo (see TabsManager) — has a chance to mutate `currentUrl`. Extensions
+  // load asynchronously, well after that echo has already run, so anything
+  // that needs to tell "the user linked here on purpose" apart from "the
+  // reader wrote its default position into the URL" must check this instead
+  // of the live `currentUrl`.
+  const initialUrl = new URL(initialHref);
+
   const basePath = options.basePath ?? "";
 
   // Keep root-absolute navigations inside the deployment's path prefix.
@@ -229,6 +238,7 @@ export function createNavigationManager(
 
   return {
     currentUrl: computed(() => currentUrl.value),
+    initialUrl,
     go,
     replace,
     push,

--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -515,6 +515,8 @@ export function createSeedBibleState(
     onboarding,
     selector,
     isMobile,
+    panes,
+    sidebar,
     joinedViaSessionLink
   );
 

--- a/packages/seed-bible/seed-bible/managers/TutorialManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/TutorialManager.tsx
@@ -2,10 +2,14 @@ import { computed, effect, signal, type ReadonlySignal } from "@preact/signals";
 import type { LoginManager } from "../managers/LoginManager";
 import type { OnboardingManager } from "../managers/OnboardingManager";
 import type { BibleSelectorState } from "../managers/BibleSelectorManager";
+import type { PanesManager } from "../managers/PanesManager";
+import { createSidebar } from "../managers/SidebarManager";
 import {
   getProfileConfigValue,
   saveProfileConfigValue,
 } from "../managers/ProfileConfigSync";
+
+type SidebarManager = ReturnType<typeof createSidebar>;
 
 const TUTORIAL_SEEN_KEY = "sb-tutorial-seen";
 const TUTORIAL_OPTED_OUT_KEY = "sb-tutorial-opted-out";
@@ -346,6 +350,8 @@ export function createTutorialManager(
   onboarding: OnboardingManager,
   selector: BibleSelectorState,
   isMobile: ReadonlySignal<boolean>,
+  panes: PanesManager,
+  sidebar: SidebarManager,
   joinedViaSessionLink = false
 ): TutorialManager {
   const running = signal<boolean>(false);
@@ -518,6 +524,17 @@ export function createTutorialManager(
   };
 
   const start = () => {
+    // Close whatever overlapping UI is up first — coach marks target the
+    // normal reader UI, so a fullscreen pane (e.g. the Today screen) or an
+    // open sidebar panel left up would hide the very elements being
+    // highlighted. Mirrors the teardown `BibleReaderToolbar` does before
+    // showing reader UI over the Today screen.
+    sidebar.closeSearchPanel();
+    sidebar.closeChatPanel();
+    sidebar.closeSettings();
+    sidebar.closeSidebar();
+    panes.closeAll();
+
     // Pick the step set for the current viewport before showing the tour.
     mode.value = isMobile.value ? "onboarding-mobile" : "onboarding-desktop";
     activeSteps.value = isMobile.value

--- a/packages/today-screen/infrastructure/di/bootstrap.tsx
+++ b/packages/today-screen/infrastructure/di/bootstrap.tsx
@@ -362,8 +362,22 @@ export const bootstrapExtension = () => {
         });
       };
 
+      // Today opens automatically on a cold load (no explicit `?today=`
+      // param) as long as the URL isn't already pointing somewhere specific —
+      // a book/chapter/verse deep link, or a shared-session invite
+      // (`?sessionId=`). An explicit `?today=` param always wins either way,
+      // matching the deep-linkable modals in SeedBibleStateManager.
+      const initialUrlParams = context.navigation.currentUrl.value.searchParams;
+      const hasCompetingDeepLink =
+        initialUrlParams.has("book") ||
+        initialUrlParams.has("chapter") ||
+        initialUrlParams.has("verse") ||
+        initialUrlParams.has("sessionId");
+      const requestedToday = initialUrlParams.get("today");
       const isTodayOpen = signal(
-        context.navigation.currentUrl.value.searchParams.get("today") === "open"
+        requestedToday !== null
+          ? requestedToday === "open"
+          : !hasCompetingDeepLink
       );
 
       const cleanupTodayUrlSync = context.navigation.syncSignalsToUrl({

--- a/packages/today-screen/infrastructure/di/bootstrap.tsx
+++ b/packages/today-screen/infrastructure/di/bootstrap.tsx
@@ -367,7 +367,15 @@ export const bootstrapExtension = () => {
       // a book/chapter/verse deep link, or a shared-session invite
       // (`?sessionId=`). An explicit `?today=` param always wins either way,
       // matching the deep-linkable modals in SeedBibleStateManager.
-      const initialUrlParams = context.navigation.currentUrl.value.searchParams;
+      //
+      // This must read `initialUrl` (the URL as first loaded), not the live
+      // `currentUrl`: TabsManager echoes the reader's current book/chapter
+      // back into the URL as soon as it initializes (so links are always
+      // shareable), which happens well before extensions finish loading. By
+      // the time this code runs, a cold load with no book/chapter param would
+      // already show `?book=GEN&chapter=1` in the live URL — indistinguishable
+      // from a real deep link unless we look at the URL from before that echo.
+      const initialUrlParams = context.navigation.initialUrl.searchParams;
       const hasCompetingDeepLink =
         initialUrlParams.has("book") ||
         initialUrlParams.has("chapter") ||

--- a/test/unit/seed-bible/i18n/I18nManager.test.ts
+++ b/test/unit/seed-bible/i18n/I18nManager.test.ts
@@ -45,6 +45,7 @@ describe("I18nManager getInitialLanguage()", () => {
     currentUrl = signal(new URL("https://example.com/"));
     nav = {
       currentUrl,
+      initialUrl: currentUrl.peek(),
       syncSignalsToUrl: vi.fn(),
       go: vi.fn(),
       replace: vi.fn(),
@@ -143,6 +144,7 @@ describe("I18nManager language fallback prompt", () => {
     currentUrl = signal(new URL("https://example.com/"));
     nav = {
       currentUrl,
+      initialUrl: currentUrl.peek(),
       syncSignalsToUrl: vi.fn(),
       go: vi.fn(),
       replace: vi.fn(),

--- a/test/unit/seed-bible/managers/TutorialManager.test.tsx
+++ b/test/unit/seed-bible/managers/TutorialManager.test.tsx
@@ -4,6 +4,10 @@ import { createTutorialManager } from "@packages/seed-bible/seed-bible/managers/
 import type { LoginManager } from "@packages/seed-bible/seed-bible/managers/LoginManager";
 import type { OnboardingManager } from "@packages/seed-bible/seed-bible/managers/OnboardingManager";
 import type { BibleSelectorState } from "@packages/seed-bible/seed-bible/managers/BibleSelectorManager";
+import type { PanesManager } from "@packages/seed-bible/seed-bible/managers/PanesManager";
+import { createSidebar as createRealSidebar } from "@packages/seed-bible/seed-bible/managers/SidebarManager";
+
+type SidebarManager = ReturnType<typeof createRealSidebar>;
 
 function createLogin(): LoginManager {
   return {
@@ -29,6 +33,22 @@ function createSelector(): BibleSelectorState {
   } as unknown as BibleSelectorState;
 }
 
+function createPanes(): PanesManager {
+  return {
+    panes: signal([]),
+    closeAll: vi.fn(),
+  } as unknown as PanesManager;
+}
+
+function createSidebar(): SidebarManager {
+  return {
+    closeSearchPanel: vi.fn(),
+    closeChatPanel: vi.fn(),
+    closeSettings: vi.fn(),
+    closeSidebar: vi.fn(),
+  } as unknown as SidebarManager;
+}
+
 describe("createTutorialManager — session-link joins", () => {
   beforeEach(() => {
     // Flags persist in localStorage; start each test from a clean slate so
@@ -45,6 +65,8 @@ describe("createTutorialManager — session-link joins", () => {
       createOnboarding("done"),
       createSelector(),
       signal(false),
+      createPanes(),
+      createSidebar(),
       /* joinedViaSessionLink */ true
     );
 
@@ -59,7 +81,9 @@ describe("createTutorialManager — session-link joins", () => {
       createLogin(),
       createOnboarding("done"),
       createSelector(),
-      signal(false)
+      signal(false),
+      createPanes(),
+      createSidebar()
     );
 
     expect(tutorial.promptVisible.value).toBe(true);
@@ -75,6 +99,8 @@ describe("createTutorialManager — session-link joins", () => {
       createOnboarding("done"),
       createSelector(),
       signal(false),
+      createPanes(),
+      createSidebar(),
       /* joinedViaSessionLink */ true
     );
 
@@ -90,7 +116,9 @@ describe("createTutorialManager — session-link joins", () => {
       createLogin(),
       createOnboarding("done"),
       createSelector(),
-      signal(false)
+      signal(false),
+      createPanes(),
+      createSidebar()
     );
 
     tutorial.startContextual("search");


### PR DESCRIPTION
## Summary

Today, opening Seed Bible with no query parameters always lands you on Genesis 1. If the `today-screen` extension is installed (it's auto-installed for everyone), this PR makes it open automatically instead, as the first thing you see — but only when there's no reason to think you were sent somewhere specific. An explicit `?today=` param, or a deep link to a particular book/chapter/verse or a shared-session invite, still takes priority and Today stays closed.

## Changes

- **Today screen bootstrap** (`packages/today-screen/infrastructure/di/bootstrap.tsx`): Today's open/closed state now defaults to *open* on load when the URL has no `book`, `chapter`, `verse`, or `sessionId` param and no explicit `?today=` override. Previously it only opened when `?today=open` was already present.

- **NavigationManager**: Added `initialUrl` — a frozen snapshot of the URL exactly as the page was first requested, before any in-app navigation touches it. This was needed because `TabsManager` echoes the reader's current book/chapter back into the URL as soon as it initializes (so reading links stay shareable), which happens well before extensions finish loading. Without this, a plain boot with no params at all would already show `?book=GEN&chapter=1` in the URL by the time Today's own init code ran, making every load look like a deep link and silently defeating the auto-open. Today now reads `initialUrl` instead of the live `currentUrl` to tell "the user linked here on purpose" apart from "the reader wrote its default position into the URL."

- **Tests**: Updated `I18nManager.test.ts`'s navigation mocks to include `initialUrl`.

## Side fix: tutorial vs. Today screen overlap

While verifying this, found that accepting the "Take the tour" prompt (or replaying it from Settings) didn't close the Today screen or other open sidebar panels first, so the tour's coach marks would end up targeting reader UI hidden behind Today's fullscreen pane.

- **TutorialManager**: `createTutorialManager()` now takes `panes` and `sidebar`, and `start()` closes any open sidebar panels and fullscreen panes before beginning the tour — mirroring the same teardown `BibleReaderToolbar` already does when it opens the Today screen or Bookmarks view.
- **SeedBibleStateManager**: passes the new `panes`/`sidebar` managers through to `createTutorialManager()`.
- **Tests**: Updated `TutorialManager.test.tsx` with mock `panes`/`sidebar`.

## Test plan

- [ ] Boot with no query params → Today opens automatically instead of Genesis 1
- [ ] Load with `?book=`/`?chapter=`/`?verse=` or `?sessionId=` → Today stays closed, deep link is honored
- [ ] Load with explicit `?today=open` or `?today=` (anything else) → respected regardless of other params
- [ ] From Today, click "Take the tour" → Today closes and the tour's coach marks land on visible reader UI
- `pnpm check:ts`, `pnpm lint`, and `pnpm test` (2581 tests) all pass

https://claude.ai/code/session_0112pVCufXkm8BEwT8fpPuq6