### PR TITLE
fix: use 100dvh for app shell so mobile reader text clears the browser toolbar

### DIFF
--- a/packages/seed-bible/seed-bible/app/main.tsx
+++ b/packages/seed-bible/seed-bible/app/main.tsx
@@ -142,7 +142,7 @@ function MainContent(props: {
         }}
         style={{
           display: "flex",
-          height: "100vh",
+          height: "100dvh",
           overflow: "hidden",
         }}
       >

--- a/packages/seed-bible/seed-bible/app/styles/base.css
+++ b/packages/seed-bible/seed-bible/app/styles/base.css
@@ -390,7 +390,7 @@ a:visited {
   justify-content: center;
   align-items: center;
   width: 100vw !important;
-  height: 100vh !important;
+  height: 100dvh !important;
 }
 
 .sb-content-row {


### PR DESCRIPTION
On real mobile browsers, the last lines of the reader were hidden behind the browser toolbar. The app shell was sized with `100vh`, which on mobile means the *large* viewport (chrome hidden) — so the app ran taller than the visible screen and its bottom sat behind the toolbar.

Switched `.sb-app-root` and `.sb-main-content` to `100dvh`, which tracks the visible viewport. Matches the `100dvh` already used for the mobile sidebar. Desktop is unaffected.

Only reproduces on real devices, not dev-tools emulation.

> _Before: Genesis 1:31 if covered by the mobile toolbar_
> <img width="300" alt="image" src="https://github.com/user-attachments/assets/4d1ec4e8-5601-4243-a07c-6a23238af92c" />

> _After: Genesis 1:31 is fully visible on mobile_
> <img width="300" alt="image" src="https://github.com/user-attachments/assets/3714b655-0dbd-4025-a55f-8d22255aa603" />



Closes #1416