### PR TITLE
feat: add sitemap generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "test": "vitest",
     "test:watch": "vitest watch",
     "dev": "bun server/index.ts",
-    "build": "pnpm build:client && pnpm build:ssr && pnpm build:server",
+    "build": "pnpm build:client && pnpm build:ssr && pnpm build:server && pnpm sitemap",
     "build:client": "vite build",
     "build:ssr": "vite build --ssr standalone/entry-ssr.tsx",
     "build:server": "bun build --target=bun --external express --external vite --outfile=server/dist/index.js ./server/index.ts",
@@ -22,6 +22,7 @@
     "build-size-report": "tsx script/build-size-report.ts",
     "i18n": "tsx script/i18n.ts",
     "list-bible-translations": "tsx script/list-bible-translations.ts",
+    "sitemap": "tsx script/generate-sitemap.ts",
     "format": "prettier --write \"packages/**/*.{js,jsx,ts,tsx,css}\"",
     "format:changed": "pretty-quick",
     "prepare": "husky && tsx script/setupMergeDriver.ts"

--- a/packages/seed-bible/seed-bible/managers/BibleReadingManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/BibleReadingManager.tsx
@@ -427,7 +427,7 @@ const FALLBACK_TRANSLATION: TranslationWithLanguage = {
  * Includes aliases so we can match the nearest available text even when the
  * preferred hardcoded ID is missing from the loaded catalog.
  */
-const UI_TO_BIBLE_LANGUAGE_CODES: Record<string, string[]> = {
+export const UI_TO_BIBLE_LANGUAGE_CODES: Record<string, string[]> = {
   am: ["amh"],
   ar: ["arb", "ara"],
   bn: ["ben"],

--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -887,6 +887,18 @@ export function createSeedBibleState(
       canonicalUrl.searchParams.set("chapter", String(chapter.chapter.number));
     }
 
+    // Preserve an explicit `?lang=` so the canonical is self-referential for
+    // the language-specific URLs the sitemap emits (otherwise search engines
+    // collapse every `?lang=` variant onto the lang-less URL and none of them
+    // index distinctly). Echo only the explicit URL param — deriving it from
+    // the active i18n language would make the canonical vary by
+    // Accept-Language, which must not happen. Set last to match the sitemap's
+    // `translation,book,chapter,lang` ordering.
+    const lang = currentUrl.searchParams.get("lang");
+    if (lang) {
+      canonicalUrl.searchParams.set("lang", lang);
+    }
+
     return `${canonicalUrl.pathname}${canonicalUrl.search}`;
   });
 

--- a/script/generate-sitemap.ts
+++ b/script/generate-sitemap.ts
@@ -1,0 +1,358 @@
+/**
+ * Generates the Seed Bible sitemap: one child sitemap per translation (every
+ * chapter of every book) plus a sitemap index and a robots.txt.
+ *
+ * Each chapter URL carries the UI locale (`?lang=`) that maps to the
+ * translation's Bible language — Spanish translations get the Spanish UI,
+ * English translations the English UI — so we never emit the full
+ * translation × every-UI-language cross product. Translations in a language
+ * with no supported UI locale are still listed, but without `?lang=` (the app
+ * then resolves the visitor's language). Pass `--mapped-only` to emit only
+ * translations that map to a supported UI locale.
+ *
+ * Output lands in the client build directory (`standalone/dist/client/` by
+ * default), which the CD workflow's main-only sync uploads to the bucket root;
+ * the host server already reverse-proxies `.xml`/`.txt` requests to the CDN, so
+ * `/sitemap.xml`, `/sitemaps/*.xml`, and `/robots.txt` are served with no extra
+ * server route.
+ *
+ * The Bible catalog is external, so the run is best-effort: a fetch failure
+ * logs a warning and exits 0 (so a deploy is never blocked) unless `--strict`
+ * is passed.
+ *
+ * Usage:
+ *   pnpm sitemap
+ *   pnpm sitemap --base-url=https://prod.seedbible.org --endpoint=https://bible.helloao.org/
+ *   pnpm sitemap --mapped-only --strict --out=standalone/dist/client
+ */
+import { mkdir, rm, writeFile } from "node:fs/promises";
+import path from "node:path";
+import {
+  FreeUseBibleAPI,
+  getDefaultAPIEndpoint,
+  type Translation,
+} from "@packages/seed-bible/seed-bible/managers/FreeUseBibleAPI";
+import {
+  bibleLanguageToUiLocale,
+  chapterUrlsForTranslation,
+  chunk,
+  renderSitemapIndex,
+  renderUrlset,
+  uniqueSitemapName,
+  MAX_URLS_PER_SITEMAP,
+  type BookChapters,
+  type SitemapIndexEntry,
+} from "./lib/sitemap";
+
+const DEFAULT_ORIGIN = "https://prod.seedbible.org";
+const DEFAULT_OUT_DIR = path.join("standalone", "dist", "client");
+const SITEMAPS_SUBDIR = "sitemaps";
+const DEFAULT_CONCURRENCY = 8;
+
+interface Options {
+  origin: string;
+  endpoint: string;
+  outDir: string;
+  mappedOnly: boolean;
+  strict: boolean;
+  concurrency: number;
+}
+
+function parseArgValue(flag: string): string | null {
+  const prefix = `${flag}=`;
+  const arg = process.argv.find((value) => value.startsWith(prefix));
+  return arg ? arg.slice(prefix.length) : null;
+}
+
+function hasFlag(flag: string): boolean {
+  return process.argv.includes(flag);
+}
+
+function printUsage(): void {
+  console.log(
+    "Usage: pnpm sitemap [--base-url=<origin>] [--endpoint=<url>] [--out=<dir>] [--mapped-only] [--strict] [--concurrency=<n>]"
+  );
+  console.log("");
+  console.log("Defaults:");
+  console.log(`  --base-url   ${DEFAULT_ORIGIN} (or SITE_ORIGIN)`);
+  console.log(
+    "  --endpoint   the production default Bible API (or BIBLE_API_ENDPOINT)"
+  );
+  console.log(`  --out        ${DEFAULT_OUT_DIR}`);
+  console.log(`  --concurrency ${DEFAULT_CONCURRENCY}`);
+}
+
+function resolveOptions(): Options {
+  const origin = (
+    parseArgValue("--base-url") ??
+    process.env.SITE_ORIGIN ??
+    DEFAULT_ORIGIN
+  ).trim();
+
+  // Mirror the app: no `useFreeBibleAPI` param → the private production mirror,
+  // so translation IDs in the sitemap match what the live site serves.
+  const endpoint = (
+    parseArgValue("--endpoint") ??
+    process.env.BIBLE_API_ENDPOINT ??
+    getDefaultAPIEndpoint(new URL(origin))
+  ).trim();
+
+  const outDir = (parseArgValue("--out") ?? DEFAULT_OUT_DIR).trim();
+
+  const concurrencyRaw = parseArgValue("--concurrency");
+  const concurrency = concurrencyRaw
+    ? Math.max(1, Number.parseInt(concurrencyRaw, 10) || DEFAULT_CONCURRENCY)
+    : DEFAULT_CONCURRENCY;
+
+  return {
+    origin,
+    endpoint,
+    outDir,
+    mappedOnly: hasFlag("--mapped-only"),
+    strict: hasFlag("--strict"),
+    concurrency,
+  };
+}
+
+/**
+ * On CI, only the `main` build's public files are synced to the bucket root, so
+ * generating on other branch builds just hammers the Bible API for output that
+ * is never uploaded. Skip those. Local runs (no DEPLOY_BRANCH) always run.
+ */
+function shouldSkipForBranch(): string | null {
+  const branch = process.env.DEPLOY_BRANCH?.trim();
+  if (branch && branch !== "main") {
+    return branch;
+  }
+  return null;
+}
+
+interface TranslationSitemap {
+  translationId: string;
+  urls: string[];
+}
+
+/** Runs `worker` over `items` with at most `limit` in flight at once. */
+async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  async function run(): Promise<void> {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) {
+        return;
+      }
+      results[index] = await worker(items[index]!, index);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () =>
+    run()
+  );
+  await Promise.all(workers);
+  return results;
+}
+
+async function buildTranslationSitemap(
+  api: FreeUseBibleAPI,
+  origin: string,
+  translation: Translation,
+  mappedOnly: boolean
+): Promise<TranslationSitemap | null> {
+  const uiLocale = bibleLanguageToUiLocale(translation.language);
+  if (mappedOnly && !uiLocale) {
+    return null;
+  }
+
+  let books: BookChapters[];
+  try {
+    const response = await api.getTranslationBooks(translation.id);
+    books = response.books.map((book) => ({
+      bookId: book.id,
+      firstChapterNumber: book.firstChapterNumber,
+      numberOfChapters: book.numberOfChapters,
+    }));
+  } catch (error) {
+    console.warn(
+      `  ! Skipping ${translation.id} (${translation.language}): failed to load books — ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return null;
+  }
+
+  const urls = chapterUrlsForTranslation(
+    origin,
+    translation.id,
+    uiLocale,
+    books
+  );
+  if (urls.length === 0) {
+    return null;
+  }
+
+  return { translationId: translation.id, urls };
+}
+
+async function generate(options: Options): Promise<void> {
+  const { origin, endpoint, outDir } = options;
+
+  console.log(`Origin:      ${origin}`);
+  console.log(`Endpoint:    ${endpoint}`);
+  console.log(`Output:      ${outDir}`);
+  console.log(`Mapped only: ${options.mappedOnly}`);
+  console.log("");
+
+  const api = new FreeUseBibleAPI(endpoint);
+  const { translations } = await api.getAvailableTranslations();
+  console.log(`Fetched ${translations.length} translations.`);
+
+  const built = await mapWithConcurrency(
+    translations,
+    options.concurrency,
+    (translation) =>
+      buildTranslationSitemap(api, origin, translation, options.mappedOnly)
+  );
+
+  const sitemaps = built.filter(
+    (entry): entry is TranslationSitemap => entry !== null
+  );
+
+  if (sitemaps.length === 0) {
+    throw new Error(
+      "No translation sitemaps could be built (every translation failed or was filtered out)."
+    );
+  }
+
+  // Write fresh: clear any stale child sitemaps from a previous run.
+  const sitemapsDir = path.join(outDir, SITEMAPS_SUBDIR);
+  await rm(sitemapsDir, { recursive: true, force: true });
+  await mkdir(sitemapsDir, { recursive: true });
+
+  const usedNames = new Set<string>();
+  const indexEntries: SitemapIndexEntry[] = [];
+  const lastmod = new Date().toISOString().slice(0, 10);
+  let totalUrls = 0;
+
+  for (const sitemap of sitemaps) {
+    totalUrls += sitemap.urls.length;
+    // A single translation is well under the 50k cap, but chunk defensively so
+    // any file we emit stays spec-compliant.
+    const parts = chunk(sitemap.urls, MAX_URLS_PER_SITEMAP);
+    const multi = parts.length > 1;
+
+    for (let i = 0; i < parts.length; i++) {
+      const suffix = multi ? `-${i + 1}` : "";
+      const name = uniqueSitemapName(
+        `${sitemap.translationId}${suffix}`,
+        usedNames
+      );
+      const fileName = `${name}.xml`;
+      await writeFile(
+        path.join(sitemapsDir, fileName),
+        renderUrlset(parts[i]!),
+        "utf-8"
+      );
+      indexEntries.push({
+        loc: `${trimTrailingSlash(origin)}/${SITEMAPS_SUBDIR}/${fileName}`,
+        lastmod,
+      });
+    }
+  }
+
+  // The index itself must also stay under the 50k-entry cap.
+  const indexChunks = chunk(indexEntries, MAX_URLS_PER_SITEMAP);
+  if (indexChunks.length <= 1) {
+    await writeFile(
+      path.join(outDir, "sitemap.xml"),
+      renderSitemapIndex(indexEntries),
+      "utf-8"
+    );
+  } else {
+    // Fan out into sitemap-1.xml … and a root index-of-indexes.
+    const rootEntries: SitemapIndexEntry[] = [];
+    for (let i = 0; i < indexChunks.length; i++) {
+      const fileName = `sitemap-${i + 1}.xml`;
+      await writeFile(
+        path.join(outDir, fileName),
+        renderSitemapIndex(indexChunks[i]!),
+        "utf-8"
+      );
+      rootEntries.push({
+        loc: `${trimTrailingSlash(origin)}/${fileName}`,
+        lastmod,
+      });
+    }
+    await writeFile(
+      path.join(outDir, "sitemap.xml"),
+      renderSitemapIndex(rootEntries),
+      "utf-8"
+    );
+  }
+
+  await writeFile(
+    path.join(outDir, "robots.txt"),
+    renderRobots(origin),
+    "utf-8"
+  );
+
+  console.log("");
+  console.log(
+    `Wrote ${indexEntries.length} child sitemap(s), ${totalUrls} URLs total.`
+  );
+  console.log(`  ${path.join(outDir, "sitemap.xml")}`);
+  console.log(`  ${path.join(outDir, "robots.txt")}`);
+}
+
+function renderRobots(origin: string): string {
+  return (
+    `User-agent: *\n` +
+    `Allow: /\n` +
+    `\n` +
+    `Sitemap: ${trimTrailingSlash(origin)}/sitemap.xml\n`
+  );
+}
+
+function trimTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
+}
+
+async function main(): Promise<void> {
+  if (hasFlag("--help") || hasFlag("-h")) {
+    printUsage();
+    return;
+  }
+
+  const skippedBranch = shouldSkipForBranch();
+  if (skippedBranch) {
+    console.log(
+      `Skipping sitemap generation for branch "${skippedBranch}" (only the main build's public files are deployed).`
+    );
+    return;
+  }
+
+  const options = resolveOptions();
+
+  try {
+    await generate(options);
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    if (options.strict) {
+      throw error;
+    }
+    console.warn(`Sitemap generation failed (non-fatal): ${message}`);
+    console.warn(
+      "Continuing without a sitemap. Pass --strict to fail instead."
+    );
+  }
+}
+
+main().catch((error) => {
+  console.error("Failed to generate sitemap:", error);
+  process.exitCode = 1;
+});

--- a/script/generate-sitemap.ts
+++ b/script/generate-sitemap.ts
@@ -22,7 +22,7 @@
  *
  * Usage:
  *   pnpm sitemap
- *   pnpm sitemap --base-url=https://prod.seedbible.org --endpoint=https://bible.helloao.org/
+ *   pnpm sitemap --base-url=https://seedbible.org --endpoint=https://bible.helloao.org/
  *   pnpm sitemap --mapped-only --strict --out=standalone/dist/client
  */
 import { mkdir, rm, writeFile } from "node:fs/promises";
@@ -34,17 +34,19 @@ import {
 } from "@packages/seed-bible/seed-bible/managers/FreeUseBibleAPI";
 import {
   bibleLanguageToUiLocale,
+  buildTranslationParam,
   chapterUrlsForTranslation,
   chunk,
   renderSitemapIndex,
   renderUrlset,
+  trimTrailingSlash,
   uniqueSitemapName,
   MAX_URLS_PER_SITEMAP,
   type BookChapters,
   type SitemapIndexEntry,
 } from "./lib/sitemap";
 
-const DEFAULT_ORIGIN = "https://prod.seedbible.org";
+const DEFAULT_ORIGIN = "https://seedbible.org";
 const DEFAULT_OUT_DIR = path.join("standalone", "dist", "client");
 const SITEMAPS_SUBDIR = "sitemaps";
 const DEFAULT_CONCURRENCY = 8;
@@ -175,7 +177,9 @@ async function buildTranslationSitemap(
   api: FreeUseBibleAPI,
   origin: string,
   translation: Translation,
-  mappedOnly: boolean
+  mappedOnly: boolean,
+  endpoint: string,
+  defaultEndpoint: string
 ): Promise<TranslationSitemap | null> {
   const uiLocale = bibleLanguageToUiLocale(translation.language);
   if (mappedOnly && !uiLocale) {
@@ -199,9 +203,18 @@ async function buildTranslationSitemap(
     return null;
   }
 
+  // Match the app's canonical `translation` param exactly (bare id for the
+  // default endpoint, full books.json URL otherwise); the filename keeps the
+  // raw id.
+  const translationParam = buildTranslationParam(
+    translation.id,
+    endpoint,
+    defaultEndpoint
+  );
+
   const urls = chapterUrlsForTranslation(
     origin,
-    translation.id,
+    translationParam,
     uiLocale,
     books
   );
@@ -221,6 +234,8 @@ async function generate(options: Options): Promise<void> {
   console.log(`Mapped only: ${options.mappedOnly}`);
   console.log("");
 
+  const defaultEndpoint = getDefaultAPIEndpoint(new URL(origin));
+
   const api = new FreeUseBibleAPI(endpoint);
   const { translations } = await api.getAvailableTranslations();
   console.log(`Fetched ${translations.length} translations.`);
@@ -229,7 +244,14 @@ async function generate(options: Options): Promise<void> {
     translations,
     options.concurrency,
     (translation) =>
-      buildTranslationSitemap(api, origin, translation, options.mappedOnly)
+      buildTranslationSitemap(
+        api,
+        origin,
+        translation,
+        options.mappedOnly,
+        endpoint,
+        defaultEndpoint
+      )
   );
 
   const sitemaps = built.filter(
@@ -249,7 +271,6 @@ async function generate(options: Options): Promise<void> {
 
   const usedNames = new Set<string>();
   const indexEntries: SitemapIndexEntry[] = [];
-  const lastmod = new Date().toISOString().slice(0, 10);
   let totalUrls = 0;
 
   for (const sitemap of sitemaps) {
@@ -273,7 +294,6 @@ async function generate(options: Options): Promise<void> {
       );
       indexEntries.push({
         loc: `${trimTrailingSlash(origin)}/${SITEMAPS_SUBDIR}/${fileName}`,
-        lastmod,
       });
     }
   }
@@ -298,7 +318,6 @@ async function generate(options: Options): Promise<void> {
       );
       rootEntries.push({
         loc: `${trimTrailingSlash(origin)}/${fileName}`,
-        lastmod,
       });
     }
     await writeFile(
@@ -329,10 +348,6 @@ function renderRobots(origin: string): string {
     `\n` +
     `Sitemap: ${trimTrailingSlash(origin)}/sitemap.xml\n`
   );
-}
-
-function trimTrailingSlash(url: string): string {
-  return url.endsWith("/") ? url.slice(0, -1) : url;
 }
 
 async function main(): Promise<void> {

--- a/script/generate-sitemap.ts
+++ b/script/generate-sitemap.ts
@@ -115,14 +115,27 @@ function resolveOptions(): Options {
 }
 
 /**
- * On CI, only the `main` build's public files are synced to the bucket root, so
- * generating on other branch builds just hammers the Bible API for output that
- * is never uploaded. Skip those. Local runs (no DEPLOY_BRANCH) always run.
+ * Decides whether to skip generation, returning a human-readable reason or
+ * `null` to proceed.
+ *
+ * Only the `main` deploy build's public files are synced to the bucket root, so
+ * generating anywhere else just hammers the Bible API for output that is never
+ * uploaded. Two cases skip:
+ *   - A deploy build for a non-main branch (`DEPLOY_BRANCH` set and != "main").
+ *   - Any other CI build. `ci.yml` runs `pnpm build` — twice per PR — with no
+ *     `DEPLOY_BRANCH` set, purely to lint/test/size the bundle; it uploads
+ *     nothing. Without this, every CI run would make live catalog fetches,
+ *     adding an external-service dependency to an otherwise hermetic build.
+ * Direct or local runs (not in CI, no `DEPLOY_BRANCH`) still generate, so
+ * `pnpm sitemap` works for development.
  */
-function shouldSkipForBranch(): string | null {
+function skipReason(): string | null {
   const branch = process.env.DEPLOY_BRANCH?.trim();
-  if (branch && branch !== "main") {
-    return branch;
+  if (branch) {
+    return branch === "main" ? null : `deploy build for branch "${branch}"`;
+  }
+  if (process.env.CI) {
+    return "CI build without DEPLOY_BRANCH=main";
   }
   return null;
 }
@@ -328,10 +341,10 @@ async function main(): Promise<void> {
     return;
   }
 
-  const skippedBranch = shouldSkipForBranch();
-  if (skippedBranch) {
+  const skip = skipReason();
+  if (skip) {
     console.log(
-      `Skipping sitemap generation for branch "${skippedBranch}" (only the main build's public files are deployed).`
+      `Skipping sitemap generation (${skip}); only the main build's public files are deployed.`
     );
     return;
   }

--- a/script/lib/sitemap.ts
+++ b/script/lib/sitemap.ts
@@ -7,10 +7,7 @@
  * splitting URL sets across the 50,000-per-file sitemap limit — can be verified
  * without hitting the network.
  */
-import {
-  DEFAULT_TRANSLATIONS_BY_LANGUAGE,
-  UI_TO_BIBLE_LANGUAGE_CODES,
-} from "@packages/seed-bible/seed-bible/managers/BibleReadingManager";
+import { UI_TO_BIBLE_LANGUAGE_CODES } from "@packages/seed-bible/seed-bible/managers/BibleReadingManager";
 
 /**
  * The largest number of `<url>` (or `<sitemap>`) entries a single sitemap file
@@ -26,24 +23,15 @@ export const MAX_URLS_PER_SITEMAP = 50000;
  * wrap it (e.g. "es").
  *
  * Some UI locales share a Bible language (e.g. `he`/`iw` both map to `heb`,
- * `fil`/`tl` to `tgl`). The pick is deterministic:
- *   1. UI locales that have a hardcoded default translation
- *      (`DEFAULT_TRANSLATIONS_BY_LANGUAGE`) win, so e.g. `en` beats a
- *      hypothetical alias for `eng`.
- *   2. Otherwise the first locale in `UI_TO_BIBLE_LANGUAGE_CODES` insertion
- *      order wins (which yields the canonical two-letter code: `he` over `iw`,
- *      `fil` over `tl`, `no` over `nb`).
+ * `fil`/`tl` to `tgl`, `no`/`nb` to `nob`/`nor`). Ties are broken by insertion
+ * order in `UI_TO_BIBLE_LANGUAGE_CODES`: the first locale listed for a code
+ * wins, which is the canonical two-letter code (`he` over `iw`, `fil` over
+ * `tl`, `no` over `nb`).
  */
 export function buildBibleLanguageToUiLocale(): Map<string, string> {
   const map = new Map<string, string>();
-  const entries = Object.entries(UI_TO_BIBLE_LANGUAGE_CODES);
 
-  const prioritized = [
-    ...entries.filter(([ui]) => DEFAULT_TRANSLATIONS_BY_LANGUAGE.has(ui)),
-    ...entries.filter(([ui]) => !DEFAULT_TRANSLATIONS_BY_LANGUAGE.has(ui)),
-  ];
-
-  for (const [ui, codes] of prioritized) {
+  for (const [ui, codes] of Object.entries(UI_TO_BIBLE_LANGUAGE_CODES)) {
     for (const code of codes) {
       const key = code.toLowerCase();
       if (!map.has(key)) {
@@ -82,8 +70,31 @@ export interface ChapterUrlParams {
 }
 
 /**
- * Builds a canonical reader URL for a chapter, matching the app's own
- * `SeedBibleStateManager.canonicalUrl` shape:
+ * Produces the value for the `translation` query param, mirroring the app's
+ * `BibleDataManager.buildTranslationId`: the bare translation ID when the
+ * catalog endpoint is the app's default endpoint, otherwise the full
+ * `…/api/{id}/books.json` URL. Keeping this in lock-step with the app ensures
+ * sitemap URLs match the site's own canonical URLs regardless of which endpoint
+ * the catalog is fetched from.
+ */
+export function buildTranslationParam(
+  translationId: string,
+  endpoint: string,
+  defaultEndpoint: string
+): string {
+  if (ensureTrailingSlash(endpoint) === ensureTrailingSlash(defaultEndpoint)) {
+    return translationId;
+  }
+  return new URL(
+    `api/${translationId}/books.json`,
+    ensureTrailingSlash(endpoint)
+  ).href;
+}
+
+/**
+ * Builds a canonical reader URL for a chapter. This mirrors the app's own
+ * `SeedBibleStateManager.canonicalUrl` (the on-page source of truth for the
+ * shape):
  *   `<origin>/?translation=<id>&book=<BOOK>&chapter=<n>[&lang=<locale>]`
  */
 export function buildChapterUrl(
@@ -226,6 +237,10 @@ export function uniqueSitemapName(id: string, used: Set<string>): string {
   return candidate;
 }
 
-function ensureTrailingSlash(url: string): string {
+export function ensureTrailingSlash(url: string): string {
   return url.endsWith("/") ? url : `${url}/`;
+}
+
+export function trimTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url.slice(0, -1) : url;
 }

--- a/script/lib/sitemap.ts
+++ b/script/lib/sitemap.ts
@@ -1,0 +1,231 @@
+/**
+ * Pure, IO-free helpers for building the Seed Bible sitemap.
+ *
+ * The generator (`script/generate-sitemap.ts`) does the network fetching and
+ * file writing; everything here is deterministic and unit-tested so the tricky
+ * bits — inverting the UI↔Bible language mapping, escaping URLs into XML, and
+ * splitting URL sets across the 50,000-per-file sitemap limit — can be verified
+ * without hitting the network.
+ */
+import {
+  DEFAULT_TRANSLATIONS_BY_LANGUAGE,
+  UI_TO_BIBLE_LANGUAGE_CODES,
+} from "@packages/seed-bible/seed-bible/managers/BibleReadingManager";
+
+/**
+ * The largest number of `<url>` (or `<sitemap>`) entries a single sitemap file
+ * may contain, per the sitemaps.org protocol. A single Bible translation has at
+ * most ~1,189 chapters, well under this, but the guard keeps every emitted file
+ * (including the index) spec-compliant regardless of catalog size.
+ */
+export const MAX_URLS_PER_SITEMAP = 50000;
+
+/**
+ * Builds the inverse of `UI_TO_BIBLE_LANGUAGE_CODES`: a map from a Bible-API
+ * language code (ISO 639-3, e.g. "spa") to the single UI locale that should
+ * wrap it (e.g. "es").
+ *
+ * Some UI locales share a Bible language (e.g. `he`/`iw` both map to `heb`,
+ * `fil`/`tl` to `tgl`). The pick is deterministic:
+ *   1. UI locales that have a hardcoded default translation
+ *      (`DEFAULT_TRANSLATIONS_BY_LANGUAGE`) win, so e.g. `en` beats a
+ *      hypothetical alias for `eng`.
+ *   2. Otherwise the first locale in `UI_TO_BIBLE_LANGUAGE_CODES` insertion
+ *      order wins (which yields the canonical two-letter code: `he` over `iw`,
+ *      `fil` over `tl`, `no` over `nb`).
+ */
+export function buildBibleLanguageToUiLocale(): Map<string, string> {
+  const map = new Map<string, string>();
+  const entries = Object.entries(UI_TO_BIBLE_LANGUAGE_CODES);
+
+  const prioritized = [
+    ...entries.filter(([ui]) => DEFAULT_TRANSLATIONS_BY_LANGUAGE.has(ui)),
+    ...entries.filter(([ui]) => !DEFAULT_TRANSLATIONS_BY_LANGUAGE.has(ui)),
+  ];
+
+  for (const [ui, codes] of prioritized) {
+    for (const code of codes) {
+      const key = code.toLowerCase();
+      if (!map.has(key)) {
+        map.set(key, ui);
+      }
+    }
+  }
+
+  return map;
+}
+
+const BIBLE_LANGUAGE_TO_UI_LOCALE = buildBibleLanguageToUiLocale();
+
+/**
+ * Resolves the UI locale that maps to a translation's Bible language, or `null`
+ * when no supported UI locale covers that language.
+ */
+export function bibleLanguageToUiLocale(
+  bibleLanguage: string | null | undefined
+): string | null {
+  if (!bibleLanguage) {
+    return null;
+  }
+  return BIBLE_LANGUAGE_TO_UI_LOCALE.get(bibleLanguage.toLowerCase()) ?? null;
+}
+
+export interface ChapterUrlParams {
+  /** Translation ID as it appears in the `translation` query param. */
+  translationId: string;
+  /** USFM book ID, e.g. "GEN". */
+  bookId: string;
+  /** 1-based chapter number. */
+  chapter: number;
+  /** UI locale for the `lang` query param; omitted when null/undefined. */
+  uiLocale?: string | null;
+}
+
+/**
+ * Builds a canonical reader URL for a chapter, matching the app's own
+ * `SeedBibleStateManager.canonicalUrl` shape:
+ *   `<origin>/?translation=<id>&book=<BOOK>&chapter=<n>[&lang=<locale>]`
+ */
+export function buildChapterUrl(
+  origin: string,
+  params: ChapterUrlParams
+): string {
+  const url = new URL("/", ensureTrailingSlash(origin));
+  url.searchParams.set("translation", params.translationId);
+  url.searchParams.set("book", params.bookId);
+  url.searchParams.set("chapter", String(params.chapter));
+  if (params.uiLocale) {
+    url.searchParams.set("lang", params.uiLocale);
+  }
+  return url.toString();
+}
+
+export interface BookChapters {
+  bookId: string;
+  firstChapterNumber: number;
+  numberOfChapters: number;
+}
+
+/**
+ * Expands a translation's book list into one canonical URL per chapter.
+ * Books with no chapters are skipped.
+ */
+export function chapterUrlsForTranslation(
+  origin: string,
+  translationId: string,
+  uiLocale: string | null,
+  books: readonly BookChapters[]
+): string[] {
+  const urls: string[] = [];
+  for (const book of books) {
+    if (book.numberOfChapters <= 0) {
+      continue;
+    }
+    const first = book.firstChapterNumber;
+    for (let i = 0; i < book.numberOfChapters; i++) {
+      urls.push(
+        buildChapterUrl(origin, {
+          translationId,
+          bookId: book.bookId,
+          chapter: first + i,
+          uiLocale,
+        })
+      );
+    }
+  }
+  return urls;
+}
+
+/** Escapes the five XML predefined entities for safe inclusion in element text. */
+export function escapeXml(value: string): string {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;")
+    .replace(/"/g, "&quot;")
+    .replace(/'/g, "&apos;");
+}
+
+/** Renders a `<urlset>` document from a list of location URLs. */
+export function renderUrlset(urls: readonly string[]): string {
+  const body = urls
+    .map((url) => `  <url><loc>${escapeXml(url)}</loc></url>`)
+    .join("\n");
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    `${body}\n` +
+    `</urlset>\n`
+  );
+}
+
+export interface SitemapIndexEntry {
+  loc: string;
+  lastmod?: string;
+}
+
+/** Renders a `<sitemapindex>` document pointing at child sitemap files. */
+export function renderSitemapIndex(
+  entries: readonly SitemapIndexEntry[]
+): string {
+  const body = entries
+    .map((entry) => {
+      const lastmod = entry.lastmod
+        ? `<lastmod>${escapeXml(entry.lastmod)}</lastmod>`
+        : "";
+      return `  <sitemap><loc>${escapeXml(entry.loc)}</loc>${lastmod}</sitemap>`;
+    })
+    .join("\n");
+  return (
+    `<?xml version="1.0" encoding="UTF-8"?>\n` +
+    `<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">\n` +
+    `${body}\n` +
+    `</sitemapindex>\n`
+  );
+}
+
+/** Splits a list into chunks of at most `size` items. */
+export function chunk<T>(
+  items: readonly T[],
+  size = MAX_URLS_PER_SITEMAP
+): T[][] {
+  if (size <= 0) {
+    throw new Error("chunk size must be a positive integer");
+  }
+  const chunks: T[][] = [];
+  for (let i = 0; i < items.length; i += size) {
+    chunks.push(items.slice(i, i + size));
+  }
+  return chunks;
+}
+
+/**
+ * Turns a translation ID into a filesystem- and URL-safe base name. Translation
+ * IDs are usually simple (`BSB`, `eng_kjv`) but can contain slashes or spaces,
+ * so anything outside `[A-Za-z0-9._-]` collapses to `_`.
+ */
+export function sanitizeSitemapName(id: string): string {
+  const cleaned = id.replace(/[^A-Za-z0-9._-]+/g, "_").replace(/^_+|_+$/g, "");
+  return cleaned || "translation";
+}
+
+/**
+ * Builds a unique child-sitemap base name for a translation, disambiguating
+ * against names already handed out (two different IDs can sanitize to the same
+ * string) by appending a numeric suffix.
+ */
+export function uniqueSitemapName(id: string, used: Set<string>): string {
+  const base = sanitizeSitemapName(id);
+  let candidate = base;
+  let counter = 2;
+  while (used.has(candidate)) {
+    candidate = `${base}-${counter}`;
+    counter++;
+  }
+  used.add(candidate);
+  return candidate;
+}
+
+function ensureTrailingSlash(url: string): string {
+  return url.endsWith("/") ? url : `${url}/`;
+}

--- a/test/unit/script/lib/sitemap.test.ts
+++ b/test/unit/script/lib/sitemap.test.ts
@@ -1,0 +1,245 @@
+import {
+  bibleLanguageToUiLocale,
+  buildBibleLanguageToUiLocale,
+  buildChapterUrl,
+  chapterUrlsForTranslation,
+  chunk,
+  escapeXml,
+  renderSitemapIndex,
+  renderUrlset,
+  sanitizeSitemapName,
+  uniqueSitemapName,
+  MAX_URLS_PER_SITEMAP,
+  type BookChapters,
+} from "../../../../script/lib/sitemap";
+
+const ORIGIN = "https://prod.seedbible.org";
+
+describe("bibleLanguageToUiLocale", () => {
+  it("maps common Bible languages to their UI locale", () => {
+    expect(bibleLanguageToUiLocale("spa")).toBe("es");
+    expect(bibleLanguageToUiLocale("eng")).toBe("en");
+    expect(bibleLanguageToUiLocale("fra")).toBe("fr");
+    expect(bibleLanguageToUiLocale("por")).toBe("pt");
+  });
+
+  it("is case-insensitive on the input code", () => {
+    expect(bibleLanguageToUiLocale("SPA")).toBe("es");
+    expect(bibleLanguageToUiLocale("Eng")).toBe("en");
+  });
+
+  it("resolves alias codes to the same UI locale", () => {
+    // German is exposed as both deu and ger by the API.
+    expect(bibleLanguageToUiLocale("deu")).toBe("de");
+    expect(bibleLanguageToUiLocale("ger")).toBe("de");
+    // Chinese: cmn and zho.
+    expect(bibleLanguageToUiLocale("cmn")).toBe("zh");
+    expect(bibleLanguageToUiLocale("zho")).toBe("zh");
+  });
+
+  it("resolves collisions deterministically to the canonical locale", () => {
+    // he/iw both map to heb; the canonical two-letter he wins.
+    expect(bibleLanguageToUiLocale("heb")).toBe("he");
+    // fil/tl both map to tgl; fil wins (first in insertion order).
+    expect(bibleLanguageToUiLocale("tgl")).toBe("fil");
+  });
+
+  it("returns null for unknown or empty languages", () => {
+    expect(bibleLanguageToUiLocale("xyz")).toBeNull();
+    expect(bibleLanguageToUiLocale("")).toBeNull();
+    expect(bibleLanguageToUiLocale(null)).toBeNull();
+    expect(bibleLanguageToUiLocale(undefined)).toBeNull();
+  });
+
+  it("never maps two Bible codes to conflicting locales within one build", () => {
+    const map = buildBibleLanguageToUiLocale();
+    // Every value must be a non-empty string; the map is a function (1 value
+    // per key) by construction.
+    for (const [code, locale] of map.entries()) {
+      expect(code).toBeTruthy();
+      expect(locale).toBeTruthy();
+    }
+  });
+});
+
+describe("buildChapterUrl", () => {
+  it("builds a canonical chapter URL with a UI locale", () => {
+    expect(
+      buildChapterUrl(ORIGIN, {
+        translationId: "spa_onbv",
+        bookId: "GEN",
+        chapter: 1,
+        uiLocale: "es",
+      })
+    ).toBe(
+      "https://prod.seedbible.org/?translation=spa_onbv&book=GEN&chapter=1&lang=es"
+    );
+  });
+
+  it("omits lang when no UI locale is given", () => {
+    expect(
+      buildChapterUrl(ORIGIN, {
+        translationId: "xyz_translation",
+        bookId: "REV",
+        chapter: 22,
+      })
+    ).toBe(
+      "https://prod.seedbible.org/?translation=xyz_translation&book=REV&chapter=22"
+    );
+  });
+
+  it("percent-encodes reserved characters in the translation ID", () => {
+    const url = buildChapterUrl(ORIGIN, {
+      translationId: "eng/esv",
+      bookId: "GEN",
+      chapter: 1,
+      uiLocale: "en",
+    });
+    expect(url).toContain("translation=eng%2Fesv");
+  });
+
+  it("works whether or not the origin has a trailing slash", () => {
+    const withSlash = buildChapterUrl("https://x.org/", {
+      translationId: "t",
+      bookId: "GEN",
+      chapter: 1,
+    });
+    const withoutSlash = buildChapterUrl("https://x.org", {
+      translationId: "t",
+      bookId: "GEN",
+      chapter: 1,
+    });
+    expect(withSlash).toBe(withoutSlash);
+    expect(withSlash).toBe("https://x.org/?translation=t&book=GEN&chapter=1");
+  });
+});
+
+describe("chapterUrlsForTranslation", () => {
+  const books: BookChapters[] = [
+    { bookId: "GEN", firstChapterNumber: 1, numberOfChapters: 3 },
+    { bookId: "EXO", firstChapterNumber: 1, numberOfChapters: 2 },
+  ];
+
+  it("emits one URL per chapter across all books", () => {
+    const urls = chapterUrlsForTranslation(ORIGIN, "t", "en", books);
+    expect(urls).toHaveLength(5);
+    expect(urls[0]).toBe(
+      "https://prod.seedbible.org/?translation=t&book=GEN&chapter=1&lang=en"
+    );
+    expect(urls[2]).toBe(
+      "https://prod.seedbible.org/?translation=t&book=GEN&chapter=3&lang=en"
+    );
+    expect(urls[4]).toBe(
+      "https://prod.seedbible.org/?translation=t&book=EXO&chapter=2&lang=en"
+    );
+  });
+
+  it("honors a non-1 firstChapterNumber", () => {
+    const urls = chapterUrlsForTranslation(ORIGIN, "t", null, [
+      { bookId: "PSA", firstChapterNumber: 42, numberOfChapters: 2 },
+    ]);
+    expect(urls).toEqual([
+      "https://prod.seedbible.org/?translation=t&book=PSA&chapter=42",
+      "https://prod.seedbible.org/?translation=t&book=PSA&chapter=43",
+    ]);
+  });
+
+  it("skips books with no chapters", () => {
+    const urls = chapterUrlsForTranslation(ORIGIN, "t", "en", [
+      { bookId: "GEN", firstChapterNumber: 1, numberOfChapters: 0 },
+      { bookId: "EXO", firstChapterNumber: 1, numberOfChapters: 1 },
+    ]);
+    expect(urls).toHaveLength(1);
+    expect(urls[0]).toContain("book=EXO");
+  });
+});
+
+describe("escapeXml", () => {
+  it("escapes all five predefined entities", () => {
+    expect(escapeXml(`&<>"'`)).toBe("&amp;&lt;&gt;&quot;&apos;");
+  });
+
+  it("escapes the & that separates query params", () => {
+    const url = "https://x.org/?a=1&b=2";
+    expect(escapeXml(url)).toBe("https://x.org/?a=1&amp;b=2");
+  });
+});
+
+describe("renderUrlset", () => {
+  it("renders well-formed XML with escaped locs", () => {
+    const xml = renderUrlset([
+      "https://x.org/?translation=t&book=GEN&chapter=1",
+    ]);
+    expect(xml).toContain('<?xml version="1.0" encoding="UTF-8"?>');
+    expect(xml).toContain(
+      '<urlset xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    );
+    expect(xml).toContain(
+      "<loc>https://x.org/?translation=t&amp;book=GEN&amp;chapter=1</loc>"
+    );
+    expect(xml.trimEnd().endsWith("</urlset>")).toBe(true);
+    // No raw unescaped ampersand should survive.
+    expect(xml).not.toMatch(/&(?!amp;|lt;|gt;|quot;|apos;)/);
+  });
+});
+
+describe("renderSitemapIndex", () => {
+  it("renders child sitemap entries with optional lastmod", () => {
+    const xml = renderSitemapIndex([
+      { loc: "https://x.org/sitemaps/a.xml", lastmod: "2026-07-18" },
+      { loc: "https://x.org/sitemaps/b.xml" },
+    ]);
+    expect(xml).toContain(
+      '<sitemapindex xmlns="http://www.sitemaps.org/schemas/sitemap/0.9">'
+    );
+    expect(xml).toContain(
+      "<sitemap><loc>https://x.org/sitemaps/a.xml</loc><lastmod>2026-07-18</lastmod></sitemap>"
+    );
+    expect(xml).toContain(
+      "<sitemap><loc>https://x.org/sitemaps/b.xml</loc></sitemap>"
+    );
+    expect(xml.trimEnd().endsWith("</sitemapindex>")).toBe(true);
+  });
+});
+
+describe("chunk", () => {
+  it("splits into chunks of at most the given size", () => {
+    expect(chunk([1, 2, 3, 4, 5], 2)).toEqual([[1, 2], [3, 4], [5]]);
+  });
+
+  it("returns a single chunk when under the limit", () => {
+    expect(chunk([1, 2, 3])).toEqual([[1, 2, 3]]);
+    expect(MAX_URLS_PER_SITEMAP).toBe(50000);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(chunk([])).toEqual([]);
+  });
+
+  it("throws on a non-positive size", () => {
+    expect(() => chunk([1], 0)).toThrow();
+  });
+});
+
+describe("sanitizeSitemapName / uniqueSitemapName", () => {
+  it("keeps simple IDs unchanged", () => {
+    expect(sanitizeSitemapName("eng_kjv")).toBe("eng_kjv");
+    expect(sanitizeSitemapName("BSB")).toBe("BSB");
+  });
+
+  it("replaces unsafe characters", () => {
+    expect(sanitizeSitemapName("eng/esv")).toBe("eng_esv");
+    expect(sanitizeSitemapName("a b c")).toBe("a_b_c");
+  });
+
+  it("falls back to a default for all-unsafe input", () => {
+    expect(sanitizeSitemapName("///")).toBe("translation");
+  });
+
+  it("disambiguates names that collide after sanitizing", () => {
+    const used = new Set<string>();
+    expect(uniqueSitemapName("eng/esv", used)).toBe("eng_esv");
+    expect(uniqueSitemapName("eng_esv", used)).toBe("eng_esv-2");
+    expect(uniqueSitemapName("eng esv", used)).toBe("eng_esv-3");
+  });
+});

--- a/test/unit/script/lib/sitemap.test.ts
+++ b/test/unit/script/lib/sitemap.test.ts
@@ -2,18 +2,20 @@ import {
   bibleLanguageToUiLocale,
   buildBibleLanguageToUiLocale,
   buildChapterUrl,
+  buildTranslationParam,
   chapterUrlsForTranslation,
   chunk,
   escapeXml,
   renderSitemapIndex,
   renderUrlset,
   sanitizeSitemapName,
+  trimTrailingSlash,
   uniqueSitemapName,
   MAX_URLS_PER_SITEMAP,
   type BookChapters,
 } from "../../../../script/lib/sitemap";
 
-const ORIGIN = "https://prod.seedbible.org";
+const ORIGIN = "https://seedbible.org";
 
 describe("bibleLanguageToUiLocale", () => {
   it("maps common Bible languages to their UI locale", () => {
@@ -72,7 +74,7 @@ describe("buildChapterUrl", () => {
         uiLocale: "es",
       })
     ).toBe(
-      "https://prod.seedbible.org/?translation=spa_onbv&book=GEN&chapter=1&lang=es"
+      "https://seedbible.org/?translation=spa_onbv&book=GEN&chapter=1&lang=es"
     );
   });
 
@@ -84,7 +86,7 @@ describe("buildChapterUrl", () => {
         chapter: 22,
       })
     ).toBe(
-      "https://prod.seedbible.org/?translation=xyz_translation&book=REV&chapter=22"
+      "https://seedbible.org/?translation=xyz_translation&book=REV&chapter=22"
     );
   });
 
@@ -114,6 +116,42 @@ describe("buildChapterUrl", () => {
   });
 });
 
+describe("buildTranslationParam", () => {
+  const DEFAULT = "https://vmfnri.helloao.org/";
+
+  it("returns the bare id when the endpoint is the default", () => {
+    expect(buildTranslationParam("BSB", DEFAULT, DEFAULT)).toBe("BSB");
+  });
+
+  it("ignores trailing-slash differences when comparing endpoints", () => {
+    expect(
+      buildTranslationParam("BSB", "https://vmfnri.helloao.org", DEFAULT)
+    ).toBe("BSB");
+  });
+
+  it("returns the full books.json URL for a non-default endpoint", () => {
+    expect(
+      buildTranslationParam("BSB", "https://bible.helloao.org/", DEFAULT)
+    ).toBe("https://bible.helloao.org/api/BSB/books.json");
+  });
+
+  it("encodes reserved characters in the id for a non-default endpoint", () => {
+    expect(
+      buildTranslationParam("eng/esv", "https://bible.helloao.org/", DEFAULT)
+    ).toBe("https://bible.helloao.org/api/eng/esv/books.json");
+  });
+});
+
+describe("trimTrailingSlash", () => {
+  it("removes a single trailing slash", () => {
+    expect(trimTrailingSlash("https://x.org/")).toBe("https://x.org");
+  });
+
+  it("leaves a slash-free URL untouched", () => {
+    expect(trimTrailingSlash("https://x.org")).toBe("https://x.org");
+  });
+});
+
 describe("chapterUrlsForTranslation", () => {
   const books: BookChapters[] = [
     { bookId: "GEN", firstChapterNumber: 1, numberOfChapters: 3 },
@@ -124,13 +162,13 @@ describe("chapterUrlsForTranslation", () => {
     const urls = chapterUrlsForTranslation(ORIGIN, "t", "en", books);
     expect(urls).toHaveLength(5);
     expect(urls[0]).toBe(
-      "https://prod.seedbible.org/?translation=t&book=GEN&chapter=1&lang=en"
+      "https://seedbible.org/?translation=t&book=GEN&chapter=1&lang=en"
     );
     expect(urls[2]).toBe(
-      "https://prod.seedbible.org/?translation=t&book=GEN&chapter=3&lang=en"
+      "https://seedbible.org/?translation=t&book=GEN&chapter=3&lang=en"
     );
     expect(urls[4]).toBe(
-      "https://prod.seedbible.org/?translation=t&book=EXO&chapter=2&lang=en"
+      "https://seedbible.org/?translation=t&book=EXO&chapter=2&lang=en"
     );
   });
 
@@ -139,8 +177,8 @@ describe("chapterUrlsForTranslation", () => {
       { bookId: "PSA", firstChapterNumber: 42, numberOfChapters: 2 },
     ]);
     expect(urls).toEqual([
-      "https://prod.seedbible.org/?translation=t&book=PSA&chapter=42",
-      "https://prod.seedbible.org/?translation=t&book=PSA&chapter=43",
+      "https://seedbible.org/?translation=t&book=PSA&chapter=42",
+      "https://seedbible.org/?translation=t&book=PSA&chapter=43",
     ]);
   });
 

--- a/test/unit/script/lib/sitemap.test.ts
+++ b/test/unit/script/lib/sitemap.test.ts
@@ -135,7 +135,12 @@ describe("buildTranslationParam", () => {
     ).toBe("https://bible.helloao.org/api/BSB/books.json");
   });
 
-  it("encodes reserved characters in the id for a non-default endpoint", () => {
+  it("keeps a slash in the id as a path segment (not percent-encoded), mirroring buildTranslationId", () => {
+    // `new URL("api/eng/esv/books.json", base)` treats the "/" as a path
+    // separator, so it is NOT percent-encoded here — matching the app's
+    // BibleDataManager.buildTranslationId. (Contrast buildChapterUrl, which
+    // puts the id in a query param via URLSearchParams and so encodes "/" to
+    // "%2F".)
     expect(
       buildTranslationParam("eng/esv", "https://bible.helloao.org/", DEFAULT)
     ).toBe("https://bible.helloao.org/api/eng/esv/books.json");

--- a/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
+++ b/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
@@ -206,6 +206,23 @@ describe("createSeedBibleState", () => {
     expect(state.bibleData.api.endpoint).toBe("https://bible.helloao.org/");
   });
 
+  it("echoes an explicit ?lang= in the canonical URL so language-specific sitemap URLs stay self-canonical", async () => {
+    const state = await createState();
+
+    // A crawler lands on a language-specific sitemap URL.
+    window.history.replaceState(null, "", "/?lang=es");
+
+    expect(state.app.canonicalUrl.value).toContain("lang=es");
+  });
+
+  it("omits lang from the canonical URL when the page URL has none", async () => {
+    const state = await createState();
+
+    window.history.replaceState(null, "", "/?foo=bar");
+
+    expect(state.app.canonicalUrl.value).not.toContain("lang=");
+  });
+
   it("selecting a tab selects the tab and switches the slot to display the selected tab", async () => {
     const state = await createStateWithTwoTabs();
 


### PR DESCRIPTION
Generate a sitemap covering every chapter of every book in every Bible
translation, one child sitemap per translation plus a sitemap index and a
robots.txt.

Each chapter URL carries the UI locale (?lang=) that maps to the
translation's Bible language — Spanish translations get the Spanish UI,
English translations the English UI — reusing the existing
UI_TO_BIBLE_LANGUAGE_CODES mapping (now exported) rather than emitting the
full translation × every-UI-language cross product. Translations in a
language with no supported UI locale are still listed without ?lang=;
--mapped-only restricts output to translations that map to a UI locale.

- script/lib/sitemap.ts: pure, unit-tested helpers (language-map inversion,
  URL building, XML rendering, chunking to the 50k-per-file limit, filename
  sanitizing).
- script/generate-sitemap.ts: fetches translations + books via
  FreeUseBibleAPI and writes into the client build output. Best-effort — a
  Bible-API failure warns and exits 0 so a deploy is never blocked
  (--strict to fail). Skips non-main branch builds, whose public files are
  not deployed.
- Wired as "pnpm sitemap" and appended to "pnpm build". Output is served by
  the host's existing .xml/.txt reverse-proxy; no new server route needed.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017Em949FfugKLX9UiqGj6Kt