### PR TITLE
fix: Move the toast message so that it is not placed in front of the toolbar

### DIFF
--- a/packages/seed-bible/seed-bible/components/ToastHost/ToastHost.css
+++ b/packages/seed-bible/seed-bible/components/ToastHost/ToastHost.css
@@ -120,7 +120,7 @@
 .sb-toast-host {
   position: fixed;
   left: 50%;
-  bottom: 1.5rem;
+  bottom: 6rem;
   transform: translateX(-50%);
   z-index: 1000;
   display: flex;
@@ -131,7 +131,19 @@
 
 @keyframes sb-toast-slide-up {
   from {
-    transform: translateY(16px);
+    transform: translateY(2rem);
+    opacity: 0;
+  }
+
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
+}
+
+@keyframes sb-toast-slide-down {
+  from {
+    transform: translateY(-2rem);
     opacity: 0;
   }
 
@@ -153,4 +165,15 @@
   text-align: center;
   box-shadow: 0 10px 30px rgba(0, 0, 0, 0.5);
   animation: sb-toast-slide-up 0.25s ease-out;
+}
+
+@media (max-width: 480px) {
+  .sb-toast-host {
+    bottom: auto;
+    top: 3rem;
+  }
+
+  .sb-toast {
+    animation: sb-toast-slide-down 0.25s ease-out;
+  }
 }


### PR DESCRIPTION
- On desktop it is above the toolbar
- On mobile it is at the top of the page

### Before
<img width="792" height="107" alt="image" src="https://github.com/user-attachments/assets/f7c10e06-8da1-45aa-bc68-314716c386a5" />

### After
<img width="828" height="193" alt="image" src="https://github.com/user-attachments/assets/0ba5578c-2509-48cc-bb76-d0762b9e142c" />
