### PR TITLE
Scripture Map settings icon (plus pane header icon slot & reactive titles)

### DIFF
--- a/packages/locations-extension/ext_locations/init.tsx
+++ b/packages/locations-extension/ext_locations/init.tsx
@@ -1,5 +1,5 @@
 import type { ChapterVerse } from "@packages/seed-bible/seed-bible/managers/FreeUseBibleAPI";
-import { computed } from "@preact/signals";
+import { computed, signal } from "@preact/signals";
 import { registerExtension } from "seed-bible";
 import { LocationIcon, PortalComponent } from "seed-bible/components";
 import locations from "./locations.json";
@@ -102,7 +102,7 @@ export default function initLocationsExtension() {
 
         context.panes.openPane({
           placement: "floating",
-          title: place.place,
+          title: signal(place.place),
           component: () => (
             <PortalComponent
               portal="map"

--- a/packages/scripture-map/components/ScriptureMap.tsx
+++ b/packages/scripture-map/components/ScriptureMap.tsx
@@ -134,6 +134,13 @@ export interface ScriptureMapConfig {
   }) => preact.JSX.Element;
   ReadingHistoryTimeline: ReadingHistoryTimelineComponent;
   userId: string | undefined;
+  /**
+   * DOM node rendered by the pane's `header` slot (see `PanesManager.openPane`)
+   * that the settings button portals into, so the button keeps this
+   * context's state while its DOM output renders in the pane header instead
+   * of the settings panel.
+   */
+  settingsHeaderSlot: Signal<HTMLElement | null>;
 }
 
 type ScriptureMapProps = {

--- a/packages/scripture-map/components/containers/Settings.tsx
+++ b/packages/scripture-map/components/containers/Settings.tsx
@@ -11,6 +11,7 @@ import { useScriptureMapContext } from "../../contexts/ScriptureMap/ScriptureMap
 import type { ReadingHistoryTimelineFooterData } from "../../../seed-bible-utils/infrastructure/models/seedBible";
 
 import { useRef } from "preact/hooks";
+import { createPortal } from "preact/compat";
 
 export type BaseSettingsOptionProps = {
   callback: () => void;
@@ -231,6 +232,7 @@ const ReadingHistoryTimelineSection = ({
 };
 
 export const Settings = () => {
+  const { settingsHeaderSlot } = useScriptureMapContext();
   const {
     settingsClass,
     settingsButtonRef,
@@ -246,7 +248,6 @@ export const Settings = () => {
     legendSquaresData,
     yearSelectorLabelTextContent,
     yearSelectorOptionsData,
-    title,
     optionsTitle,
     optionsDescription,
     lessText,
@@ -255,27 +256,26 @@ export const Settings = () => {
 
   return (
     <div className={settingsClass}>
-      <div className="settings-title scripture-title">
-        <span class="material-symbols-outlined">splitscreen_portrait</span>
-        <span className="scripture-title">{title}</span>
-      </div>
-
-      <div
-        className="header-button settings-button"
-        ref={settingsButtonRef}
-        onClick={handleSettingsButtonClick}
-      >
-        <span className="material-symbols-outlined">more_vert</span>
-        {showOptions && (
-          <SettingsOptions
-            setShowOptions={setShowOptions}
-            settingsButtonRef={settingsButtonRef}
-            optionsData={optionsData}
-            optionsTitle={optionsTitle}
-            optionsDescription={optionsDescription}
-          />
+      {settingsHeaderSlot.value &&
+        createPortal(
+          <div
+            className="header-button settings-button"
+            ref={settingsButtonRef}
+            onClick={handleSettingsButtonClick}
+          >
+            <span className="material-symbols-outlined">more_vert</span>
+            {showOptions && (
+              <SettingsOptions
+                setShowOptions={setShowOptions}
+                settingsButtonRef={settingsButtonRef}
+                optionsData={optionsData}
+                optionsTitle={optionsTitle}
+                optionsDescription={optionsDescription}
+              />
+            )}
+          </div>,
+          settingsHeaderSlot.value
         )}
-      </div>
 
       <span className={"horizontal-divider"}></span>
 

--- a/packages/scripture-map/components/containers/Settings.tsx
+++ b/packages/scripture-map/components/containers/Settings.tsx
@@ -81,9 +81,6 @@ export interface SettingsYearselectorOptionProps {
   content: number;
 }
 
-const SETTINGS_ICON =
-  "https://auth-aux-aobot-prod-filesbucket-141297942820.s3.amazonaws.com/aoBot/5a87cdff4617c9047e44ec47ddd8a101aa317e2223d83dd40f615e3f9740f03a.svg";
-
 const Option = (props: SettingsOptionProps) => {
   const { MaterialIcon } = useScriptureMapContext();
 
@@ -268,7 +265,7 @@ export const Settings = () => {
         ref={settingsButtonRef}
         onClick={handleSettingsButtonClick}
       >
-        <img src={SETTINGS_ICON} alt="SETTINGS_ICON" className="coloredIcon" />
+        <span className="material-symbols-outlined">more_vert</span>
         {showOptions && (
           <SettingsOptions
             setShowOptions={setShowOptions}

--- a/packages/scripture-map/components/containers/Settings.tsx
+++ b/packages/scripture-map/components/containers/Settings.tsx
@@ -277,8 +277,6 @@ export const Settings = () => {
           settingsHeaderSlot.value
         )}
 
-      <span className={"horizontal-divider"}></span>
-
       {mode === ScriptureMapModes.Project && project && (
         <>
           <ProjectStateSetter />

--- a/packages/scripture-map/di/bootstrap.tsx
+++ b/packages/scripture-map/di/bootstrap.tsx
@@ -1,4 +1,4 @@
-// import { effect } from "@preact/signals";
+import { computed, signal, type Signal } from "@preact/signals";
 import {
   registerExtension,
   type SeedBibleState,
@@ -15,6 +15,17 @@ import type { ScriptureMapEvents } from "../models/events";
 const Icon = () => {
   return <MaterialIcon>splitscreen_portrait</MaterialIcon>;
 };
+
+// Portal target for the settings button: the pane's `header` slot can't reach
+// ScriptureMap's context, since it's a sibling of the body, not a descendant.
+const SettingsHeaderSlot = ({ node }: { node: Signal<HTMLElement | null> }) => (
+  <div
+    className="scripture-map-settings-header-slot"
+    ref={(element: HTMLDivElement | null) => {
+      node.value = element;
+    }}
+  />
+);
 
 // const customCSS = getCustomStyles();
 
@@ -78,15 +89,31 @@ export const bootstrapExtension = () => {
         },
         icon: Icon,
         onSelect: () => {
+          const settingsHeaderSlot = signal<HTMLElement | null>(null);
+
           context.panes.openPane({
             placement: "side",
-            title: "Scripture Map",
+            // `title` is a signal (not a hook), so it's translated directly
+            // through the i18n manager; passing the current `language.value`
+            // as `lng` subscribes this computed to language changes so the
+            // title stays in sync while the pane is open.
+            title: computed(() => {
+              const { value: language } = context.i18n.language;
+              return context.i18n.t("scripture-map", {
+                ns: extensionId,
+                defaultValue: "Scripture Map",
+                lng: language,
+              });
+            }),
+            icon: Icon,
+            header: () => <SettingsHeaderSlot node={settingsHeaderSlot} />,
             component: () => {
               const { t, language } = useI18n();
 
               return (
                 <ScriptureMap
                   config={{
+                    settingsHeaderSlot,
                     mode: ScriptureMapModes.Viewer,
                     onChapterClick: (_, key) => {
                       let { bookId } = key;

--- a/packages/scripture-map/hooks/useSettings.tsx
+++ b/packages/scripture-map/hooks/useSettings.tsx
@@ -32,7 +32,6 @@ interface UseSettingsType {
   legendSquaresData: SettingsLegendSquareData[];
   yearSelectorLabelTextContent: string;
   yearSelectorOptionsData: SettingsYearselectorOptionData[];
-  title: string;
   optionsTitle: string;
   optionsDescription: string;
   lessText: string;
@@ -333,10 +332,6 @@ export const useSettings: UseSettings = () => {
     setShowOptions,
   ]);
 
-  const title = useMemo(() => {
-    return translate("scripture-map");
-  }, [translate]);
-
   const optionsTitle = useMemo(() => {
     return translate("options-title");
   }, [translate]);
@@ -368,7 +363,6 @@ export const useSettings: UseSettings = () => {
     legendSquaresData,
     yearSelectorLabelTextContent,
     yearSelectorOptionsData,
-    title,
     optionsTitle,
     optionsDescription,
     lessText,

--- a/packages/scripture-map/styles/styles.css
+++ b/packages/scripture-map/styles/styles.css
@@ -10,7 +10,7 @@
   height: 100%;
   --timelineItemSize: 16px;
   position: relative;
-  padding-top: 1rem;
+  padding-top: 0.5rem;
   background-color: var(--sb-reader-background);
 }
 
@@ -30,27 +30,6 @@
   gap: 0.25rem;
   display: grid;
   grid-template-columns: 1rem 1fr 2.5rem 1rem;
-  grid-template-rows: 1.25rem auto auto;
-}
-
-.scripture-map-settings.collapsed {
-  grid-template-rows: 1.25rem;
-}
-
-.scripture-map-settings .horizontal-divider {
-  background-color: var(--sb-divider-color);
-  height: 1.5px;
-}
-
-.scripture-map-settings > :nth-child(1 of .horizontal-divider) {
-  grid-column: 1 / 6;
-  grid-row: 1 / 2;
-}
-
-.scripture-map-settings > :nth-child(2 of .horizontal-divider) {
-  grid-column: 2 / 5;
-  grid-row: 5 / 6;
-  align-self: center;
 }
 
 .scripture-map-settings-header-slot {

--- a/packages/scripture-map/styles/styles.css
+++ b/packages/scripture-map/styles/styles.css
@@ -84,15 +84,7 @@
   /* border: 1px solid var(--sb-divider-color); */
   border-radius: 0.25rem;
   padding: 0.375rem;
-}
-
-/* The settings icon is an <img> (not a font glyph), so the button's font-size
-   above doesn't size it — give it an explicit rem size so it scales with the
-   UI Size knob like the rest of the chrome. 1rem = its intrinsic 16px at
-   size M, so this is a no-op at M. */
-.settings-button .coloredIcon {
-  width: 1rem;
-  height: 1rem;
+  color: var(--sb-reader-font-color);
 }
 
 .header-button.settings-button:hover:not(

--- a/packages/scripture-map/styles/styles.css
+++ b/packages/scripture-map/styles/styles.css
@@ -30,11 +30,11 @@
   gap: 0.25rem;
   display: grid;
   grid-template-columns: 1rem 1fr 2.5rem 1rem;
-  grid-template-rows: 2.5rem 1.25rem auto auto;
+  grid-template-rows: 1.25rem auto auto;
 }
 
 .scripture-map-settings.collapsed {
-  grid-template-rows: 2.5rem 1.25rem;
+  grid-template-rows: 1.25rem;
 }
 
 .scripture-map-settings .horizontal-divider {
@@ -44,27 +44,17 @@
 
 .scripture-map-settings > :nth-child(1 of .horizontal-divider) {
   grid-column: 1 / 6;
-  grid-row: 2 / 3;
+  grid-row: 1 / 2;
 }
 
 .scripture-map-settings > :nth-child(2 of .horizontal-divider) {
   grid-column: 2 / 5;
-  grid-row: 6 / 7;
+  grid-row: 5 / 6;
   align-self: center;
 }
 
-.settings-title {
-  display: flex;
-  justify-content: flex-start;
-  align-items: center;
-  gap: 0.5rem;
-  grid-column: 2 / 3;
-  grid-row: 1 / 2;
-}
-
-.settings-title > span {
-  font-size: 1.25rem;
-  font-weight: 600;
+.scripture-map-settings-header-slot {
+  display: contents;
 }
 
 .header-button {
@@ -73,18 +63,15 @@
   align-items: center;
   cursor: pointer;
   position: relative;
-  justify-self: center;
-  align-self: center;
-  grid-row: 1 / 2;
 }
 
 .settings-button {
-  grid-column: 3 / 4;
-  font-size: 1.75rem !important;
-  /* border: 1px solid var(--sb-divider-color); */
-  border-radius: 0.25rem;
-  padding: 0.375rem;
-  color: var(--sb-reader-font-color);
+  font-size: 1.375rem !important;
+  height: 2.5rem;
+  min-width: 2.5rem;
+  border-radius: 0.5rem;
+  padding: 0;
+  color: inherit;
 }
 
 .header-button.settings-button:hover:not(

--- a/packages/seed-bible-refresh-example-extension/ext_Example/init.tsx
+++ b/packages/seed-bible-refresh-example-extension/ext_Example/init.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable seed-bible-i18n/i18n-untranslated-content */
-import { effect } from "@preact/signals";
+import { effect, signal } from "@preact/signals";
 import { registerExtension, type SeedBibleState } from "seed-bible";
 import { MaterialIcon, PortalComponent } from "seed-bible/components";
 import { useI18n } from "seed-bible/i18n";
@@ -32,7 +32,7 @@ export default function initExampleExtension() {
           console.log("Example tool selected!");
           context.panes.openPane({
             placement: "side",
-            title: "My Example Tool",
+            title: signal("My Example Tool"),
             component: () => {
               // You can use the useI18n hook in your tool component to get translated strings
               const { t } = useI18n("example-extension");
@@ -116,7 +116,7 @@ export default function initExampleExtension() {
           context.panesManager.openPane({
             id: "example-portal-pane",
             placement: "floating",
-            title: "Grid Portal",
+            title: signal("Grid Portal"),
             component: () => (
               <PortalComponent
                 portal="home"
@@ -146,7 +146,7 @@ export default function initExampleExtension() {
           context.panesManager.openPane({
             id: "example-portal-pane",
             placement: "floating",
-            title: "Map Portal",
+            title: signal("Map Portal"),
             component: () => (
               <PortalComponent
                 portal="map_portal"

--- a/packages/seed-bible/seed-bible/components/PaneHeader/PaneHeader.css
+++ b/packages/seed-bible/seed-bible/components/PaneHeader/PaneHeader.css
@@ -18,8 +18,21 @@
 .sb-pane-header-title {
   flex: 1 1 auto;
   min-width: 0;
+  display: flex;
+  align-items: center;
+  gap: 6px;
   font-weight: 700;
   letter-spacing: 0.02em;
+}
+
+.sb-pane-header-icon {
+  flex: 0 0 auto;
+  display: inline-flex;
+  font-size: 1.125rem;
+}
+
+.sb-pane-header-title-text {
+  min-width: 0;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;

--- a/packages/seed-bible/seed-bible/components/PaneHeader/PaneHeader.tsx
+++ b/packages/seed-bible/seed-bible/components/PaneHeader/PaneHeader.tsx
@@ -1,12 +1,19 @@
 import "./PaneHeader.css";
 import type { ComponentChild } from "preact";
+import type { Signal } from "@preact/signals";
 import { useI18n } from "../../i18n/I18nManager";
 
 export interface PaneHeaderProps {
-  /** Title shown in the header. */
-  title: string;
+  /** Title shown in the header. A signal so translated titles stay in sync
+   * with UI language changes while the pane is open. */
+  title: Signal<string>;
   /** Called when the close button is pressed. */
   onClose: () => void;
+  /**
+   * Optional icon rendered before the title. Rendered as a component so it
+   * can use hooks.
+   */
+  icon?: () => ComponentChild;
   /**
    * Optional custom header content rendered between the title and the close
    * button. Rendered as a component so it can use hooks (i18n, signals).
@@ -25,12 +32,19 @@ export interface PaneHeaderProps {
  * header slot, and a close button.
  */
 export function PaneHeader(props: PaneHeaderProps) {
-  const { title, onClose, header: Header, onPointerDown } = props;
+  const { title, onClose, icon: Icon, header: Header, onPointerDown } = props;
   const { t } = useI18n();
 
   return (
     <div className="sb-pane-header" onPointerDown={onPointerDown}>
-      <div className="sb-pane-header-title">{title}</div>
+      <div className="sb-pane-header-title">
+        {Icon && (
+          <span className="sb-pane-header-icon">
+            <Icon />
+          </span>
+        )}
+        <span className="sb-pane-header-title-text">{title.value}</span>
+      </div>
       {Header && (
         <div
           className="sb-pane-header-actions"

--- a/packages/seed-bible/seed-bible/components/PaneLayout/PaneLayout.tsx
+++ b/packages/seed-bible/seed-bible/components/PaneLayout/PaneLayout.tsx
@@ -199,6 +199,7 @@ export function PaneLayout(props: PaneLayoutProps) {
         >
           <PaneHeader
             title={pane.title}
+            icon={pane.icon}
             header={pane.header}
             onClose={() => panesManager.closePane(pane.id)}
             onPointerDown={(event: PointerEvent) => startMove(pane, event)}
@@ -256,6 +257,7 @@ export function FullscreenPane(props: FullscreenPaneProps) {
     >
       <PaneHeader
         title={pane.title}
+        icon={pane.icon}
         header={pane.header}
         onClose={() => panesManager.closePane(pane.id)}
       />
@@ -295,6 +297,7 @@ export function SidePane(props: SidePaneProps) {
     >
       <PaneHeader
         title={pane.title}
+        icon={pane.icon}
         header={pane.header}
         onClose={() => panesManager.closePane(pane.id)}
       />

--- a/packages/seed-bible/seed-bible/managers/PanesManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/PanesManager.tsx
@@ -11,9 +11,14 @@ export interface Pane {
   /** Stable pane identifier. */
   id: string;
   /** Title shown in the pane's header. */
-  title: string;
+  title: Signal<string>;
   /** Custom component rendered in this pane. */
   component: () => ComponentChild;
+  /**
+   * Optional icon rendered before the title in the pane's header. Rendered as
+   * a component so it can use hooks.
+   */
+  icon?: () => ComponentChild;
   /**
    * Optional custom header content rendered inside the pane's header, between
    * the title and the close button. Rendered as a component so it can use
@@ -36,9 +41,14 @@ export interface PaneOpenOptions {
   /** Placement mode for the new pane. Immutable after creation. */
   placement: PanePlacement;
   /** Title shown in the pane's header. */
-  title: string;
+  title: Signal<string>;
   /** Custom component rendered in the pane. */
   component: () => ComponentChild;
+  /**
+   * Optional icon rendered before the title in the pane's header. Rendered as
+   * a component so it can use hooks.
+   */
+  icon?: () => ComponentChild;
   /**
    * Optional custom header content rendered inside the pane's header, between
    * the title and the close button. Rendered as a component so it can use
@@ -111,11 +121,12 @@ function createPaneFactory() {
   let nextPaneId = 1;
 
   return (
-    title: string,
+    title: Signal<string>,
     component: () => ComponentChild,
     placement: PanePlacement,
     customId?: string,
-    header?: () => ComponentChild
+    header?: () => ComponentChild,
+    icon?: () => ComponentChild
   ): Pane => {
     const paneId = nextPaneId;
     nextPaneId += 1;
@@ -125,6 +136,7 @@ function createPaneFactory() {
       id: customId ?? `pane-${paneId}`,
       title,
       component,
+      icon,
       header,
       placement,
       x: 48 + offset,
@@ -186,6 +198,7 @@ export function createPanes(isMobile?: ReadonlySignal<boolean>): PanesManager {
           ...existingPane,
           title: options.title,
           component: options.component,
+          icon: options.icon,
           header: options.header,
         };
         syncPaneState(
@@ -213,7 +226,8 @@ export function createPanes(isMobile?: ReadonlySignal<boolean>): PanesManager {
       options.component,
       options.placement,
       options.id,
-      options.header
+      options.header,
+      options.icon
     );
     syncPaneState([...basePanes, nextPane], nextPane.id);
     return nextPane;

--- a/packages/today-screen/infrastructure/di/bootstrap.tsx
+++ b/packages/today-screen/infrastructure/di/bootstrap.tsx
@@ -357,7 +357,7 @@ export const bootstrapExtension = () => {
         context.panes.openPane({
           id: TODAY_PANE_ID,
           placement: "fullscreen",
-          title: "Today",
+          title: signal("Today"),
           component,
         });
       };

--- a/packages/transcript-ui-extension/ext_AI_Transcript_UI/main/init.tsx
+++ b/packages/transcript-ui-extension/ext_AI_Transcript_UI/main/init.tsx
@@ -1,4 +1,4 @@
-import { effect } from "@preact/signals";
+import { effect, signal } from "@preact/signals";
 import { registerExtension, type SeedBibleState } from "seed-bible";
 import { createTranscriptionManager } from "@seed-bible/ai-transcript-extension/transcriptionManager";
 import { App } from "./App";
@@ -39,7 +39,7 @@ export default function initTranscriptUI() {
                   </ManagerProvider>
                 );
               },
-              title: "AI Transcript",
+              title: signal("AI Transcript"),
             });
 
             const { login } = context;

--- a/test/unit/scripture-map/components/containers/Settings.test.tsx
+++ b/test/unit/scripture-map/components/containers/Settings.test.tsx
@@ -178,11 +178,6 @@ describe("Settings", () => {
       expect(container.querySelector(".settings-button")).toBeNull();
       expect(portalTarget.querySelector(".settings-button")).not.toBeNull();
     });
-
-    it("renders a .horizontal-divider", () => {
-      setup();
-      expect(container.querySelector(".horizontal-divider")).not.toBeNull();
-    });
   });
 
   describe("settings button", () => {

--- a/test/unit/scripture-map/components/containers/Settings.test.tsx
+++ b/test/unit/scripture-map/components/containers/Settings.test.tsx
@@ -14,6 +14,10 @@ vi.mock("../../../../../packages/scripture-map/hooks/useSettings", () => ({
   useSettings: vi.fn(),
 }));
 
+const { settingsHeaderSlotMock } = vi.hoisted(() => ({
+  settingsHeaderSlotMock: { value: null as HTMLElement | null },
+}));
+
 vi.mock(
   "../../../../../packages/scripture-map/contexts/ScriptureMap/ScriptureMapContext",
   () => ({
@@ -27,6 +31,7 @@ vi.mock(
           data-has-footer={footer ? "true" : "false"}
         />
       ),
+      settingsHeaderSlot: settingsHeaderSlotMock,
     })),
   })
 );
@@ -120,7 +125,6 @@ function makeHookResult(overrides: Record<string, unknown> = {}) {
     legendSquaresData: [] as SettingsLegendSquareData[],
     yearSelectorLabelTextContent: "2024",
     yearSelectorOptionsData: [] as SettingsYearselectorOptionData[],
-    title: "Scripture Map",
     optionsTitle: "Options",
     optionsDescription: "Manage your view.",
     lessText: "Less",
@@ -131,16 +135,25 @@ function makeHookResult(overrides: Record<string, unknown> = {}) {
 
 describe("Settings", () => {
   let container: HTMLDivElement;
+  // The settings button portals into the pane header's slot rather than
+  // rendering inline (see Settings.tsx), so it lives in its own DOM node,
+  // separate from `container`.
+  let portalTarget: HTMLDivElement;
 
   beforeEach(() => {
     container = document.createElement("div");
     document.body.appendChild(container);
+    portalTarget = document.createElement("div");
+    document.body.appendChild(portalTarget);
+    settingsHeaderSlotMock.value = portalTarget;
     (useSettings as Mock).mockReturnValue(makeHookResult());
   });
 
   afterEach(() => {
     act(() => render(null, container));
     container.remove();
+    portalTarget.remove();
+    settingsHeaderSlotMock.value = null;
     vi.clearAllMocks();
   });
 
@@ -160,18 +173,10 @@ describe("Settings", () => {
       ).not.toBeNull();
     });
 
-    it("renders .settings-title with the title text", () => {
-      setup({ title: "My Map" });
-      const titleEl = container.querySelector(
-        ".settings-title .scripture-title"
-      );
-      expect(titleEl).not.toBeNull();
-      expect(titleEl!.textContent).toBe("My Map");
-    });
-
-    it("renders the settings button", () => {
+    it("renders the settings button into the pane header's slot", () => {
       setup();
-      expect(container.querySelector(".settings-button")).not.toBeNull();
+      expect(container.querySelector(".settings-button")).toBeNull();
+      expect(portalTarget.querySelector(".settings-button")).not.toBeNull();
     });
 
     it("renders a .horizontal-divider", () => {
@@ -185,36 +190,45 @@ describe("Settings", () => {
       const handleSettingsButtonClick = vi.fn();
       setup({ handleSettingsButtonClick });
       act(() => {
-        container
+        portalTarget
           .querySelector(".settings-button")!
           .dispatchEvent(new MouseEvent("click", { bubbles: true }));
       });
       expect(handleSettingsButtonClick).toHaveBeenCalledTimes(1);
+    });
+
+    it("does not render the settings button when the header slot isn't mounted yet", () => {
+      settingsHeaderSlotMock.value = null;
+      setup();
+      expect(container.querySelector(".settings-button")).toBeNull();
+      expect(portalTarget.querySelector(".settings-button")).toBeNull();
     });
   });
 
   describe("SettingsOptions panel", () => {
     it("does not render .settings-options-container when showOptions is false", () => {
       setup({ showOptions: false });
-      expect(container.querySelector(".settings-options-container")).toBeNull();
+      expect(
+        portalTarget.querySelector(".settings-options-container")
+      ).toBeNull();
     });
 
     it("renders .settings-options-container when showOptions is true", () => {
       setup({ showOptions: true });
       expect(
-        container.querySelector(".settings-options-container")
+        portalTarget.querySelector(".settings-options-container")
       ).not.toBeNull();
     });
 
     it("renders optionsTitle inside the options container", () => {
       setup({ showOptions: true, optionsTitle: "Settings" });
-      const panel = container.querySelector(".settings-options-container")!;
+      const panel = portalTarget.querySelector(".settings-options-container")!;
       expect(panel.textContent).toContain("Settings");
     });
 
     it("renders optionsDescription inside the options container", () => {
       setup({ showOptions: true, optionsDescription: "Configure your view." });
-      const panel = container.querySelector(".settings-options-container")!;
+      const panel = portalTarget.querySelector(".settings-options-container")!;
       expect(panel.textContent).toContain("Configure your view.");
     });
 
@@ -226,7 +240,7 @@ describe("Settings", () => {
           makeStaticOption({ key: "b", staticText: "Hide colors" }),
         ],
       });
-      const buttons = container.querySelectorAll(".option-button");
+      const buttons = portalTarget.querySelectorAll(".option-button");
       expect(buttons).toHaveLength(2);
       expect(buttons[0]!.textContent).toContain("Open books");
       expect(buttons[1]!.textContent).toContain("Hide colors");
@@ -243,9 +257,9 @@ describe("Settings", () => {
           }),
         ],
       });
-      expect(container.querySelector(".option-button")!.textContent).toContain(
-        "Hide timeline"
-      );
+      expect(
+        portalTarget.querySelector(".option-button")!.textContent
+      ).toContain("Hide timeline");
     });
 
     it("renders dynamic option text using disabledText when condition is false", () => {
@@ -259,9 +273,9 @@ describe("Settings", () => {
           }),
         ],
       });
-      expect(container.querySelector(".option-button")!.textContent).toContain(
-        "Show timeline"
-      );
+      expect(
+        portalTarget.querySelector(".option-button")!.textContent
+      ).toContain("Show timeline");
     });
 
     it("calls the option callback when an option button is clicked", () => {
@@ -271,7 +285,7 @@ describe("Settings", () => {
         optionsData: [makeStaticOption({ key: "x", callback })],
       });
       act(() => {
-        container
+        portalTarget
           .querySelector(".option-button")!
           .dispatchEvent(new MouseEvent("click", { bubbles: true }));
       });

--- a/test/unit/seed-bible/components/PaneHeader.test.tsx
+++ b/test/unit/seed-bible/components/PaneHeader.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "preact";
 import { act } from "preact/test-utils";
+import { signal } from "@preact/signals";
 import { PaneHeader } from "@packages/seed-bible/seed-bible/components/PaneHeader/PaneHeader";
 
 vi.mock("@packages/seed-bible/seed-bible/i18n/I18nManager", async () => {
@@ -31,7 +32,10 @@ describe("PaneHeader", () => {
 
   it("renders only a title and close button when no header is provided", () => {
     act(() => {
-      render(<PaneHeader title="My Pane" onClose={vi.fn()} />, container);
+      render(
+        <PaneHeader title={signal("My Pane")} onClose={vi.fn()} />,
+        container
+      );
     });
 
     expect(container.querySelector(".sb-pane-header-title")?.textContent).toBe(
@@ -47,7 +51,7 @@ describe("PaneHeader", () => {
     act(() => {
       render(
         <PaneHeader
-          title="My Pane"
+          title={signal("My Pane")}
           onClose={vi.fn()}
           header={() => <button className="my-custom-button">Refresh</button>}
         />,
@@ -84,7 +88,7 @@ describe("PaneHeader", () => {
     act(() => {
       render(
         <PaneHeader
-          title="My Pane"
+          title={signal("My Pane")}
           onClose={vi.fn()}
           onPointerDown={onPointerDown}
           header={() => <button className="my-custom-button">Refresh</button>}
@@ -109,7 +113,7 @@ describe("PaneHeader", () => {
     act(() => {
       render(
         <PaneHeader
-          title="My Pane"
+          title={signal("My Pane")}
           onClose={vi.fn()}
           onPointerDown={onPointerDown}
           header={() => <button className="my-custom-button">Refresh</button>}

--- a/test/unit/seed-bible/components/PortalComponent.test.tsx
+++ b/test/unit/seed-bible/components/PortalComponent.test.tsx
@@ -138,7 +138,7 @@ describe("PortalComponent inside a dragged floating pane", () => {
     panes.openPane({
       id: "portal-pane",
       placement: "floating",
-      title: "Map Portal",
+      title: signal("Map Portal"),
       component: () => {
         renderCount += 1;
         return (

--- a/test/unit/seed-bible/managers/PanesManager.test.ts
+++ b/test/unit/seed-bible/managers/PanesManager.test.ts
@@ -20,13 +20,13 @@ describe("createPanes", () => {
 
       const pane = panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes Component"),
       });
 
       expect(panes.panes.value).toHaveLength(1);
       expect(pane.placement).toBe("floating");
-      expect(pane.title).toBe("Notes");
+      expect(pane.title.value).toBe("Notes");
       expect(pane.component()).toBe("Notes Component");
       expect(panes.selectedPaneId.value).toBe(pane.id);
     });
@@ -36,12 +36,12 @@ describe("createPanes", () => {
 
       const first = panes.openPane({
         placement: "floating",
-        title: "First",
+        title: signal("First"),
         component: componentReturning("First"),
       });
       const second = panes.openPane({
         placement: "floating",
-        title: "Second",
+        title: signal("Second"),
         component: componentReturning("Second"),
       });
 
@@ -63,7 +63,7 @@ describe("createPanes", () => {
 
       const pane = panes.openPane({
         placement: "side",
-        title: "Side Panel",
+        title: signal("Side Panel"),
         component: componentReturning("Side Component"),
       });
 
@@ -76,12 +76,12 @@ describe("createPanes", () => {
 
       const firstSide = panes.openPane({
         placement: "side",
-        title: "First Side",
+        title: signal("First Side"),
         component: componentReturning("First Side"),
       });
       const secondSide = panes.openPane({
         placement: "side",
-        title: "Second Side",
+        title: signal("Second Side"),
         component: componentReturning("Second Side"),
       });
 
@@ -99,17 +99,17 @@ describe("createPanes", () => {
 
       const floating = panes.openPane({
         placement: "floating",
-        title: "Floating",
+        title: signal("Floating"),
         component: componentReturning("Floating"),
       });
       panes.openPane({
         placement: "side",
-        title: "First Side",
+        title: signal("First Side"),
         component: componentReturning("First Side"),
       });
       panes.openPane({
         placement: "side",
-        title: "Second Side",
+        title: signal("Second Side"),
         component: componentReturning("Second Side"),
       });
 
@@ -128,17 +128,17 @@ describe("createPanes", () => {
 
       panes.openPane({
         placement: "floating",
-        title: "Floating",
+        title: signal("Floating"),
         component: componentReturning("Floating"),
       });
       panes.openPane({
         placement: "side",
-        title: "Side",
+        title: signal("Side"),
         component: componentReturning("Side"),
       });
       const fullscreen = panes.openPane({
         placement: "fullscreen",
-        title: "Fullscreen",
+        title: signal("Fullscreen"),
         component: componentReturning("Fullscreen"),
       });
 
@@ -152,12 +152,12 @@ describe("createPanes", () => {
 
       const first = panes.openPane({
         placement: "fullscreen",
-        title: "First",
+        title: signal("First"),
         component: componentReturning("First"),
       });
       const second = panes.openPane({
         placement: "fullscreen",
-        title: "Second",
+        title: signal("Second"),
         component: componentReturning("Second"),
       });
 
@@ -176,26 +176,26 @@ describe("createPanes", () => {
       panes.openPane({
         id: "fullscreen-pane",
         placement: "fullscreen",
-        title: "Fullscreen",
+        title: signal("Fullscreen"),
         component: componentReturning("Fullscreen"),
       });
       // A floating pane opened afterwards coexists with nothing else here.
       panes.openPane({
         placement: "floating",
-        title: "Floating",
+        title: signal("Floating"),
         component: componentReturning("Floating"),
       });
 
       const reused = panes.openPane({
         id: "fullscreen-pane",
         placement: "fullscreen",
-        title: "Fullscreen Updated",
+        title: signal("Fullscreen Updated"),
         component: componentReturning("Fullscreen Updated"),
       });
 
       expect(panes.panes.value).toHaveLength(1);
       expect(panes.panes.value[0]?.id).toBe(reused.id);
-      expect(reused.title).toBe("Fullscreen Updated");
+      expect(reused.title.value).toBe("Fullscreen Updated");
     });
   });
 
@@ -206,12 +206,12 @@ describe("createPanes", () => {
 
       panes.openPane({
         placement: "floating",
-        title: "First",
+        title: signal("First"),
         component: componentReturning("First"),
       });
       const second = panes.openPane({
         placement: "floating",
-        title: "Second",
+        title: signal("Second"),
         component: componentReturning("Second"),
       });
 
@@ -225,7 +225,7 @@ describe("createPanes", () => {
 
       const pane = panes.openPane({
         placement: "floating",
-        title: "Floating",
+        title: signal("Floating"),
         component: componentReturning("Floating"),
       });
 
@@ -241,7 +241,7 @@ describe("createPanes", () => {
       const pane = panes.openPane({
         id: "my-custom-pane",
         placement: "floating",
-        title: "Custom",
+        title: signal("Custom"),
         component: componentReturning("Custom"),
       });
 
@@ -257,19 +257,19 @@ describe("createPanes", () => {
       panes.openPane({
         id: "reusable-pane",
         placement: "floating",
-        title: "First Title",
+        title: signal("First Title"),
         component: componentReturning("First Content"),
       });
 
       const result = panes.openPane({
         id: "reusable-pane",
         placement: "floating",
-        title: "Updated Title",
+        title: signal("Updated Title"),
         component: componentReturning("Updated Content"),
       });
 
       expect(result.id).toBe("reusable-pane");
-      expect(result.title).toBe("Updated Title");
+      expect(result.title.value).toBe("Updated Title");
       expect(result.component()).toBe("Updated Content");
       expect(
         panes.panes.value.filter((pane) => pane.id === "reusable-pane")
@@ -282,14 +282,14 @@ describe("createPanes", () => {
       panes.openPane({
         id: "reusable-pane",
         placement: "side",
-        title: "First Title",
+        title: signal("First Title"),
         component: componentReturning("First Content"),
       });
 
       const result = panes.openPane({
         id: "reusable-pane",
         placement: "floating",
-        title: "Updated Title",
+        title: signal("Updated Title"),
         component: componentReturning("Updated Content"),
       });
 
@@ -304,12 +304,12 @@ describe("createPanes", () => {
       panes.openPane({
         id: "reusable-pane",
         placement: "floating",
-        title: "First",
+        title: signal("First"),
         component: componentReturning("First"),
       });
       const otherPane = panes.openPane({
         placement: "floating",
-        title: "Other",
+        title: signal("Other"),
         component: componentReturning("Other"),
       });
       expect(panes.selectedPaneId.value).toBe(otherPane.id);
@@ -317,7 +317,7 @@ describe("createPanes", () => {
       const result = panes.openPane({
         id: "reusable-pane",
         placement: "floating",
-        title: "Updated",
+        title: signal("Updated"),
         component: componentReturning("Updated"),
       });
 
@@ -331,7 +331,7 @@ describe("createPanes", () => {
 
       const pane = panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
       });
 
@@ -343,7 +343,7 @@ describe("createPanes", () => {
 
       const pane = panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
         header: componentReturning("Header Buttons"),
       });
@@ -358,7 +358,7 @@ describe("createPanes", () => {
       panes.openPane({
         id: "reusable-pane",
         placement: "floating",
-        title: "First",
+        title: signal("First"),
         component: componentReturning("First"),
         header: componentReturning("First Header"),
       });
@@ -366,7 +366,7 @@ describe("createPanes", () => {
       const result = panes.openPane({
         id: "reusable-pane",
         placement: "floating",
-        title: "Second",
+        title: signal("Second"),
         component: componentReturning("Second"),
         header: componentReturning("Second Header"),
       });
@@ -380,7 +380,7 @@ describe("createPanes", () => {
       panes.openPane({
         id: "reusable-pane",
         placement: "floating",
-        title: "First",
+        title: signal("First"),
         component: componentReturning("First"),
         header: componentReturning("First Header"),
       });
@@ -388,7 +388,7 @@ describe("createPanes", () => {
       const result = panes.openPane({
         id: "reusable-pane",
         placement: "floating",
-        title: "Second",
+        title: signal("Second"),
         component: componentReturning("Second"),
       });
 
@@ -401,7 +401,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
       });
 
@@ -423,7 +423,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
       });
 
@@ -439,12 +439,12 @@ describe("createPanes", () => {
       const panes = createPanes();
       const first = panes.openPane({
         placement: "floating",
-        title: "First",
+        title: signal("First"),
         component: componentReturning("First"),
       });
       panes.openPane({
         placement: "floating",
-        title: "Second",
+        title: signal("Second"),
         component: componentReturning("Second"),
       });
 
@@ -457,7 +457,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "floating",
-        title: "First",
+        title: signal("First"),
         component: componentReturning("First"),
       });
 
@@ -470,12 +470,12 @@ describe("createPanes", () => {
       const panes = createPanes();
       const first = panes.openPane({
         placement: "floating",
-        title: "First",
+        title: signal("First"),
         component: componentReturning("First"),
       });
       const second = panes.openPane({
         placement: "floating",
-        title: "Second",
+        title: signal("Second"),
         component: componentReturning("Second"),
       });
       panes.selectPane(first.id);
@@ -489,17 +489,17 @@ describe("createPanes", () => {
       const panes = createPanes();
       panes.openPane({
         placement: "floating",
-        title: "First",
+        title: signal("First"),
         component: componentReturning("First"),
       });
       const second = panes.openPane({
         placement: "floating",
-        title: "Second",
+        title: signal("Second"),
         component: componentReturning("Second"),
       });
       const third = panes.openPane({
         placement: "floating",
-        title: "Third",
+        title: signal("Third"),
         component: componentReturning("Third"),
       });
       panes.selectPane(third.id);
@@ -515,7 +515,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "floating",
-        title: "Only",
+        title: signal("Only"),
         component: componentReturning("Only"),
       });
 
@@ -530,7 +530,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
       });
 
@@ -545,7 +545,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
       });
 
@@ -560,7 +560,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "side",
-        title: "Side",
+        title: signal("Side"),
         component: componentReturning("Side"),
       });
       const originalX = pane.x;
@@ -577,7 +577,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "fullscreen",
-        title: "Full",
+        title: signal("Full"),
         component: componentReturning("Full"),
       });
       const originalX = pane.x;
@@ -596,7 +596,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "side",
-        title: "Side",
+        title: signal("Side"),
         component: componentReturning("Side"),
       });
       const originalHeight = pane.height;
@@ -612,7 +612,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "side",
-        title: "Side",
+        title: signal("Side"),
         component: componentReturning("Side"),
       });
 
@@ -626,7 +626,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
       });
 
@@ -641,7 +641,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
       });
 
@@ -656,7 +656,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const pane = panes.openPane({
         placement: "fullscreen",
-        title: "Full",
+        title: signal("Full"),
         component: componentReturning("Full"),
       });
 
@@ -671,7 +671,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
       });
       const before = panes.panes.value;
@@ -687,7 +687,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       panes.openPane({
         placement: "fullscreen",
-        title: "Full",
+        title: signal("Full"),
         component: componentReturning("Full"),
       });
 
@@ -701,7 +701,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       const floating = panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
       });
 
@@ -717,7 +717,7 @@ describe("createPanes", () => {
       const panes = createPanes(isMobile);
       panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
       });
 
@@ -730,7 +730,7 @@ describe("createPanes", () => {
       const panes = createPanes();
       panes.openPane({
         placement: "floating",
-        title: "Notes",
+        title: signal("Notes"),
         component: componentReturning("Notes"),
       });
       const before = panes.panes.value;

--- a/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
+++ b/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
@@ -439,7 +439,7 @@ describe("createSeedBibleState", () => {
     const state = await createState();
     const pane = state.panes.openPane({
       placement: "side",
-      title: "Test Pane",
+      title: signal("Test Pane"),
       component: () => null,
     });
     const previousSelectedTabId = state.tabs.selectedTabId.value;
@@ -520,7 +520,7 @@ describe("createSeedBibleState", () => {
       const state = await createState();
       const sidePane = state.panes.openPane({
         placement: "side",
-        title: "Side Pane",
+        title: signal("Side Pane"),
         component: () => null,
       });
 
@@ -549,7 +549,7 @@ describe("createSeedBibleState", () => {
       const state = await createState();
       const fullscreenPane = state.panes.openPane({
         placement: "fullscreen",
-        title: "Fullscreen Pane",
+        title: signal("Fullscreen Pane"),
         component: () => null,
       });
 


### PR DESCRIPTION
Fixes #1380.

The settings icon wasn't the standard 3-dot glyph and didn't adapt to dark mode. Fixing it brought to my attention a bigger issue: the icon/title/settings were in the pane content below instead of being in the pane header bar. This PR moves them into the real pane header and removes the duplication.

## Changes

- Scripture Map settings is now a theme-responsive `more_vert` material icon. Matches the existing options menu icon used in the sidebar.
- `Pane`/`PaneOpenOptions`/`PaneHeader` gained an optional `icon`, rendered before the title.
- Scripture map settings button portals into the pane header's `header` slot (it needs live map state that only exists in the pane body's context, so the component stays in the body and just portals its DOM into the header).
- `Pane.title` is now `Signal<string>` instead of `string`, so translated titles stay in sync with language changes instead of freezing at open time. Updated all `openPane` call sites and tests.
- Removed the now-redundant divider/spacing left behind in the content area.

> _Scripture map title and settings button moved to actual panel header bar_
> <img width="895" height="629" alt="image" src="https://github.com/user-attachments/assets/0f0f494c-d93e-4c99-b2f3-8fff4a3c0db3" />

> _Examples of Today screen and Grid portal panes showing that they look as before the changes_
> <img width="890" height="626" alt="image" src="https://github.com/user-attachments/assets/89a6d030-0b52-4eab-803a-a3560ec4a433" />
