### PR TITLE
fix: keep chat panel open when picking a provider from portaled menu

### DIFF
--- a/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.tsx
+++ b/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.tsx
@@ -734,6 +734,11 @@ export function FloatingChatPanel(props: FloatingReaderPanelsProps) {
       if (!target) return;
       if (target.closest(".sb-floating-chat-panel")) return;
       if (target.closest(".sb-reader-toolbar")) return;
+      // Context menus (e.g. the "new chat" provider list) are portaled to
+      // <body>, so they live outside `.sb-floating-chat-panel` in the DOM even
+      // though they're part of this panel's UI. Ignore taps inside them so
+      // picking a provider doesn't close the panel out from under the click.
+      if (target.closest(".sb-context-menu")) return;
       sidebar.closeChatPanel();
     };
 


### PR DESCRIPTION
The floating chat panel closes itself on any pointerdown outside
`.sb-floating-chat-panel`. Since the context-menu clipping fix, the
"new chat" provider list (and the header members menu) render through a
`<body>`-level portal, so tapping the Apologist provider registered as
an outside click and closed the panel before the item's onClick could
select the newly created chat.

Ignore pointerdowns that land inside a `.sb-context-menu`, which are
portaled but logically part of the panel's UI.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CB7xkxfC5PpqXR5HsunBcG