### PR TITLE
Persist shared session id in the URL so refresh rejoins it

### DIFF
--- a/packages/seed-bible/seed-bible/managers/TabsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/TabsManager.tsx
@@ -386,9 +386,16 @@ export function createTabs(
     // change and re-commit, defeating the prescriptive (one-write-per-nav)
     // design.
     untracked(() => {
-      const readingState = selectedTab.peek()?.readingState;
-      const nextQueryParams =
-        readingState?.getUrlQueryParams(navigation.currentUrl.peek()) ?? {};
+      const tab = selectedTab.peek();
+      const nextQueryParams: Record<string, string | null> =
+        tab?.readingState.getUrlQueryParams(navigation.currentUrl.peek()) ?? {};
+
+      // Keep a shared session's id in the URL so a refresh rejoins it (see
+      // `setupInitialSession` in SeedBibleStateManager, which reads this
+      // param back on startup) instead of silently dropping the user.
+      if (tab?.sharedSession) {
+        nextQueryParams.sessionId = tab.sharedSession.id;
+      }
 
       const oldKeys = Object.keys(oldQueryParams);
       const newKeys = Object.keys(nextQueryParams);

--- a/test/unit/seed-bible/managers/TabsManager.test.ts
+++ b/test/unit/seed-bible/managers/TabsManager.test.ts
@@ -163,6 +163,36 @@ function createTabsManager({
   return { navigation, dataManager, highlightsManager, i18nManager, tabs };
 }
 
+function createMockSharedSession(
+  id: string,
+  readingState: BibleReadingState
+): BibleReadingSession {
+  return {
+    id,
+    readingState,
+    document: {} as SharedDocument,
+    options: signal({
+      allowedNavigators: null,
+      allowedDecorators: null,
+      hostUserId: null,
+      highlightDurationSeconds: 16,
+      endedAt: null,
+      shareTranslation: false,
+      coHostUserIds: [],
+    }),
+    updateOptions: vi.fn(),
+    removeSharedDecoration: vi.fn(),
+    dispose: vi.fn(),
+    allUsers: signal([]),
+    connectedUsers: signal([]),
+    localSessionId: signal(id),
+    userCanDecorate: vi.fn().mockReturnValue(true),
+    userCanNavigate: vi.fn().mockReturnValue(true),
+    currentUser: signal(null),
+    isHost: vi.fn().mockReturnValue(false),
+  } as BibleReadingSession;
+}
+
 describe("createTabs", () => {
   afterEach(() => {
     vi.restoreAllMocks();
@@ -197,36 +227,62 @@ describe("createTabs", () => {
     const { tabs: manager } = createTabsManager();
     await waitForTabsToLoad(manager.tabs.value);
 
-    const sharedSession = {
-      id: "session-123",
-      readingState: manager.tabs.value[0]!.readingState,
-      document: {} as SharedDocument,
-      options: signal({
-        allowedNavigators: null,
-        allowedDecorators: null,
-        hostUserId: null,
-        highlightDurationSeconds: 16,
-        endedAt: null,
-        shareTranslation: false,
-        coHostUserIds: [],
-      }),
-      updateOptions: vi.fn(),
-      removeSharedDecoration: vi.fn(),
-      dispose: vi.fn(),
-      allUsers: signal([]),
-      connectedUsers: signal([]),
-      localSessionId: signal("session-123"),
-      userCanDecorate: vi.fn().mockReturnValue(true),
-      userCanNavigate: vi.fn().mockReturnValue(true),
-      currentUser: signal(null),
-      isHost: vi.fn().mockReturnValue(false),
-    } as BibleReadingSession;
+    const sharedSession = createMockSharedSession(
+      "session-123",
+      manager.tabs.value[0]!.readingState
+    );
 
     const nextTab = manager.addTab(sharedSession);
 
     expect(nextTab.readingState).toBe(sharedSession.readingState);
     expect(nextTab.sharedSession).toBe(sharedSession);
     expect(manager.selectedTabId.value).toBe(nextTab.id);
+  });
+
+  it("addTab() with a shared session writes its id to the URL as sessionId", async () => {
+    setWebResponses(createExampleManagerResponseMap());
+    const { tabs: manager, navigation } = createTabsManager();
+    await waitForTabsToLoad(manager.tabs.value);
+
+    const sharedSession = createMockSharedSession(
+      "session-456",
+      manager.tabs.value[0]!.readingState
+    );
+
+    manager.addTab(sharedSession);
+    await waitFor(
+      () => navigation.currentUrl.value.searchParams.get("sessionId") !== null
+    );
+
+    expect(navigation.currentUrl.value.searchParams.get("sessionId")).toBe(
+      "session-456"
+    );
+  });
+
+  it("selectTab() away from a shared-session tab removes sessionId from the URL", async () => {
+    setWebResponses(createExampleManagerResponseMap());
+    const { tabs: manager, navigation } = createTabsManager();
+    await waitForTabsToLoad(manager.tabs.value);
+
+    const plainTab = manager.tabs.value[0]!;
+    const sharedSession = createMockSharedSession(
+      "session-789",
+      plainTab.readingState
+    );
+    const sharedTab = manager.addTab(sharedSession);
+    await waitFor(
+      () => navigation.currentUrl.value.searchParams.get("sessionId") !== null
+    );
+
+    manager.selectTab(plainTab.id);
+    await waitFor(
+      () => navigation.currentUrl.value.searchParams.get("sessionId") === null
+    );
+
+    expect(
+      navigation.currentUrl.value.searchParams.get("sessionId")
+    ).toBeNull();
+    expect(sharedTab.sharedSession).toBe(sharedSession);
   });
 
   it("addTab() accepts a reading state for the new tab", async () => {


### PR DESCRIPTION
commitSelectedTabToUrl already writes the selected tab's reading
position (book/chapter/translation) into the URL and reacts on every
tab switch. Fold the selected tab's sharedSession.id into that same
query-param diff as sessionId, using the existing removedKeys cleanup
to drop it when switching to a non-shared tab.

setupInitialSession already reads ?sessionId= on startup and rejoins,
but nothing wrote it back, so refreshing a shared tab silently kicked
the user out.

Fixes #1411

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_019ZzLv6EtgiNvUEQTRcNdU7