### PR TITLE
fix: stop highlight ribbon padding from crowding an adjacent verse's text

### DIFF
--- a/packages/seed-bible/seed-bible/app/highlightRibbon.ts
+++ b/packages/seed-bible/seed-bible/app/highlightRibbon.ts
@@ -242,7 +242,7 @@ export function buildRibbonPath(
   return paths.join(" ");
 }
 
-function isBlockLevel(node: Node): boolean {
+export function isBlockLevel(node: Node): boolean {
   if (node.nodeType !== 1) return false;
   const display = getComputedStyle(node as Element).display;
   return (
@@ -323,4 +323,68 @@ export function collectLineRects(
     }
   }
   return lines;
+}
+
+/**
+ * Measure the inline text sitting immediately next to `el` in reading order —
+ * `side: "before"` for the content that precedes it, `"after"` for what follows
+ * — as a rectangle relative to (originLeft, originTop). Returns the rect nearest
+ * to `el` (the previous content's last visual line, or the next content's first).
+ *
+ * Returns null when a block boundary — a line break, heading, block-level poetry
+ * line, or the absolutely-positioned ribbon layer — or the start/end of the flow
+ * sits on that side, because then nothing shares a text line with `el`'s edge.
+ *
+ * The caller compares this against the run's own first/last line to tell whether
+ * a highlight begins or ends mid-line, with another verse's text right beside it.
+ * Where it does, the run's horizontal pad on that edge is dropped so the ribbon
+ * doesn't reach over into that neighbouring text (see `measureRibbons`).
+ */
+export function adjacentInlineRect(
+  el: Element,
+  side: "before" | "after",
+  originLeft: number,
+  originTop: number
+): RibbonRect | null {
+  const range = document.createRange();
+  // No layout to measure against in jsdom (unit tests) — bail cleanly.
+  if (typeof range.getClientRects !== "function") return null;
+  const step = (n: Node): Node | null =>
+    side === "before" ? n.previousSibling : n.nextSibling;
+  for (let sib = step(el); sib; sib = step(sib)) {
+    if (sib.nodeType === 3) {
+      // Skip whitespace-only text nodes between elements.
+      if (!sib.textContent || !sib.textContent.trim()) continue;
+    } else if (sib.nodeType === 1) {
+      const style = getComputedStyle(sib as Element);
+      if (
+        isBlockLevel(sib) ||
+        style.position === "absolute" ||
+        style.position === "fixed"
+      ) {
+        return null;
+      }
+    } else {
+      continue;
+    }
+    range.selectNodeContents(sib);
+    const rects = range.getClientRects();
+    // The edge we face: the last drawable rect before us, or the first after us.
+    let pick: DOMRect | null = null;
+    for (let i = 0; i < rects.length; i++) {
+      const r = rects[i];
+      if (!r || r.width <= 0 || r.height <= 0) continue;
+      if (side === "before" || !pick) pick = r;
+    }
+    if (pick) {
+      return {
+        left: pick.left - originLeft,
+        right: pick.right - originLeft,
+        top: pick.top - originTop,
+        bottom: pick.bottom - originTop,
+      };
+    }
+    // Inline sibling with nothing drawable (e.g. empty) — keep scanning outward.
+  }
+  return null;
 }

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
@@ -7,8 +7,10 @@ import type { JSX } from "preact";
 import { Suspense, useRef, useLayoutEffect, useState } from "preact/compat";
 import { computed, type ReadonlySignal, type Signal } from "@preact/signals";
 import {
+  adjacentInlineRect,
   buildRibbonPath,
   collectLineRects,
+  type RibbonRect,
   RIBBON_RADIUS_EM,
   RIBBON_PAD_X_EM,
 } from "../../app/highlightRibbon";
@@ -1048,12 +1050,13 @@ function ChapterContent(props: ChapterContentProps) {
     const rtl = style.direction === "rtl";
 
     // Phase 1: measure every highlighted run's per-line geometry. `leadPad` /
-    // `trailPad` default to padX and may be dropped to 0 below where two colors
-    // abut horizontally.
+    // `trailPad` default to padX and may be dropped to 0 below where the run's
+    // edge sits alongside another verse's text on the same line.
     const runs = Array.from(
       content.querySelectorAll<HTMLElement>("[data-highlight-fill]")
     )
       .map((el, index) => ({
+        el,
         key: el.getAttribute("data-highlight-key") || `i${index}`,
         fill: el.getAttribute("data-highlight-fill") ?? "",
         lines: collectLineRects(el, box.left, box.top),
@@ -1062,35 +1065,25 @@ function ChapterContent(props: ChapterContentProps) {
       }))
       .filter((run) => run.fill !== "" && run.lines.length > 0);
 
-    // Phase 2: where two different-colored runs sit side by side on the same
-    // visual line (e.g. "...garden, ³but about..."), their facing pads would eat
-    // the small gap the verse-number margin leaves and the colors would nearly
-    // touch (and, when they overlap, the rounded ends read as points). Drop the
-    // pad on just those two facing edges — the earlier run's trailing edge (where
-    // it ends) and the later run's leading edge (where the next starts) — so that
-    // margin reads as a clean gutter. In RTL the earlier run sits to the right of
-    // the later one, so the gap is measured on the mirrored sides. Only
-    // consecutive runs that actually abut (a sub-em gap, not an unhighlighted
-    // verse between them) are trimmed.
-    const abutMax = fontSize; // ~1em: covers the verse-number margin, far under a verse's width
-    for (let k = 1; k < runs.length; k++) {
-      const prev = runs[k - 1]!;
-      const cur = runs[k]!;
-      if (prev.fill === cur.fill) continue;
-      const prevLast = prev.lines[prev.lines.length - 1]!;
-      const curFirst = cur.lines[0]!;
-      const sharesLine =
-        curFirst.top < prevLast.bottom - 2 &&
-        prevLast.top < curFirst.bottom - 2;
-      // Reading-order gap between where `prev` ends and `cur` begins: in LTR that
-      // is prev's right edge to cur's left edge; in RTL it mirrors.
-      const gap = rtl
-        ? prevLast.left - curFirst.right
-        : curFirst.left - prevLast.right;
-      if (sharesLine && gap >= 0 && gap < abutMax) {
-        prev.trailPad = 0;
-        cur.leadPad = 0;
-      }
+    // Phase 2: where a run begins or ends mid-line — with another verse's text
+    // right beside it on the same visual line — its horizontal pad would reach
+    // over into that text. This happens whenever a highlighted verse starts (or
+    // ends) partway along a line, whether the neighbour is a plain unhighlighted
+    // verse ("...had your fill. ²⁷Do not work...") or a differently-colored
+    // highlight abutting on the same line. Drop the pad on just that facing edge
+    // so the ribbon stops at its own glyphs and leaves the verse-number margin as
+    // a clean gutter. Every edge that faces a line break or the page margin keeps
+    // its pad. `adjacentInlineRect` reports the neighbouring text on each side;
+    // lead/trail map to the correct physical edge for RTL inside buildRibbonPath.
+    const sharesLine = (r: RibbonRect, line: RibbonRect) =>
+      r.top < line.bottom - 2 && r.bottom > line.top + 2;
+    for (const run of runs) {
+      const first = run.lines[0]!;
+      const last = run.lines[run.lines.length - 1]!;
+      const before = adjacentInlineRect(run.el, "before", box.left, box.top);
+      const after = adjacentInlineRect(run.el, "after", box.left, box.top);
+      if (before && sharesLine(before, first)) run.leadPad = 0;
+      if (after && sharesLine(after, last)) run.trailPad = 0;
     }
 
     const next: Array<{

--- a/test/unit/seed-bible/components/highlightRibbon.test.ts
+++ b/test/unit/seed-bible/components/highlightRibbon.test.ts
@@ -1,5 +1,6 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, afterEach } from "vitest";
 import {
+  adjacentInlineRect,
   buildRibbonPath,
   type RibbonRect,
 } from "@packages/seed-bible/seed-bible/app/highlightRibbon";
@@ -165,7 +166,154 @@ describe("buildRibbonPath", () => {
     const d = buildRibbonPath(overlapping, 8, 4, PITCH);
     expect((d.match(/M /g) ?? []).length).toBe(1); // one continuous body
   });
+});
 
+// A minimal fake DOM node whose measured rects and computed style we control, so
+// we can exercise adjacentInlineRect's sibling walk without a real layout engine.
+type FakeNode = {
+  nodeType: number;
+  textContent?: string;
+  previousSibling: FakeNode | null;
+  nextSibling: FakeNode | null;
+  __rects: Array<{
+    left: number;
+    right: number;
+    top: number;
+    bottom: number;
+    width: number;
+    height: number;
+  }>;
+  __style: { display: string; position: string };
+};
+
+function rect(left: number, top: number, right: number, bottom: number) {
+  return {
+    left,
+    top,
+    right,
+    bottom,
+    width: right - left,
+    height: bottom - top,
+  };
+}
+
+function fakeNode(over: Partial<FakeNode> = {}): FakeNode {
+  return {
+    nodeType: 1,
+    previousSibling: null,
+    nextSibling: null,
+    __rects: [],
+    __style: { display: "inline", position: "static" },
+    ...over,
+  };
+}
+
+// Wire an ordered list of siblings together via previous/next pointers.
+function chain(nodes: FakeNode[]) {
+  for (let i = 0; i < nodes.length; i++) {
+    nodes[i]!.previousSibling = nodes[i - 1] ?? null;
+    nodes[i]!.nextSibling = nodes[i + 1] ?? null;
+  }
+}
+
+describe("adjacentInlineRect", () => {
+  const realCreateRange = document.createRange;
+  const realGetComputedStyle = globalThis.getComputedStyle;
+
+  afterEach(() => {
+    document.createRange = realCreateRange;
+    globalThis.getComputedStyle = realGetComputedStyle;
+  });
+
+  // Stub createRange/getComputedStyle so the function measures our fake nodes.
+  function install() {
+    let selected: FakeNode | null = null;
+    document.createRange = (() => ({
+      getClientRects: () => (selected?.__rects ?? []) as unknown as DOMRectList,
+      selectNodeContents: (n: unknown) => {
+        selected = n as FakeNode;
+      },
+    })) as unknown as typeof document.createRange;
+    globalThis.getComputedStyle = ((n: unknown) =>
+      (n as FakeNode)
+        .__style as unknown as CSSStyleDeclaration) as typeof getComputedStyle;
+  }
+
+  it("returns the previous inline text's last line, relative to the origin", () => {
+    // prev has two lines; the one nearest the run (its last) is what we face.
+    const prev = fakeNode({
+      __rects: [rect(10, 0, 90, 20), rect(10, 25, 60, 45)],
+    });
+    const run = fakeNode();
+    chain([prev, run]);
+    install();
+
+    const r = adjacentInlineRect(run as unknown as Element, "before", 10, 5);
+    // Nearest rect (10,25,60,45) shifted by origin (10,5).
+    expect(r).toEqual({ left: 0, right: 50, top: 20, bottom: 40 });
+  });
+
+  it("returns the next inline text's first line", () => {
+    const run = fakeNode();
+    const next = fakeNode({
+      __rects: [rect(200, 25, 260, 45), rect(80, 50, 140, 70)],
+    });
+    chain([run, next]);
+    install();
+
+    const r = adjacentInlineRect(run as unknown as Element, "after", 0, 0);
+    expect(r).toEqual({ left: 200, right: 260, top: 25, bottom: 45 });
+  });
+
+  it("stops at a block-level boundary (a line break) with null", () => {
+    const lineBreak = fakeNode({
+      __style: { display: "block", position: "static" },
+      __rects: [rect(0, 0, 300, 5)],
+    });
+    const run = fakeNode();
+    chain([lineBreak, run]);
+    install();
+
+    expect(
+      adjacentInlineRect(run as unknown as Element, "before", 0, 0)
+    ).toBeNull();
+  });
+
+  it("stops at the out-of-flow ribbon layer (position: absolute) with null", () => {
+    const layer = fakeNode({
+      __style: { display: "inline", position: "absolute" },
+      __rects: [rect(0, 0, 300, 400)],
+    });
+    const run = fakeNode();
+    chain([layer, run]);
+    install();
+
+    expect(
+      adjacentInlineRect(run as unknown as Element, "before", 0, 0)
+    ).toBeNull();
+  });
+
+  it("skips whitespace-only text nodes to reach the real neighbour", () => {
+    const prev = fakeNode({ __rects: [rect(10, 0, 90, 20)] });
+    const space = fakeNode({ nodeType: 3, textContent: "  " });
+    const run = fakeNode();
+    chain([prev, space, run]);
+    install();
+
+    const r = adjacentInlineRect(run as unknown as Element, "before", 0, 0);
+    expect(r).toEqual({ left: 10, right: 90, top: 0, bottom: 20 });
+  });
+
+  it("returns null when there is no sibling on that side", () => {
+    const run = fakeNode();
+    install();
+    expect(
+      adjacentInlineRect(run as unknown as Element, "before", 0, 0)
+    ).toBeNull();
+  });
+});
+
+describe("buildRibbonPath (slot adjacency)", () => {
   it("makes two vertically-adjacent runs meet at the shared slot boundary", () => {
     // Two single-line runs on consecutive lines (pitch 65): run A on the first
     // slot, run B on the next. Their touching edges should land on the same y.


### PR DESCRIPTION
A highlight that begins or ends partway along a line (for example verse 27
starting right after unhighlighted "...had your fill." on the same line) was
still padding its leading/trailing edge, so the rounded ribbon reached left
over the previous verse's text.

The earlier fix only trimmed that pad where two differently-colored highlights
abutted, missing the far more common case of a highlight sitting next to plain,
unhighlighted verse text. Detect the neighbouring inline text on each side of a
run (`adjacentInlineRect`) and drop the horizontal pad on any edge that faces
another verse's text on the same line — whether highlighted or not — while edges
that face a line break or the page margin keep their pad. This generalizes and
replaces the previous different-color-only logic.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_012Awv9KctEA5a52wA1abJJ2