### PR TITLE
Fix extension uninstall not syncing across devices (#1454)

### DIFF
--- a/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
@@ -7,6 +7,7 @@ import { safeLocalStorage } from "../app/ssrEnv";
 import {
   getProfileConfigValue,
   saveProfileConfigValue,
+  saveProfileConfigValues,
 } from "./ProfileConfigSync";
 import hash from "hash.js";
 import stringify from "@casual-simulation/fast-json-stable-stringify";
@@ -640,9 +641,20 @@ export function createExtensionManager(
       )
     );
 
-  /** Writes the given installed-extensions sync metadata to the user's profile config. */
-  const writeProfileExtensionsMeta = (meta: InstalledExtensionsMeta) => {
-    saveProfileConfigValue(login, INSTALLED_EXTENSIONS_META_CONFIG_KEY, meta);
+  /**
+   * Writes the given installed-extension IDs and their sync metadata to the
+   * user's profile config in a single write (one `login.updateProfile`
+   * call), rather than one write per key — the two always change together,
+   * so there's no reason for them to reach the server as separate writes.
+   */
+  const writeProfileExtensionState = (
+    ids: Set<string>,
+    meta: InstalledExtensionsMeta
+  ) => {
+    saveProfileConfigValues(login, {
+      [INSTALLED_EXTENSIONS_CONFIG_KEY]: [...ids],
+      [INSTALLED_EXTENSIONS_META_CONFIG_KEY]: meta,
+    });
   };
 
   /**
@@ -679,15 +691,6 @@ export function createExtensionManager(
       return new Set(value.filter((id) => typeof id === "string"));
     }
     return new Set();
-  };
-
-  /**
-   * Writes the given set of installed extension IDs to the user's profile config.
-   * No-ops when logged out or when the value is unchanged (handled by
-   * saveProfileConfigValue).
-   */
-  const writeProfileExtensionIds = (ids: Set<string>) => {
-    saveProfileConfigValue(login, INSTALLED_EXTENSIONS_CONFIG_KEY, [...ids]);
   };
 
   /**
@@ -776,11 +779,10 @@ export function createExtensionManager(
       const profileIds = readProfileExtensionIds();
       if (!profileIds.has(id)) {
         profileIds.add(id);
-        writeProfileExtensionIds(profileIds);
         const profileMeta = readProfileExtensionsMeta();
         profileMeta.installedAtMs[id] = now;
         profileMeta.updatedAtMs = now;
-        writeProfileExtensionsMeta(profileMeta);
+        writeProfileExtensionState(profileIds, profileMeta);
       }
     };
 
@@ -812,11 +814,10 @@ export function createExtensionManager(
     const forgetFromProfile = () => {
       const profileIds = readProfileExtensionIds();
       if (profileIds.delete(id)) {
-        writeProfileExtensionIds(profileIds);
         const profileMeta = readProfileExtensionsMeta();
         delete profileMeta.installedAtMs[id];
         profileMeta.updatedAtMs = now;
-        writeProfileExtensionsMeta(profileMeta);
+        writeProfileExtensionState(profileIds, profileMeta);
       }
     };
 
@@ -1145,8 +1146,7 @@ export function createExtensionManager(
       writePersistedExtensionsMeta(merged.localMeta);
     }
     if (!setsEqual(profileIds, savedIds)) {
-      writeProfileExtensionIds(savedIds);
-      writeProfileExtensionsMeta(merged.profileMeta);
+      writeProfileExtensionState(savedIds, merged.profileMeta);
     }
 
     const promises: Promise<boolean>[] = [];

--- a/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
@@ -391,6 +391,156 @@ function isExtensionModule(value: unknown): value is ExtensionModule {
   );
 }
 
+/**
+ * Per-store metadata for the installed-extensions ID list: when each
+ * currently-installed extension was installed, and when this store's ID list
+ * was last mutated (an install or uninstall). Used by
+ * `mergeInstalledExtensionIds` to tell "this ID is missing because it was
+ * never installed here" apart from "this ID is missing because it was
+ * uninstalled elsewhere after this store last had it" (see #1454) — a plain
+ * union of the two ID sets can't distinguish those, so an uninstall on one
+ * device would keep getting undone by a stale copy on another.
+ */
+export interface InstalledExtensionsMeta {
+  installedAtMs: Record<string, number>;
+  updatedAtMs: number;
+}
+
+export const emptyExtensionsMeta = (): InstalledExtensionsMeta => ({
+  installedAtMs: {},
+  updatedAtMs: 0,
+});
+
+export const parseExtensionsMeta = (
+  value: unknown
+): InstalledExtensionsMeta => {
+  if (
+    value &&
+    typeof value === "object" &&
+    typeof (value as Partial<InstalledExtensionsMeta>).updatedAtMs ===
+      "number" &&
+    typeof (value as Partial<InstalledExtensionsMeta>).installedAtMs ===
+      "object"
+  ) {
+    const raw = (value as InstalledExtensionsMeta).installedAtMs;
+    const installedAtMs: Record<string, number> = {};
+    for (const [id, ts] of Object.entries(raw)) {
+      if (typeof ts === "number") {
+        installedAtMs[id] = ts;
+      }
+    }
+    return {
+      installedAtMs,
+      updatedAtMs: (value as InstalledExtensionsMeta).updatedAtMs,
+    };
+  }
+  return emptyExtensionsMeta();
+};
+
+export interface InstalledExtensionsStoreState {
+  ids: Set<string>;
+  meta: InstalledExtensionsMeta;
+}
+
+export interface MergedInstalledExtensions {
+  ids: Set<string>;
+  localMeta: InstalledExtensionsMeta;
+  profileMeta: InstalledExtensionsMeta;
+}
+
+/**
+ * Merges the installed-extension IDs saved in local storage with the ones
+ * saved in the user's synced profile config.
+ *
+ * A plain union of the two ID sets (the previous behavior) can't tell "never
+ * installed here" apart from "uninstalled elsewhere since this store last had
+ * it" — so an uninstall on one device kept getting silently undone by a stale
+ * copy of the ID on another (#1454). Instead, for an ID that's only on one
+ * side, this compares that side's recorded install time for the ID against
+ * the *other* side's `updatedAtMs` (the last time that store's ID list was
+ * mutated, by any add or remove): if the other side was updated more
+ * recently than this ID was installed, and still doesn't have it, that's
+ * treated as an inferred deletion rather than reinstalled.
+ *
+ * An ID with no recorded install time (e.g. installed before this metadata
+ * existed) is treated as installed "just now" for this comparison rather than
+ * "long ago" — since `updatedAtMs` is a single scalar per store (bumped by
+ * *any* add/remove, not per-extension), treating an unknown install time as
+ * old could cause an unrelated, more recent change on the other side to
+ * wrongly look like this specific ID was deleted there. This falls back to
+ * today's safe adopt-it behavior for such IDs until they're installed or
+ * uninstalled again post-fix, which gives them a real timestamp.
+ */
+export function mergeInstalledExtensionIds(
+  local: InstalledExtensionsStoreState,
+  profile: InstalledExtensionsStoreState,
+  nowMs: number
+): MergedInstalledExtensions {
+  const resultIds = new Set<string>();
+  const localMeta: InstalledExtensionsMeta = {
+    installedAtMs: { ...local.meta.installedAtMs },
+    updatedAtMs: local.meta.updatedAtMs,
+  };
+  const profileMeta: InstalledExtensionsMeta = {
+    installedAtMs: { ...profile.meta.installedAtMs },
+    updatedAtMs: profile.meta.updatedAtMs,
+  };
+
+  const allIds = new Set([...local.ids, ...profile.ids]);
+  for (const id of allIds) {
+    const inLocal = local.ids.has(id);
+    const inProfile = profile.ids.has(id);
+
+    if (inLocal && inProfile) {
+      resultIds.add(id);
+      continue;
+    }
+
+    if (inLocal && !inProfile) {
+      const installedAt = local.meta.installedAtMs[id] ?? Infinity;
+      const profileIsNewer =
+        profile.meta.updatedAtMs > 0 && profile.meta.updatedAtMs >= installedAt;
+      if (profileIsNewer) {
+        // The profile was updated (and still doesn't have this ID) after it
+        // was installed locally — infer it was uninstalled elsewhere.
+        delete localMeta.installedAtMs[id];
+        localMeta.updatedAtMs = nowMs;
+        continue;
+      }
+      // The profile hasn't caught up yet — adopt the local install into it.
+      resultIds.add(id);
+      profileMeta.installedAtMs[id] = Number.isFinite(installedAt)
+        ? installedAt
+        : nowMs;
+      profileMeta.updatedAtMs = nowMs;
+      continue;
+    }
+
+    if (!inLocal && inProfile) {
+      const installedAt = profile.meta.installedAtMs[id] ?? Infinity;
+      const localIsNewer =
+        local.meta.updatedAtMs > 0 && local.meta.updatedAtMs >= installedAt;
+      if (localIsNewer) {
+        delete profileMeta.installedAtMs[id];
+        profileMeta.updatedAtMs = nowMs;
+        continue;
+      }
+      resultIds.add(id);
+      localMeta.installedAtMs[id] = Number.isFinite(installedAt)
+        ? installedAt
+        : nowMs;
+      localMeta.updatedAtMs = nowMs;
+      continue;
+    }
+  }
+
+  return { ids: resultIds, localMeta, profileMeta };
+}
+
+function setsEqual<T>(a: Set<T>, b: Set<T>): boolean {
+  return a.size === b.size && [...a].every((value) => b.has(value));
+}
+
 export function createExtensionManager(
   login: LoginManager,
   options: ExtensionManagerOptions = {}
@@ -445,6 +595,55 @@ export function createExtensionManager(
    * any device the user logs into.
    */
   const INSTALLED_EXTENSIONS_CONFIG_KEY = "installedExtensions";
+
+  const INSTALLED_EXTENSIONS_META_STORAGE_KEY = "sb-installed-extensions-meta";
+
+  /** Reads the installed-extensions sync metadata from local storage. */
+  const readPersistedExtensionsMeta = (): InstalledExtensionsMeta => {
+    try {
+      const raw = safeLocalStorage.getItem(
+        INSTALLED_EXTENSIONS_META_STORAGE_KEY
+      );
+      if (!raw) {
+        return emptyExtensionsMeta();
+      }
+      return parseExtensionsMeta(JSON.parse(raw));
+    } catch (err) {
+      console.error(
+        "Failed to read persisted installed-extensions metadata:",
+        err
+      );
+      return emptyExtensionsMeta();
+    }
+  };
+
+  /** Writes the given installed-extensions sync metadata to local storage. */
+  const writePersistedExtensionsMeta = (meta: InstalledExtensionsMeta) => {
+    try {
+      safeLocalStorage.setItem(
+        INSTALLED_EXTENSIONS_META_STORAGE_KEY,
+        JSON.stringify(meta)
+      );
+    } catch (err) {
+      console.error("Failed to persist installed-extensions metadata:", err);
+    }
+  };
+
+  const INSTALLED_EXTENSIONS_META_CONFIG_KEY = "installedExtensionsMeta";
+
+  /** Reads the installed-extensions sync metadata from the user's profile config. */
+  const readProfileExtensionsMeta = (): InstalledExtensionsMeta =>
+    parseExtensionsMeta(
+      getProfileConfigValue(
+        login.profile.value,
+        INSTALLED_EXTENSIONS_META_CONFIG_KEY
+      )
+    );
+
+  /** Writes the given installed-extensions sync metadata to the user's profile config. */
+  const writeProfileExtensionsMeta = (meta: InstalledExtensionsMeta) => {
+    saveProfileConfigValue(login, INSTALLED_EXTENSIONS_META_CONFIG_KEY, meta);
+  };
 
   /**
    * Waits for an in-flight profile load to settle, if the user is logged in
@@ -559,10 +758,15 @@ export function createExtensionManager(
 
   /** Records that the extension with the given ID has been installed. */
   const persistInstalledExtensionId = (id: string): void | Promise<void> => {
+    const now = Date.now();
     const ids = readPersistedExtensionIds();
     if (!ids.has(id)) {
       ids.add(id);
       writePersistedExtensionIds(ids);
+      const localMeta = readPersistedExtensionsMeta();
+      localMeta.installedAtMs[id] = now;
+      localMeta.updatedAtMs = now;
+      writePersistedExtensionsMeta(localMeta);
     }
 
     // Mirror the install into the user's profile config so it follows them
@@ -573,6 +777,10 @@ export function createExtensionManager(
       if (!profileIds.has(id)) {
         profileIds.add(id);
         writeProfileExtensionIds(profileIds);
+        const profileMeta = readProfileExtensionsMeta();
+        profileMeta.installedAtMs[id] = now;
+        profileMeta.updatedAtMs = now;
+        writeProfileExtensionsMeta(profileMeta);
       }
     };
 
@@ -591,15 +799,24 @@ export function createExtensionManager(
 
   /** Removes the extension with the given ID from the persisted set. */
   const forgetInstalledExtensionId = (id: string): void | Promise<void> => {
+    const now = Date.now();
     const ids = readPersistedExtensionIds();
     if (ids.delete(id)) {
       writePersistedExtensionIds(ids);
+      const localMeta = readPersistedExtensionsMeta();
+      delete localMeta.installedAtMs[id];
+      localMeta.updatedAtMs = now;
+      writePersistedExtensionsMeta(localMeta);
     }
 
     const forgetFromProfile = () => {
       const profileIds = readProfileExtensionIds();
       if (profileIds.delete(id)) {
         writeProfileExtensionIds(profileIds);
+        const profileMeta = readProfileExtensionsMeta();
+        delete profileMeta.installedAtMs[id];
+        profileMeta.updatedAtMs = now;
+        writeProfileExtensionsMeta(profileMeta);
       }
     };
 
@@ -896,27 +1113,40 @@ export function createExtensionManager(
   };
 
   /**
-   * Loads the extensions that the user previously installed. The saved set is
-   * the union of the IDs persisted in local storage and the IDs stored in the
-   * logged-in user's profile config — so extensions installed while logged out
-   * are adopted into the account, and extensions installed on another device are
-   * installed here. The merged set is written back to both stores. Extensions
-   * that are already installed are skipped, and IDs that are not part of any
-   * known extension set are left in storage (a later build may reintroduce them)
-   * but skipped for now.
+   * Loads the extensions that the user previously installed. The saved set
+   * merges the IDs persisted in local storage with the IDs stored in the
+   * logged-in user's profile config via `mergeInstalledExtensionIds` — so
+   * extensions installed while logged out are adopted into the account,
+   * extensions installed on another device are installed here, and an
+   * extension uninstalled on another device (which already reached the
+   * profile) is not resurrected by a stale local copy, or vice versa (#1454).
+   * The merged set and its sync metadata are written back to whichever
+   * store(s) changed. Extensions that are already installed are skipped, and
+   * IDs that are not part of any known extension set are left in storage (a
+   * later build may reintroduce them) but skipped for now.
    */
   const loadSavedExtensions = async () => {
     await awaitProfileLoaded();
     const localIds = readPersistedExtensionIds();
     const profileIds = readProfileExtensionIds();
-    const savedIds = new Set([...localIds, ...profileIds]);
+    const localMeta = readPersistedExtensionsMeta();
+    const profileMeta = readProfileExtensionsMeta();
 
-    // Write the merged set back to both stores so the two stay in sync.
-    if (savedIds.size !== localIds.size) {
+    const merged = mergeInstalledExtensionIds(
+      { ids: localIds, meta: localMeta },
+      { ids: profileIds, meta: profileMeta },
+      Date.now()
+    );
+    const savedIds = merged.ids;
+
+    // Write back to whichever store(s) the merge actually changed.
+    if (!setsEqual(localIds, savedIds)) {
       writePersistedExtensionIds(savedIds);
+      writePersistedExtensionsMeta(merged.localMeta);
     }
-    if (savedIds.size !== profileIds.size) {
+    if (!setsEqual(profileIds, savedIds)) {
       writeProfileExtensionIds(savedIds);
+      writeProfileExtensionsMeta(merged.profileMeta);
     }
 
     const promises: Promise<boolean>[] = [];

--- a/packages/seed-bible/seed-bible/managers/ProfileConfigSync.tsx
+++ b/packages/seed-bible/seed-bible/managers/ProfileConfigSync.tsx
@@ -20,20 +20,68 @@ export function getProfileConfigValue(
 }
 
 /**
- * Persists a single config key to the logged-in user's profile, merging
- * with the existing profile.config so other keys aren't clobbered. No-ops
- * if the user isn't authenticated or the value matches what's already saved.
+ * For object/array values, deep-equality would be ideal but JSON.stringify
+ * is sufficient here since config values are always written as
+ * parsed/normalized shapes.
+ */
+function isEqualConfigValue(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (
+    typeof a === "object" &&
+    a !== null &&
+    typeof b === "object" &&
+    b !== null
+  ) {
+    try {
+      return JSON.stringify(a) === JSON.stringify(b);
+    } catch {
+      return false;
+    }
+  }
+  return false;
+}
+
+/**
+ * Persists a single config key to the logged-in user's profile. Thin wrapper
+ * around `saveProfileConfigValues` for the common single-key case — see
+ * there for the merge/no-op/profile-load-guard behavior.
+ */
+export async function saveProfileConfigValue(
+  login: LoginManager,
+  key: string,
+  value: unknown
+): Promise<void> {
+  return saveProfileConfigValues(login, { [key]: value });
+}
+
+/**
+ * Persists multiple config keys to the logged-in user's profile in a single
+ * write, merging with the existing profile.config so other keys aren't
+ * clobbered. No-ops if the user isn't authenticated, the profile hasn't
+ * loaded yet, or none of the given values differ from what's already saved.
+ * Keys whose value is unchanged are left out of the write; if every key is
+ * unchanged, no write happens at all.
  *
  * Also no-ops while `login.profile` hasn't loaded yet. `profile` is fetched
  * asynchronously after login, so a null profile while `userId` is set means
  * the fetch is still in flight — not that the profile is empty. Writing in
  * that window would save a bare `{ name: "" }` profile and permanently wipe
  * whatever was actually stored on the account once the write lands.
+ *
+ * When the profile has already loaded, this runs synchronously up to (and
+ * including) the `login.updateProfile` call — no `await` is evaluated on
+ * that path — so callers that don't await this still observe the write
+ * within the same tick. Only awaits when a profile load is actually pending.
+ *
+ * Use this (instead of multiple `saveProfileConfigValue` calls) whenever
+ * several config keys must always land together — writing them one at a
+ * time would call `login.updateProfile` once per key instead of once total.
  */
-export async function saveProfileConfigValue(
+export async function saveProfileConfigValues(
   login: LoginManager,
-  key: string,
-  value: unknown
+  values: Record<string, unknown>
 ): Promise<void> {
   if (!login.userId.value) {
     return;
@@ -53,7 +101,7 @@ export async function saveProfileConfigValue(
 
     if (!login.profile.value) {
       console.warn(
-        "Cannot save profile config value: profile has not loaded yet"
+        "Cannot save profile config value(s): profile has not loaded yet"
       );
       return;
     }
@@ -65,31 +113,18 @@ export async function saveProfileConfigValue(
       ? (existingProfile.config as Record<string, unknown>)
       : {};
 
-  if (existingConfig[key] === value) {
-    return;
-  }
+  const changedEntries = Object.entries(values).filter(
+    ([key, value]) => !isEqualConfigValue(existingConfig[key], value)
+  );
 
-  // For object/array values, deep-equality would be ideal but JSON.stringify
-  // is sufficient here since we always write parsed/normalized shapes.
-  if (
-    typeof value === "object" &&
-    value !== null &&
-    typeof existingConfig[key] === "object" &&
-    existingConfig[key] !== null
-  ) {
-    try {
-      if (JSON.stringify(existingConfig[key]) === JSON.stringify(value)) {
-        return;
-      }
-    } catch {
-      // Fall through and write anyway.
-    }
+  if (changedEntries.length === 0) {
+    return;
   }
 
   login.updateProfile({
     config: {
       ...existingConfig,
-      [key]: value,
+      ...Object.fromEntries(changedEntries),
     },
   });
 }

--- a/test/unit/seed-bible/managers/ExtensionManager.test.ts
+++ b/test/unit/seed-bible/managers/ExtensionManager.test.ts
@@ -12,8 +12,10 @@ vi.mock("@packages/seed-bible/seed-bible/i18n/I18nManager", () => ({
 import {
   createExtensionManager,
   ExtensionInitalizer,
+  mergeInstalledExtensionIds,
   registerExtension,
   type ExtensionSet,
+  type InstalledExtensionsMeta,
 } from "@packages/seed-bible/seed-bible/managers/ExtensionManager";
 import type { Mock } from "vitest";
 
@@ -1634,6 +1636,79 @@ describe("createExtensionManager", () => {
     ]);
   });
 
+  it("does not reinstall an extension that was uninstalled on another device, and propagates the uninstall to a stale local cache (regression for #1454)", async () => {
+    const crossDeviceExtension = {
+      url: "pkg://cross-device",
+      meta: {
+        id: "ext.cross-device",
+        translations: {
+          en: { title: "Cross Device", description: "Cross Device" },
+        },
+      },
+    };
+    const extensionSet: ExtensionSet = {
+      id: "set.cross-device",
+      extensions: [crossDeviceExtension],
+    };
+    mockExtensionModule("pkg://cross-device");
+
+    // Device A: install the extension while logged in. This writes the ID
+    // and its install-time metadata to both local storage and the profile.
+    login = createTestLogin({
+      userId: "user-1",
+      profile: { name: "Test" } as UserProfile,
+    });
+    const deviceA = createExtensionManager(login, {
+      defaultExtensions: extensionSet,
+    });
+    await deviceA.loadExtension(crossDeviceExtension);
+    expect(getProfileInstalled(login)).toEqual(["ext.cross-device"]);
+
+    // Device B: simulate having earlier pulled the profile down and cached
+    // the extension in its own (separate) local storage — captured here,
+    // before device A's uninstall below changes the profile.
+    const deviceBLocalIds = localStorage.getItem("sb-installed-extensions");
+    const deviceBLocalMeta = localStorage.getItem(
+      "sb-installed-extensions-meta"
+    );
+
+    // Device A: uninstall the extension. This removes it — and bumps the
+    // sync metadata — on both local storage and the profile.
+    deviceA.unloadExtension("ext.cross-device");
+    expect(getProfileInstalled(login)).toEqual([]);
+
+    // Switch the shared local storage to device B's stale, pre-uninstall
+    // snapshot, and boot a fresh manager for it (same account/profile, since
+    // the profile is the synced, server-side source of truth both devices
+    // read from).
+    localStorage.setItem("sb-installed-extensions", deviceBLocalIds ?? "[]");
+    if (deviceBLocalMeta) {
+      localStorage.setItem("sb-installed-extensions-meta", deviceBLocalMeta);
+    }
+    const deviceB = createExtensionManager(login, {
+      defaultExtensions: extensionSet,
+    });
+
+    // Reset the load log — it already recorded device A's earlier install —
+    // so it only reflects what device B's own sync does.
+    loadedModules.length = 0;
+    await deviceB.loadSavedExtensions();
+
+    // Device B must NOT resurrect the extension...
+    expect(loadedModules).toEqual([]);
+    expect(
+      deviceB.getExtensions().find((e) => e.id === "ext.cross-device")
+        ?.installed
+    ).toBeFalsy();
+    // ...and must NOT write it back into the profile, undoing device A's
+    // uninstall for every other device.
+    expect(getProfileInstalled(login)).toEqual([]);
+    // Device B's own stale cache is corrected to match.
+    expect(
+      JSON.parse(localStorage.getItem("sb-installed-extensions") ?? "[]")
+    ).toEqual([]);
+  });
+
   it("does not wipe the profile when the boot-time extension sync races the profile load (regression for #1318)", async () => {
     localStorage.setItem(
       "sb-installed-extensions",
@@ -1774,7 +1849,113 @@ describe("createExtensionManager", () => {
 
     // This is the actual bug report (#1357): loading the app was writing the
     // profile repeatedly with no user action. Merging both extensions should
-    // take exactly one write, not one per extension racing the profile load.
-    expect(updateProfileSpy).toHaveBeenCalledTimes(1);
+    // take exactly one write per config key, not one per extension racing
+    // the profile load. There are two calls (not one) because the #1454 fix
+    // added a second config key (`installedExtensionsMeta`, the per-extension
+    // install-time bookkeeping) alongside the existing `installedExtensions`
+    // ID list — each is written once, not once per extension.
+    expect(updateProfileSpy).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("mergeInstalledExtensionIds()", () => {
+  const meta = (
+    overrides: Partial<InstalledExtensionsMeta> = {}
+  ): InstalledExtensionsMeta => ({
+    installedAtMs: {},
+    updatedAtMs: 0,
+    ...overrides,
+  });
+
+  it("keeps an ID that's installed on both sides", () => {
+    const result = mergeInstalledExtensionIds(
+      {
+        ids: new Set(["ext.a"]),
+        meta: meta({ installedAtMs: { "ext.a": 100 }, updatedAtMs: 100 }),
+      },
+      {
+        ids: new Set(["ext.a"]),
+        meta: meta({ installedAtMs: { "ext.a": 100 }, updatedAtMs: 100 }),
+      },
+      200
+    );
+
+    expect([...result.ids]).toEqual(["ext.a"]);
+  });
+
+  it("adopts a local-only install into the profile when the profile hasn't caught up yet", () => {
+    const result = mergeInstalledExtensionIds(
+      {
+        ids: new Set(["ext.a"]),
+        meta: meta({ installedAtMs: { "ext.a": 100 }, updatedAtMs: 100 }),
+      },
+      { ids: new Set(), meta: meta() },
+      200
+    );
+
+    expect([...result.ids]).toEqual(["ext.a"]);
+    expect(result.profileMeta.installedAtMs["ext.a"]).toBe(100);
+  });
+
+  it("adopts a profile-only install into local storage when local hasn't caught up yet", () => {
+    const result = mergeInstalledExtensionIds(
+      { ids: new Set(), meta: meta() },
+      {
+        ids: new Set(["ext.a"]),
+        meta: meta({ installedAtMs: { "ext.a": 100 }, updatedAtMs: 100 }),
+      },
+      200
+    );
+
+    expect([...result.ids]).toEqual(["ext.a"]);
+    expect(result.localMeta.installedAtMs["ext.a"]).toBe(100);
+  });
+
+  it("infers a local-only extension was uninstalled elsewhere when the profile was updated after it was installed locally (core #1454 repro)", () => {
+    // Device A installs X, device B's stale local cache still has it, but
+    // device A already uninstalled X from the profile after B's cached copy
+    // was installed — the profile's `updatedAtMs` (300) is newer than B's
+    // recorded install time for X (100), and the profile doesn't have X.
+    const result = mergeInstalledExtensionIds(
+      {
+        ids: new Set(["ext.x"]),
+        meta: meta({ installedAtMs: { "ext.x": 100 }, updatedAtMs: 100 }),
+      },
+      { ids: new Set(), meta: meta({ updatedAtMs: 300 }) },
+      400
+    );
+
+    expect([...result.ids]).toEqual([]);
+    expect(result.localMeta.installedAtMs["ext.x"]).toBeUndefined();
+  });
+
+  it("infers a profile-only extension was uninstalled locally when local was updated after it was installed on the profile (symmetric case)", () => {
+    const result = mergeInstalledExtensionIds(
+      { ids: new Set(), meta: meta({ updatedAtMs: 300 }) },
+      {
+        ids: new Set(["ext.x"]),
+        meta: meta({ installedAtMs: { "ext.x": 100 }, updatedAtMs: 100 }),
+      },
+      400
+    );
+
+    expect([...result.ids]).toEqual([]);
+    expect(result.profileMeta.installedAtMs["ext.x"]).toBeUndefined();
+  });
+
+  it("does not infer a deletion for an ID with no recorded install time, even if the other side was updated more recently", () => {
+    // Legacy data from before this metadata existed (or any ID with an
+    // untracked install time) must never be treated as deleted just because
+    // the other store's single `updatedAtMs` scalar (bumped by *any*
+    // unrelated add/remove) happens to be more recent — that scalar isn't
+    // per-extension, so there's no real evidence this specific ID was
+    // actually removed. Falls back to the pre-fix adopt behavior instead.
+    const result = mergeInstalledExtensionIds(
+      { ids: new Set(["ext.legacy"]), meta: meta() },
+      { ids: new Set(), meta: meta({ updatedAtMs: 300 }) },
+      400
+    );
+
+    expect([...result.ids]).toEqual(["ext.legacy"]);
   });
 });

--- a/test/unit/seed-bible/managers/ExtensionManager.test.ts
+++ b/test/unit/seed-bible/managers/ExtensionManager.test.ts
@@ -1849,12 +1849,12 @@ describe("createExtensionManager", () => {
 
     // This is the actual bug report (#1357): loading the app was writing the
     // profile repeatedly with no user action. Merging both extensions should
-    // take exactly one write per config key, not one per extension racing
-    // the profile load. There are two calls (not one) because the #1454 fix
-    // added a second config key (`installedExtensionsMeta`, the per-extension
-    // install-time bookkeeping) alongside the existing `installedExtensions`
-    // ID list — each is written once, not once per extension.
-    expect(updateProfileSpy).toHaveBeenCalledTimes(2);
+    // take exactly one write, not one per extension racing the profile load.
+    // The #1454 fix added a second config key (`installedExtensionsMeta`,
+    // the per-extension install-time bookkeeping) that's always written
+    // alongside `installedExtensions`, via `saveProfileConfigValues` — both
+    // keys land in the same `updateProfile` call, so this is still 1.
+    expect(updateProfileSpy).toHaveBeenCalledTimes(1);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes a bug where uninstalling an extension on one device would be silently undone by a stale copy on another device. The root cause: the extension sync logic used a simple union of local and profile IDs, which couldn't distinguish "never installed here" from "uninstalled elsewhere after we last synced."

## Changes

**New metadata tracking for extension installs:**
- Added `InstalledExtensionsMeta` interface to track per-extension install timestamps (`installedAtMs`) and when each store's ID list was last mutated (`updatedAtMs`)
- Persists metadata to local storage (`sb-installed-extensions-meta`) and user profile config (`installedExtensionsMeta`)
- Metadata is read/written alongside extension IDs to keep them in sync

**Smart merge logic (`mergeInstalledExtensionIds`):**
- When an extension ID exists on only one side, compares that side's install time against the *other* side's `updatedAtMs` (last mutation time)
- If the other side was updated *after* this ID was installed, and still doesn't have it, treats it as an inferred deletion rather than a stale copy to resurrect
- IDs with no recorded install time (legacy data) are treated as "just now" to avoid false deletions from unrelated, more recent changes on the other side — falls back to safe adopt behavior until they're installed/uninstalled again post-fix

**Consolidated profile writes:**
- Replaced `writeProfileExtensionIds` with `writeProfileExtensionState`, which writes both IDs and metadata in a single `login.updateProfile` call
- Added `saveProfileConfigValues` to write multiple config keys atomically (both keys always change together, so no reason for separate writes)

**Updated sync flow:**
- `persistInstalledExtensionId` and `forgetInstalledExtensionId` now update metadata timestamps on both local and profile stores
- `loadSavedExtensions` uses `mergeInstalledExtensionIds` instead of a simple union, and only writes back to stores that actually changed

## Implementation Details

- Metadata is optional for backward compatibility: missing timestamps are treated as "just now" rather than "long ago"
- The `updatedAtMs` scalar per store (bumped by *any* add/remove) is intentionally not per-extension — this prevents an unrelated, more recent change on one device from wrongly inferring deletion of an untracked ID on another
- All metadata reads/writes are wrapped in try-catch to gracefully degrade if storage fails
- Test coverage includes the core #1454 regression (uninstall on device A not resurrected by stale cache on device B) and edge cases (legacy data, symmetric cases)

Fixes #1454

https://claude.ai/code/session_01S6HJ1JDMfdsYPBtnBifjMR