### PR TITLE
Fix language switch revert bug in ConfigManager

### DIFF
--- a/packages/seed-bible/seed-bible/i18n/I18nManager.tsx
+++ b/packages/seed-bible/seed-bible/i18n/I18nManager.tsx
@@ -187,7 +187,16 @@ export function createI18nManager(
         return null;
       },
       set value(newValue: string | null) {
-        language.value = newValue ?? defaultLanguage;
+        // Invoked when the URL's `?lang=` changes on its own — deep links and
+        // browser back/forward. Route through `i18n.changeLanguage` so the
+        // actual translations reload; the `languageChanged` listener above then
+        // moves the `language` signal to match. Assigning the signal directly
+        // here would desync `i18n.language` (and therefore every `t()` call)
+        // from the URL.
+        const next = newValue ?? defaultLanguage;
+        if (next !== i18n.language) {
+          void i18n.changeLanguage(next);
+        }
       },
     },
   });

--- a/packages/seed-bible/seed-bible/i18n/I18nManager.tsx
+++ b/packages/seed-bible/seed-bible/i18n/I18nManager.tsx
@@ -233,6 +233,21 @@ export function createI18nManager(
     ensureTranslationsLoaded = loadTranslations;
   };
 
+  /**
+   * Wired by SeedBibleState to persist the user's chosen UI language (e.g. to
+   * their profile). Invoked ONLY for selector-driven changes via
+   * `requestLanguageChange` — never for URL-driven changes (deep links,
+   * browser back/forward) or profile-applied changes, so opening a shared
+   * `?lang=` link updates the view without overwriting the account's saved
+   * language.
+   */
+  let persistLanguage: ((language: string) => void) | null = null;
+  const setLanguagePersister = (
+    persister: ((language: string) => void) | null
+  ) => {
+    persistLanguage = persister;
+  };
+
   const changeLanguage = i18n.changeLanguage.bind(i18n);
 
   const applyBibleTranslationForUiLanguage = async (uiLanguage: string) => {
@@ -267,6 +282,10 @@ export function createI18nManager(
     if (nextLanguage !== language.value) {
       await changeLanguage(nextLanguage);
     }
+    // Persist the user's explicit selection. Only selector-driven changes reach
+    // this function; URL-driven changes go through the `syncSignalsToUrl`
+    // setter above and are deliberately left un-persisted.
+    persistLanguage?.(nextLanguage);
     await applyBibleTranslationForUiLanguage(nextLanguage);
   };
 
@@ -291,6 +310,7 @@ export function createI18nManager(
     confirmLanguageFallback,
     cancelLanguageFallback,
     setBibleTranslationApplicator,
+    setLanguagePersister,
     languageFallbackPrompt,
     defaultLanguage,
     availableLanguages,

--- a/packages/seed-bible/seed-bible/managers/ConfigManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ConfigManager.tsx
@@ -171,12 +171,6 @@ export function createConfig(
 
   const config = signal<AppConfig>(readConfig());
 
-  // Set while `applyProfileLanguage` is applying a language it just read from
-  // the profile, so the `languageChanged` listener below doesn't mistake that
-  // profile-to-i18n sync for a user-driven change and write the same value
-  // straight back to the profile it came from.
-  let isApplyingProfileLanguage = false;
-
   // Re-read the URL/profile-derived config (font size, panels, preset) whenever
   // either the URL or the profile changes.
   effect(() => {
@@ -193,8 +187,8 @@ export function createConfig(
   // would fight the user's in-session language switch: picking a language
   // writes `?lang=` first, that URL write would re-run this effect, and the
   // profile's still-unsaved previous language would revert `i18n.language`
-  // (leaving only `?translation=` applied — the bug this guards against). Only
-  // read `login.profile` here so the effect subscribes to the profile alone.
+  // (leaving only `?translation=` applied). Only read `login.profile` here so
+  // the effect subscribes to the profile alone.
   effect(() => {
     const profileLanguage = getProfileConfigValue(login.profile.value, "lang");
     const nextLanguage =
@@ -203,12 +197,19 @@ export function createConfig(
         : null;
 
     if (nextLanguage && nextLanguage !== i18n.language) {
-      isApplyingProfileLanguage = true;
-      void i18n.changeLanguage(nextLanguage).finally(() => {
-        isApplyingProfileLanguage = false;
-      });
+      void i18n.changeLanguage(nextLanguage);
     }
   });
+
+  // Persist the user's chosen UI language to their profile. Wired into
+  // I18nManager's `requestLanguageChange` (the selector path) via
+  // `setLanguagePersister`, so it runs ONLY for explicit selector choices —
+  // never for URL-driven changes (a shared `?lang=` link or browser
+  // back/forward), which stay view-only, and never for the profile-to-i18n
+  // sync above (which would just write the value straight back).
+  const persistLanguage = (language: string) => {
+    void saveProfileConfigValue(login, "lang", language);
+  };
 
   const setDisablePanels = (disablePanels: boolean) => {
     const nextConfig = {
@@ -231,17 +232,10 @@ export function createConfig(
     saveProfileConfigValue(login, "fontSize", nextFontSize);
   };
 
-  i18n.on("languageChanged", (language: string) => {
-    if (isApplyingProfileLanguage) {
-      return;
-    }
-    console.log("languageChanged event received from i18n:", language);
-    saveProfileConfigValue(login, "lang", language);
-  });
-
   return {
     config,
     setDisablePanels,
     setFontSize,
+    persistLanguage,
   };
 }

--- a/packages/seed-bible/seed-bible/managers/ConfigManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ConfigManager.tsx
@@ -1,6 +1,6 @@
 import { effect, signal } from "@preact/signals";
 import i18n from "i18next";
-import type { LoginManager, UserProfile } from "../managers/LoginManager";
+import type { LoginManager } from "../managers/LoginManager";
 import {
   getProfileConfigValue,
   saveProfileConfigValue,
@@ -171,23 +171,36 @@ export function createConfig(
 
   const config = signal<AppConfig>(readConfig());
 
-  // Set while `syncConfigFromBot` is applying a language it just read from the
-  // profile, so the `languageChanged` listener below doesn't mistake that
+  // Set while `applyProfileLanguage` is applying a language it just read from
+  // the profile, so the `languageChanged` listener below doesn't mistake that
   // profile-to-i18n sync for a user-driven change and write the same value
   // straight back to the profile it came from.
   let isApplyingProfileLanguage = false;
 
-  const syncConfigFromBot = (
-    profile: UserProfile | null = login.profile.value
-  ) => {
-    const url = navigation.currentUrl.value;
+  // Re-read the URL/profile-derived config (font size, panels, preset) whenever
+  // either the URL or the profile changes.
+  effect(() => {
     config.value = readConfig();
+  });
 
-    const profileLanguage = getProfileConfigValue(profile, "lang");
+  // Apply the profile's saved UI language, but ONLY when the profile itself
+  // changes (i.e. on login / profile load) — deliberately NOT on every URL
+  // change.
+  //
+  // The `?lang=` query param is owned by I18nManager (see its
+  // `syncSignalsToUrl({ lang })`), which is the single source of truth for the
+  // URL <-> `i18n.language` relationship. If this ran on URL changes too, it
+  // would fight the user's in-session language switch: picking a language
+  // writes `?lang=` first, that URL write would re-run this effect, and the
+  // profile's still-unsaved previous language would revert `i18n.language`
+  // (leaving only `?translation=` applied — the bug this guards against). Only
+  // read `login.profile` here so the effect subscribes to the profile alone.
+  effect(() => {
+    const profileLanguage = getProfileConfigValue(login.profile.value, "lang");
     const nextLanguage =
       typeof profileLanguage === "string" && profileLanguage.trim().length > 0
         ? profileLanguage
-        : url.searchParams.get("lang");
+        : null;
 
     if (nextLanguage && nextLanguage !== i18n.language) {
       isApplyingProfileLanguage = true;
@@ -195,10 +208,6 @@ export function createConfig(
         isApplyingProfileLanguage = false;
       });
     }
-  };
-
-  effect(() => {
-    syncConfigFromBot(login.profile.value);
   });
 
   const setDisablePanels = (disablePanels: boolean) => {

--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -363,6 +363,10 @@ export function createSeedBibleState(
   const highlights = createHighlightsManager(os, login);
   const bookmarks = createBookmarksManager(os, login);
   const config = createConfig(login, navigation);
+  // Persist a user's explicit language selection to their profile. Wiring it
+  // through `requestLanguageChange` (rather than a blanket `languageChanged`
+  // listener) keeps URL-driven language changes view-only.
+  i18n.setLanguagePersister(config.persistLanguage);
   const panelsEnabled = computed(() => !config.config.value.disablePanels);
   const themeManager = createTheme(login, navigation);
   const chats = createChatsManager(login, i18n);

--- a/test/unit/seed-bible/i18n/I18nManager.test.ts
+++ b/test/unit/seed-bible/i18n/I18nManager.test.ts
@@ -5,7 +5,10 @@ import {
   type I18nManager,
 } from "@packages/seed-bible/seed-bible/i18n/I18nManager";
 import type { Translation } from "@packages/seed-bible/seed-bible/managers/FreeUseBibleAPI";
-import { type NavigationManager } from "@packages/seed-bible/seed-bible/managers/NavigationManager";
+import {
+  createNavigationManager,
+  type NavigationManager,
+} from "@packages/seed-bible/seed-bible/managers/NavigationManager";
 import { signal, type Signal } from "@preact/signals";
 
 const i18nFolder = path.resolve(
@@ -181,5 +184,50 @@ describe("I18nManager language fallback prompt", () => {
       id: "spa_onbv",
       language: "spa",
     });
+  });
+});
+
+describe("I18nManager URL <-> language sync", () => {
+  beforeEach(() => {
+    window.history.replaceState({}, "", "/");
+    Object.defineProperty(window.navigator, "languages", {
+      configurable: true,
+      value: ["en-US"],
+    });
+  });
+
+  // Regression for #1443: the `?lang=` query param is the source of truth for
+  // the UI language. When it changes on its own (deep link, browser
+  // back/forward), the actual i18next translations must reload — not just the
+  // `language` signal — otherwise `t()` keeps returning the old language.
+  it("reloads i18n when ?lang= changes in the URL", async () => {
+    const nav = createNavigationManager({ initialHref: window.location.href });
+    const manager = createI18nManager(nav, ["en"]);
+    await manager.ready;
+    expect(manager.i18n.language).toBe("en");
+
+    window.history.pushState({}, "", "/?lang=de");
+
+    const start = Date.now();
+    while (manager.i18n.language !== "de" && Date.now() - start < 1000) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    expect(manager.i18n.language).toBe("de");
+    expect(manager.language.value).toBe("de");
+  });
+
+  // Selecting a UI language writes `?lang=` to the URL (primary), and the
+  // signal reflects the new language.
+  it("writes ?lang= when the UI language is changed", async () => {
+    const nav = createNavigationManager({ initialHref: window.location.href });
+    const manager = createI18nManager(nav, ["en"]);
+    await manager.ready;
+    manager.setBibleTranslationApplicator(vi.fn(), () => null, null);
+
+    await manager.requestLanguageChange("fr");
+
+    expect(manager.language.value).toBe("fr");
+    expect(nav.currentUrl.value.searchParams.get("lang")).toBe("fr");
   });
 });

--- a/test/unit/seed-bible/managers/ConfigManager.test.ts
+++ b/test/unit/seed-bible/managers/ConfigManager.test.ts
@@ -1,0 +1,108 @@
+import { createI18nManager } from "@packages/seed-bible/seed-bible/i18n/I18nManager";
+import { createNavigationManager } from "@packages/seed-bible/seed-bible/managers/NavigationManager";
+import { createConfig } from "@packages/seed-bible/seed-bible/managers/ConfigManager";
+import type {
+  LoginManager,
+  UserProfile,
+} from "@packages/seed-bible/seed-bible/managers/LoginManager";
+import type { Translation } from "@packages/seed-bible/seed-bible/managers/FreeUseBibleAPI";
+import { signal } from "@preact/signals";
+
+/**
+ * Minimal LoginManager stand-in. `updateProfile` optimistically updates the
+ * `profile` signal the same way the real manager does, which is what the
+ * ConfigManager's profile-language effect subscribes to.
+ */
+function makeFakeLogin(initialProfile: UserProfile | null): LoginManager {
+  const userId = signal<string | null>(initialProfile ? "user-1" : null);
+  const profile = signal<UserProfile | null>(initialProfile);
+  return {
+    userId,
+    profile,
+    profilePromise: Promise.resolve(initialProfile),
+    updateProfile: (newData: Partial<UserProfile>) => {
+      if (!profile.value) return;
+      profile.value = { ...profile.value, ...newData };
+    },
+  } as unknown as LoginManager;
+}
+
+function profileWithLang(lang: string): UserProfile {
+  return { name: "Test", config: { lang } } as unknown as UserProfile;
+}
+
+function getProfileLang(login: LoginManager): string | undefined {
+  return (login.profile.value as { config?: { lang?: string } } | null)?.config
+    ?.lang;
+}
+
+describe("ConfigManager language handling", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    window.history.replaceState({}, "", "/");
+    Object.defineProperty(window.navigator, "languages", {
+      configurable: true,
+      value: ["en-US"],
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  // Regression for #1443: changing the UI language in the settings screen
+  // must change the interface language (`?lang=`), not only the scripture
+  // translation (`?translation=`). The bug was that ConfigManager re-applied
+  // the profile's still-unsaved previous language whenever the URL changed —
+  // and the language switch itself writes `?lang=` — so it reverted the switch.
+  it("keeps a logged-in user's newly selected UI language (does not revert to the profile's previous language)", async () => {
+    const nav = createNavigationManager({ initialHref: window.location.href });
+    const i18n = createI18nManager(nav, ["en"]);
+    await i18n.ready;
+
+    const login = makeFakeLogin(profileWithLang("en"));
+    createConfig(login, nav);
+
+    // The scripture-translation side-effect writes `?translation=`.
+    const apply = vi.fn(async () => {
+      nav.updateQueryParam("translation", "fra_onbv");
+    });
+    i18n.setBibleTranslationApplicator(
+      apply,
+      () => [{ id: "fra_onbv", language: "fra" } as Translation],
+      null
+    );
+
+    await i18n.requestLanguageChange("fr");
+    // Let any queued microtasks / async effects settle.
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    // Primary effect: the UI language changed and is reflected in `?lang=`.
+    expect(i18n.language.value).toBe("fr");
+    expect(nav.currentUrl.value.searchParams.get("lang")).toBe("fr");
+    // Secondary effect: the scripture translation changed too.
+    expect(nav.currentUrl.value.searchParams.get("translation")).toBe(
+      "fra_onbv"
+    );
+    // The new language is persisted back to the profile.
+    expect(getProfileLang(login)).toBe("fr");
+  });
+
+  it("applies the profile's saved language when the profile loads (e.g. on login)", async () => {
+    const nav = createNavigationManager({ initialHref: window.location.href });
+    const i18n = createI18nManager(nav, ["en"]);
+    await i18n.ready;
+    expect(i18n.language.value).toBe("en");
+
+    // Start logged out, then "log in" by populating the profile signal.
+    const login = makeFakeLogin(null);
+    createConfig(login, nav);
+
+    login.profile.value = profileWithLang("fr");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(i18n.language.value).toBe("fr");
+  });
+});

--- a/test/unit/seed-bible/managers/ConfigManager.test.ts
+++ b/test/unit/seed-bible/managers/ConfigManager.test.ts
@@ -63,7 +63,10 @@ describe("ConfigManager language handling", () => {
     await i18n.ready;
 
     const login = makeFakeLogin(profileWithLang("en"));
-    createConfig(login, nav);
+    const config = createConfig(login, nav);
+    // Selector-driven changes persist to the profile via this wiring (done by
+    // SeedBibleState in production).
+    i18n.setLanguagePersister(config.persistLanguage);
 
     // The scripture-translation side-effect writes `?translation=`.
     const apply = vi.fn(async () => {
@@ -104,5 +107,50 @@ describe("ConfigManager language handling", () => {
     await new Promise((resolve) => setTimeout(resolve, 0));
 
     expect(i18n.language.value).toBe("fr");
+  });
+
+  // A shared `?lang=` link or browser back/forward changes the displayed
+  // language, but must NOT overwrite the account's saved language — only the
+  // in-app selector persists.
+  it("does not persist a URL-driven language change to the profile", async () => {
+    const nav = createNavigationManager({ initialHref: window.location.href });
+    const i18n = createI18nManager(nav, ["en"]);
+    await i18n.ready;
+
+    const login = makeFakeLogin(profileWithLang("en"));
+    const config = createConfig(login, nav);
+    i18n.setLanguagePersister(config.persistLanguage);
+
+    // Deep-link / back-forward navigation that puts ?lang=de in the URL.
+    window.history.pushState({}, "", "/?lang=de");
+    const start = Date.now();
+    while (i18n.i18n.language !== "de" && Date.now() - start < 1000) {
+      await new Promise((resolve) => setTimeout(resolve, 5));
+    }
+
+    // The displayed language switched ...
+    expect(i18n.language.value).toBe("de");
+    // ... but the saved profile language is untouched.
+    expect(getProfileLang(login)).toBe("en");
+  });
+
+  it("persists a selector-driven change even when the language matches no prior profile value", async () => {
+    const nav = createNavigationManager({ initialHref: window.location.href });
+    const i18n = createI18nManager(nav, ["en"]);
+    await i18n.ready;
+
+    // Logged-in user with no saved language yet.
+    const login = makeFakeLogin({
+      name: "Test",
+      config: {},
+    } as unknown as UserProfile);
+    const config = createConfig(login, nav);
+    i18n.setLanguagePersister(config.persistLanguage);
+    i18n.setBibleTranslationApplicator(vi.fn(), () => null, null);
+
+    await i18n.requestLanguageChange("de");
+    await new Promise((resolve) => setTimeout(resolve, 0));
+
+    expect(getProfileLang(login)).toBe("de");
   });
 });

--- a/test/unit/seed-bible/managers/ConfigManager.test.ts
+++ b/test/unit/seed-bible/managers/ConfigManager.test.ts
@@ -154,3 +154,119 @@ describe("ConfigManager language handling", () => {
     expect(getProfileLang(login)).toBe("de");
   });
 });
+
+// The agreement reached on PR #1444 for how the incoming `?lang=` URL
+// parameter interacts with the account's saved language:
+//   1. Signed in WITH a saved language  -> profile overrides the URL param.
+//   2. Signed in WITHOUT a saved language -> use the URL param.
+//   3. Not signed in                      -> use the URL param.
+// And in every case, merely loading a `?lang=` URL must never overwrite the
+// saved profile language (only the selector persists).
+describe("ConfigManager initial load with ?lang= URL parameter", () => {
+  let logSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    logSpy = vi.spyOn(console, "log").mockImplementation(() => undefined);
+    window.history.replaceState({}, "", "/");
+    Object.defineProperty(window.navigator, "languages", {
+      configurable: true,
+      value: ["en-US"],
+    });
+  });
+
+  afterEach(() => {
+    logSpy.mockRestore();
+  });
+
+  async function settle() {
+    await new Promise((resolve) => setTimeout(resolve, 0));
+  }
+
+  function navWithLang(lang: string) {
+    return createNavigationManager({
+      initialHref: `http://localhost:3000/?lang=${lang}`,
+    });
+  }
+
+  // Case 1: the saved profile language wins over the URL param, and the URL
+  // param is NOT written back to the profile (Kal's reported bug).
+  it("lets a saved profile language override the URL param without overwriting the profile", async () => {
+    const nav = navWithLang("de");
+    const i18n = createI18nManager(nav, []);
+    // Ensure i18n has settled on the URL language ("de") before the
+    // profile-apply effect first runs, so the override is exercised
+    // deterministically regardless of test order (i18next is a singleton).
+    await i18n.ready;
+
+    const login = makeFakeLogin(profileWithLang("en"));
+    const config = createConfig(login, nav);
+    i18n.setLanguagePersister(config.persistLanguage);
+
+    await settle();
+
+    // Profile "en" wins over URL "de" ...
+    expect(i18n.i18n.language).toBe("en");
+    // ... and the saved language is untouched.
+    expect(getProfileLang(login)).toBe("en");
+  });
+
+  // Case 1, async: the profile loads a moment after boot (real login flow).
+  // Reproduces Kal's exact steps — the URL language shows first, then the
+  // profile language replaces it, and the profile is never overwritten.
+  it("does not overwrite the profile when the profile loads after a ?lang= boot", async () => {
+    const nav = navWithLang("de");
+    const i18n = createI18nManager(nav, []);
+    const login = makeFakeLogin(null);
+    const config = createConfig(login, nav);
+    i18n.setLanguagePersister(config.persistLanguage);
+
+    await i18n.ready;
+    await settle();
+
+    // Before login: the URL language is shown.
+    expect(i18n.i18n.language).toBe("de");
+
+    // Simulate login completing with a saved preference of "en".
+    login.userId.value = "user-1";
+    login.profile.value = profileWithLang("en");
+    await settle();
+
+    // Profile overrides the URL language ...
+    expect(i18n.i18n.language).toBe("en");
+    // ... and critically, the profile is still "en", not the URL's "de".
+    expect(getProfileLang(login)).toBe("en");
+  });
+
+  // Case 2: signed in but no saved preference -> the URL param is used, and
+  // is not persisted (no explicit selector choice was made).
+  it("uses the URL param when a signed-in user has no saved language", async () => {
+    const nav = navWithLang("de");
+    const i18n = createI18nManager(nav, []);
+    const login = makeFakeLogin({
+      name: "Test",
+      config: {},
+    } as unknown as UserProfile);
+    const config = createConfig(login, nav);
+    i18n.setLanguagePersister(config.persistLanguage);
+
+    await i18n.ready;
+    await settle();
+
+    expect(i18n.i18n.language).toBe("de");
+    expect(getProfileLang(login)).toBeUndefined();
+  });
+
+  // Case 3: not signed in -> the URL param is used.
+  it("uses the URL param when the user is not signed in", async () => {
+    const nav = navWithLang("de");
+    const i18n = createI18nManager(nav, []);
+    const login = makeFakeLogin(null);
+    const config = createConfig(login, nav);
+    i18n.setLanguagePersister(config.persistLanguage);
+
+    await i18n.ready;
+    await settle();
+
+    expect(i18n.i18n.language).toBe("de");
+  });
+});


### PR DESCRIPTION
## Summary

Fixes a bug (#1443) where changing the UI language in settings would revert to the user's previously saved language. The root cause was that `ConfigManager` was re-applying the profile's language on every URL change, including the URL change caused by the language switch itself.

## Changes

**ConfigManager** (`packages/seed-bible/seed-bible/managers/ConfigManager.tsx`):
- Split the monolithic `syncConfigFromBot` effect into two separate effects with different subscription dependencies
- The profile-language effect now subscribes **only to `login.profile`**, not the URL, so it only runs when the profile loads (e.g., on login) — not on every URL change
- A separate effect re-reads other config (font size, panels, preset) whenever the URL or profile changes
- Added detailed comments explaining why the profile-language effect must not subscribe to URL changes, since `?lang=` is owned by `I18nManager` and is the single source of truth for the URL ↔ language relationship

**I18nManager** (`packages/seed-bible/seed-bible/i18n/I18nManager.tsx`):
- Fixed the `language` signal's setter to route URL-driven `?lang=` changes through `i18n.changeLanguage()` instead of assigning directly
- This ensures the actual i18next translations reload when the URL changes (e.g., deep links, browser back/forward), preventing desync between the `language` signal and what `t()` actually returns

**Tests**:
- Added comprehensive test suite (`test/unit/seed-bible/managers/ConfigManager.test.ts`) covering the regression: verifies that a user's newly selected language is not reverted when the URL changes
- Added tests to `I18nManager.test.ts` verifying that `?lang=` changes in the URL trigger actual i18n reloads and that language selection writes `?lang=` correctly

## Implementation Details

The bug occurred because:
1. User picks a new language → `I18nManager` writes `?lang=fr` to the URL
2. URL change triggers `ConfigManager`'s effect
3. Effect reads the profile's still-unsaved previous language (`lang: "en"`) and applies it
4. User sees the language revert, even though the profile eventually saves the new language

The fix enforces a clear ownership model: `I18nManager` owns the URL ↔ `i18n.language` sync (including reloading translations on URL changes), while `ConfigManager` only applies the profile's language when the profile itself changes, not on URL changes.

https://claude.ai/code/session_012boq6vwxsFMXA98cB1LuRo