### PR TITLE
fix: reset userInfo on logout so login() reopens the modal

### DIFF
--- a/packages/seed-bible/seed-bible/managers/LoginManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/LoginManager.tsx
@@ -369,6 +369,7 @@ export function createLoginManager({
     batch(() => {
       sessionKey.value = null;
       connectionKey.value = null;
+      userInfo.value = null;
     });
   };
 

--- a/test/unit/seed-bible/managers/LoginManager.test.ts
+++ b/test/unit/seed-bible/managers/LoginManager.test.ts
@@ -567,6 +567,23 @@ describe("createLoginManager", () => {
 
       await waitFor(() => manager.userId.value === null);
       await waitFor(() => manager.profile.value === null);
+      // login() caches userInfo to skip a redundant login flow while still
+      // authenticated; that cache must not survive logout, or a subsequent
+      // login() call resolves from the stale cache instead of reopening the
+      // login UI.
+      expect(manager.userInfo.value).toBeNull();
+    });
+
+    it("login() reopens the login UI after a logout", async () => {
+      const manager = createAuthenticatedManager();
+
+      await waitFor(() => manager.userId.value === USER_ID);
+      await manager.logout();
+      await waitFor(() => manager.userId.value === null);
+
+      void manager.login();
+
+      await waitFor(() => manager.isLoginOpen.value === true);
     });
 
     it("updateProfile() persists the profile when authenticated", async () => {


### PR DESCRIPTION
login() short-circuits with the cached userInfo when it is truthy,
skipping loginCore() (and its isLoginOpen.value = true). logout()
cleared sessionKey/connectionKey but left userInfo stale, so the
account settings page's "Log in" button silently no-op'd after logout.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01TJiHHCjxn8dBb5a2f5aYep