### PR TITLE
fix: stop Welcome ↔ Today flash by gating on reading-history status (#1490)

### DIFF
--- a/packages/today-screen/domain/models/readingHistory.tsx
+++ b/packages/today-screen/domain/models/readingHistory.tsx
@@ -56,4 +56,23 @@ export type CommunityReading<T extends string> = {
   [K in T]: FilteredReading;
 };
 
-export type UserLastReading = { bookId: string; chapter: number } | undefined;
+/** A concrete resume position: the last book/chapter a user was reading. */
+export type LastReading = { bookId: string; chapter: number };
+
+/** The result of a last-reading lookup — a position, or `undefined` if none. */
+export type UserLastReading = LastReading | undefined;
+
+/**
+ * The Today screen's reading-history gate as a three-state status, replacing
+ * the old `LastReading | undefined` that conflated "still loading" with "no
+ * history". `loading` and `ready` both render the personalized layout
+ * (`loading` shows placeholders); only `empty` renders the Welcome page.
+ *
+ * - `loading` — a userId is known and the history fetch is in flight.
+ * - `empty`   — no userId (new/anonymous), or the fetch confirmed no history.
+ * - `ready`   — the fetch found a resume position.
+ */
+export type ReadingHistoryState =
+  | { status: "loading" }
+  | { status: "empty" }
+  | { status: "ready"; lastReading: LastReading };

--- a/packages/today-screen/extension.json
+++ b/packages/today-screen/extension.json
@@ -20,6 +20,7 @@
       "wednesday-short": "Wed",
       "friday-short": "Fri",
       "resume-reading": "CONTINUE WHERE YOU LEFT",
+      "resume-reading-loading": "Loading your reading history…",
       "greeting-morning": "Good morning",
       "greeting-afternoon": "Good afternoon",
       "greeting-evening": "Good evening",

--- a/packages/today-screen/extension.json
+++ b/packages/today-screen/extension.json
@@ -5,8 +5,6 @@
     "en": {
       "title": "Today screen",
       "description": "Personalized daily home screen for the reader: time-based greeting, resume-reading shortcut, bookmarks, verse search, a community panel with live sessions and other readers' activity, a reading-history timeline, and chapter recommendations.",
-      "everything-begins-small": "Everything begins small.",
-      "no-rush": "Take your time. — there is no streak to keep, or race to win.",
       "read-first-chapter": "Read the first chapter",
       "open-bible": "Open Bible",
       "anonymous-greeting": "Welcome!",

--- a/packages/today-screen/infrastructure/di/bootstrap.tsx
+++ b/packages/today-screen/infrastructure/di/bootstrap.tsx
@@ -1,6 +1,10 @@
 import { computed, effect, signal } from "@preact/signals";
 import { registerExtension, type SeedBibleState } from "seed-bible";
 import { MaterialIcon } from "@packages/seed-bible/seed-bible/components";
+import {
+  Skeleton,
+  SkeletonContainer,
+} from "@packages/seed-bible/seed-bible/components/Skeleton/Skeleton";
 import { Today } from "../presentation/components/Today";
 import { useI18n } from "@packages/seed-bible/seed-bible/i18n";
 import { TodayReadingHistoryService } from "@packages/today-screen/application/services/TodayReadingHistoryService";
@@ -230,6 +234,8 @@ export const bootstrapExtension = () => {
               config={{
                 ColorParser,
                 MaterialIcon,
+                Skeleton,
+                SkeletonContainer,
                 language,
                 username: context.login.profile.value?.name,
                 userId: context.login.userId.value ?? undefined,

--- a/packages/today-screen/infrastructure/di/bootstrap.tsx
+++ b/packages/today-screen/infrastructure/di/bootstrap.tsx
@@ -5,10 +5,8 @@ import { Today } from "../presentation/components/Today";
 import { useI18n } from "@packages/seed-bible/seed-bible/i18n";
 import { TodayReadingHistoryService } from "@packages/today-screen/application/services/TodayReadingHistoryService";
 import { SubscribedUsersProvider } from "../adapters/subscriptions/SubscribedUsersProvider";
-import type {
-  FilteredReading,
-  UserLastReading,
-} from "@packages/today-screen/domain/models/readingHistory";
+import type { FilteredReading } from "@packages/today-screen/domain/models/readingHistory";
+import { createReadingHistoryState } from "./createReadingHistoryState";
 import type { UtilsAPI } from "@packages/seed-bible-utils/infrastructure/models/seedBible";
 import { getReadingHistoryEvents } from "@packages/seed-bible/seed-bible/managers";
 import { getDefaultTranslationForLanguage } from "@packages/seed-bible/seed-bible/managers";
@@ -85,7 +83,16 @@ export const bootstrapExtension = () => {
         },
       });
 
-      const userLastReading = signal<UserLastReading>(undefined);
+      // Three-state reading-history gate (loading | empty | ready). Derived
+      // from `userId` (known synchronously at startup) so a returning user
+      // never flashes the Welcome page while their history loads.
+      const { readingHistory, dispose: disposeReadingHistory } =
+        createReadingHistoryState({
+          userId: context.login.userId,
+          refetchTrigger: context.app.currentReadingState,
+          getUserLastReading: (userId, range) =>
+            todayReadingHistoryService.getUserLastReading(userId, range),
+        });
 
       /**
        * Fetches the community reading for one exact period. The presentation
@@ -168,33 +175,6 @@ export const bootstrapExtension = () => {
           .trim();
       };
 
-      const cleanupUserLastReading = effect(() => {
-        const userId = context.login.userId.value;
-        // eslint-disable-next-line @typescript-eslint/no-unused-expressions
-        context.app.currentReadingState.value;
-
-        if (!userId) {
-          userLastReading.value = undefined;
-          return;
-        }
-
-        const now = Math.floor(Date.now() / 1000);
-        const oneYearAgo = now - 365 * 24 * 60 * 60;
-
-        void todayReadingHistoryService
-          .getUserLastReading(userId, { from: oneYearAgo, to: now })
-          .then((result) => {
-            userLastReading.value = result;
-          })
-          .catch((err) => {
-            console.error(
-              "[Debug] [today-screen] getUserLastReading failed for userId",
-              userId,
-              err
-            );
-          });
-      });
-
       const lastTranslationBooks = signal<{
         books: Array<{
           id: string;
@@ -265,7 +245,7 @@ export const bootstrapExtension = () => {
                       ),
                     }
                   : undefined,
-                userLastReading,
+                readingHistory,
                 getCommunityReading,
                 translate: (key, options) =>
                   t(key, {
@@ -434,7 +414,7 @@ export const bootstrapExtension = () => {
       };
 
       yield () => {
-        cleanupUserLastReading();
+        disposeReadingHistory();
         cleanupTranslationBooks();
         cleanupTranslationId();
         cleanupTodayUrlSync();

--- a/packages/today-screen/infrastructure/di/createReadingHistoryState.tsx
+++ b/packages/today-screen/infrastructure/di/createReadingHistoryState.tsx
@@ -1,0 +1,95 @@
+import { signal, effect, type ReadonlySignal } from "@preact/signals";
+import type {
+  ReadingHistoryState,
+  UserLastReading,
+} from "@packages/today-screen/domain/models/readingHistory";
+
+export interface ReadingHistoryStateDeps {
+  /** The current user id, synchronously known from the cached session key. */
+  userId: ReadonlySignal<string | null>;
+  /**
+   * Any signal whose changes should re-fetch the resume position (the user's
+   * live reading state). Read only for its reactivity — the value is unused.
+   */
+  refetchTrigger: ReadonlySignal<unknown>;
+  getUserLastReading: (
+    userId: string,
+    range: { from: number; to: number }
+  ) => Promise<UserLastReading>;
+}
+
+const ONE_YEAR_SECONDS = 365 * 24 * 60 * 60;
+
+/**
+ * Owns the Today screen's reading-history gate. It derives the first-paint
+ * branch from `userId` (known synchronously at startup), so a returning user
+ * never flashes the Welcome page while their history loads:
+ *
+ * - `userId === null` → `empty` (Welcome), no fetch.
+ * - `userId !== null` → `loading` (personalized placeholders), then reconcile
+ *   to `ready` / `empty` when the fetch resolves.
+ *
+ * Cross-account safety: on every `userId` change the state resets to `loading`
+ * (clearing the previous account's position before the new fetch resolves),
+ * and any in-flight fetch whose userId is no longer current is ignored — so
+ * account A's result can never overwrite account B's state. A same-user refetch
+ * (reading progressed) keeps the current card visible while revalidating.
+ *
+ * The returned `dispose` tears down the internal effect.
+ */
+export function createReadingHistoryState(deps: ReadingHistoryStateDeps): {
+  readingHistory: ReadonlySignal<ReadingHistoryState>;
+  dispose: () => void;
+} {
+  const readingHistory = signal<ReadingHistoryState>({ status: "loading" });
+
+  // The userId the effect last acted on. The initial `undefined` (never a real
+  // value) forces the first run to be treated as a change.
+  let lastSeenUserId: string | null | undefined = undefined;
+
+  const dispose = effect(() => {
+    const userId = deps.userId.value;
+    // Re-run when reading progresses so the resume position stays fresh.
+    // eslint-disable-next-line @typescript-eslint/no-unused-expressions
+    deps.refetchTrigger.value;
+
+    const userChanged = userId !== lastSeenUserId;
+    lastSeenUserId = userId;
+
+    if (!userId) {
+      // Signed out: back to Welcome, dropping the previous account's position.
+      readingHistory.value = { status: "empty" };
+      return;
+    }
+
+    // Only clear to a placeholder when the account itself changed; a plain
+    // reading-progress refetch keeps the current card visible (no flicker).
+    if (userChanged) {
+      readingHistory.value = { status: "loading" };
+    }
+
+    const requestedUserId = userId;
+    const now = Math.floor(Date.now() / 1000);
+
+    void deps
+      .getUserLastReading(userId, { from: now - ONE_YEAR_SECONDS, to: now })
+      .then((result) => {
+        // Ignore a result for a user who is no longer current.
+        if (deps.userId.peek() !== requestedUserId) return;
+        readingHistory.value = result
+          ? { status: "ready", lastReading: result }
+          : { status: "empty" };
+      })
+      .catch((err) => {
+        if (deps.userId.peek() !== requestedUserId) return;
+        console.error(
+          "[Debug] [today-screen] getUserLastReading failed for userId",
+          userId,
+          err
+        );
+        readingHistory.value = { status: "empty" };
+      });
+  });
+
+  return { readingHistory, dispose };
+}

--- a/packages/today-screen/infrastructure/di/createReadingHistoryState.tsx
+++ b/packages/today-screen/infrastructure/di/createReadingHistoryState.tsx
@@ -76,9 +76,14 @@ export function createReadingHistoryState(deps: ReadingHistoryStateDeps): {
       .then((result) => {
         // Ignore a result for a user who is no longer current.
         if (deps.userId.peek() !== requestedUserId) return;
-        readingHistory.value = result
-          ? { status: "ready", lastReading: result }
-          : { status: "empty" };
+        if (result) {
+          readingHistory.value = { status: "ready", lastReading: result };
+        } else if (userChanged) {
+          // Fresh load / account switch with no history → Welcome.
+          readingHistory.value = { status: "empty" };
+        }
+        // Same-user refetch that came back empty: keep the card already showing
+        // rather than erasing a known-good position on a spurious empty result.
       })
       .catch((err) => {
         if (deps.userId.peek() !== requestedUserId) return;
@@ -87,7 +92,14 @@ export function createReadingHistoryState(deps: ReadingHistoryStateDeps): {
           userId,
           err
         );
-        readingHistory.value = { status: "empty" };
+        // Only surface Welcome when there was no prior card to keep — a fresh
+        // load or account switch. On a same-user refetch, a transient error
+        // must NOT flash a returning user back to Welcome. Gating on
+        // `userChanged` (not "is state ready?") keeps the cross-account
+        // guarantee: a failed account-switch fetch still clears the old card.
+        if (userChanged) {
+          readingHistory.value = { status: "empty" };
+        }
       });
   });
 

--- a/packages/today-screen/infrastructure/presentation/components/Today.tsx
+++ b/packages/today-screen/infrastructure/presentation/components/Today.tsx
@@ -4,9 +4,9 @@ import { TodayContainer } from "./containers/TodayContainer";
 import type { ReadonlySignal, Signal } from "@preact/signals";
 import type {
   FilteredReading,
+  ReadingHistoryState,
   TimespanOption,
   TimespanOptionId,
-  UserLastReading,
 } from "../../../domain/models/readingHistory";
 import type { ReadingHistoryTimelineComponent } from "../../../../seed-bible-utils/infrastructure/models/seedBible";
 import type { GetDayRangeSecondsType } from "../../../../seed-bible-utils/domain/functions/time";
@@ -42,7 +42,11 @@ export interface TodayConfig {
       }
     | undefined;
   userId: string | undefined;
-  userLastReading: Signal<UserLastReading>;
+  /**
+   * Reading-history gate: `loading`/`ready` render the personalized layout,
+   * `empty` renders Welcome. See {@link ReadingHistoryState}.
+   */
+  readingHistory: ReadonlySignal<ReadingHistoryState>;
   getCommunityReading: (timespan: {
     from: number;
     to: number;

--- a/packages/today-screen/infrastructure/presentation/components/Today.tsx
+++ b/packages/today-screen/infrastructure/presentation/components/Today.tsx
@@ -31,6 +31,20 @@ export interface TodayConfig {
     children: string;
     className?: string;
   }) => preact.JSX.Element;
+  /** Shared shimmering placeholder block (see the reader's `Skeleton`). */
+  Skeleton: (props: {
+    shape?: "block" | "line" | "circle" | "button";
+    width?: string;
+    height?: string;
+    radius?: string;
+    className?: string;
+  }) => preact.JSX.Element;
+  /** Accessible wrapper announcing a group of `Skeleton` blocks as loading. */
+  SkeletonContainer: (props: {
+    label: string;
+    className?: string;
+    children: preact.ComponentChildren;
+  }) => preact.JSX.Element;
   language: string;
   username: string | undefined;
   userProfile:

--- a/packages/today-screen/infrastructure/presentation/components/containers/ResumeReadingSection.tsx
+++ b/packages/today-screen/infrastructure/presentation/components/containers/ResumeReadingSection.tsx
@@ -8,8 +8,29 @@ export interface ResumeReadingCardData {
 }
 
 export const ResumeReadingSection = () => {
-  const { MaterialIcon, cardData, handleButtonClick } =
+  const { MaterialIcon, isLoading, cardData, handleButtonClick } =
     useResumeReadingSection();
+
+  // History still loading: show a placeholder card so a returning user sees the
+  // personalized layout (never Welcome) while the resume position is fetched.
+  if (isLoading || !cardData) {
+    return (
+      <div
+        className="today-resume-card today-resume-card--loading"
+        aria-hidden="true"
+      >
+        <span
+          className="today-resume-skeleton"
+          style={{ width: "45%", height: "0.75rem" }}
+        />
+        <span
+          className="today-resume-skeleton"
+          style={{ width: "60%", height: "1.5rem" }}
+        />
+        <span className="today-resume-skeleton today-resume-skeleton--button" />
+      </div>
+    );
+  }
 
   return (
     <div className="today-resume-card">

--- a/packages/today-screen/infrastructure/presentation/components/containers/ResumeReadingSection.tsx
+++ b/packages/today-screen/infrastructure/presentation/components/containers/ResumeReadingSection.tsx
@@ -8,27 +8,30 @@ export interface ResumeReadingCardData {
 }
 
 export const ResumeReadingSection = () => {
-  const { MaterialIcon, isLoading, cardData, handleButtonClick } =
-    useResumeReadingSection();
+  const {
+    MaterialIcon,
+    Skeleton,
+    SkeletonContainer,
+    isLoading,
+    loadingLabel,
+    cardData,
+    handleButtonClick,
+  } = useResumeReadingSection();
 
   // History still loading: show a placeholder card so a returning user sees the
   // personalized layout (never Welcome) while the resume position is fetched.
   if (isLoading || !cardData) {
     return (
-      <div
+      <SkeletonContainer
+        label={loadingLabel}
         className="today-resume-card today-resume-card--loading"
-        aria-hidden="true"
       >
-        <span
-          className="today-resume-skeleton"
-          style={{ width: "45%", height: "0.75rem" }}
-        />
-        <span
-          className="today-resume-skeleton"
-          style={{ width: "60%", height: "1.5rem" }}
-        />
-        <span className="today-resume-skeleton today-resume-skeleton--button" />
-      </div>
+        <div className="today-resume-card-loading-text">
+          <Skeleton shape="line" width="45%" />
+          <Skeleton shape="line" width="60%" height="1.5rem" />
+        </div>
+        <Skeleton shape="circle" width="3rem" height="3rem" />
+      </SkeletonContainer>
     );
   }
 

--- a/packages/today-screen/infrastructure/presentation/components/containers/Welcome.tsx
+++ b/packages/today-screen/infrastructure/presentation/components/containers/Welcome.tsx
@@ -1,5 +1,4 @@
 import { useWelcome } from "../../hooks/useWelcome";
-import { SpinnerIcon } from "../ui/SpinnerIcon";
 import { SeedBibleIcon } from "../ui/SeedBibleIcon";
 
 export const Welcome = () => {
@@ -13,8 +12,6 @@ export const Welcome = () => {
     startButtonText,
     startButtonIcon,
     handleStartButtonClick,
-    footerTitle,
-    footerContent,
     seedBibleIconStyle,
   } = useWelcome();
 
@@ -42,11 +39,6 @@ export const Welcome = () => {
           {startButtonText}
           <MaterialIcon>{startButtonIcon}</MaterialIcon>
         </button>
-      </div>
-      <div className={"welcome-screen-footer"}>
-        {<SpinnerIcon style={{ width: "2.25rem", height: "2.25rem" }} />}
-        <h3 className={"welcome-screen-footer-title"}>{footerTitle}</h3>
-        <span className={"welcome-screen-footer-content"}>{footerContent}</span>
       </div>
     </div>
   );

--- a/packages/today-screen/infrastructure/presentation/hooks/useResumeReadingSection.tsx
+++ b/packages/today-screen/infrastructure/presentation/hooks/useResumeReadingSection.tsx
@@ -7,8 +7,22 @@ type UseResumeReadingSection = () => {
     children: string;
     className?: string | undefined;
   }) => preact.JSX.Element;
+  Skeleton: (props: {
+    shape?: "block" | "line" | "circle" | "button";
+    width?: string;
+    height?: string;
+    radius?: string;
+    className?: string;
+  }) => preact.JSX.Element;
+  SkeletonContainer: (props: {
+    label: string;
+    className?: string;
+    children: preact.ComponentChildren;
+  }) => preact.JSX.Element;
   /** True while history is still loading — render a placeholder card. */
   isLoading: boolean;
+  /** Already-translated status announced by the loading placeholder. */
+  loadingLabel: string;
   /** The resume-card data, or `null` while loading. */
   cardData: ResumeReadingCardData | null;
   handleButtonClick: () => void;
@@ -17,6 +31,8 @@ type UseResumeReadingSection = () => {
 export const useResumeReadingSection: UseResumeReadingSection = () => {
   const {
     MaterialIcon,
+    Skeleton,
+    SkeletonContainer,
     readingHistory,
     translate,
     bookNames,
@@ -48,7 +64,10 @@ export const useResumeReadingSection: UseResumeReadingSection = () => {
 
   return {
     MaterialIcon,
+    Skeleton,
+    SkeletonContainer,
     isLoading: state.status === "loading",
+    loadingLabel: translate("resume-reading-loading"),
     cardData,
     handleButtonClick,
   };

--- a/packages/today-screen/infrastructure/presentation/hooks/useResumeReadingSection.tsx
+++ b/packages/today-screen/infrastructure/presentation/hooks/useResumeReadingSection.tsx
@@ -7,14 +7,17 @@ type UseResumeReadingSection = () => {
     children: string;
     className?: string | undefined;
   }) => preact.JSX.Element;
-  cardData: ResumeReadingCardData;
+  /** True while history is still loading — render a placeholder card. */
+  isLoading: boolean;
+  /** The resume-card data, or `null` while loading. */
+  cardData: ResumeReadingCardData | null;
   handleButtonClick: () => void;
 };
 
 export const useResumeReadingSection: UseResumeReadingSection = () => {
   const {
     MaterialIcon,
-    userLastReading,
+    readingHistory,
     translate,
     bookNames,
     addTab,
@@ -22,34 +25,30 @@ export const useResumeReadingSection: UseResumeReadingSection = () => {
     getDefaultTranslation,
   } = useTodayContext();
 
-  if (!userLastReading.value) {
-    throw new Error(
-      `useResumeReadingSection: userLastReading.value is undefined`
-    );
-  }
+  const state = readingHistory.value;
+  // A resume position only exists in the `ready` state; in `loading` we render
+  // a placeholder instead of dereferencing a value that isn't there yet.
+  const lastReading = state.status === "ready" ? state.lastReading : undefined;
 
-  const cardData = useMemo<ResumeReadingCardData>(() => {
+  const cardData = useMemo<ResumeReadingCardData | null>(() => {
+    if (!lastReading) return null;
     return {
       title: translate("resume-reading"),
-      book:
-        bookNames.value.get(userLastReading.value!.bookId) ??
-        userLastReading.value!.bookId,
-      chapter: userLastReading.value!.chapter,
+      book: bookNames.value.get(lastReading.bookId) ?? lastReading.bookId,
+      chapter: lastReading.chapter,
       buttonIcon: "arrow_right_alt",
     };
-  }, [userLastReading.value, translate, bookNames.value]);
+  }, [lastReading, translate, bookNames.value]);
 
   const handleButtonClick = useCallback(() => {
-    addTab(
-      userLastReading.value!.bookId,
-      userLastReading.value!.chapter,
-      getDefaultTranslation()
-    );
+    if (!lastReading) return;
+    addTab(lastReading.bookId, lastReading.chapter, getDefaultTranslation());
     closeToday();
-  }, [userLastReading.value]);
+  }, [lastReading, addTab, closeToday, getDefaultTranslation]);
 
   return {
     MaterialIcon,
+    isLoading: state.status === "loading",
     cardData,
     handleButtonClick,
   };

--- a/packages/today-screen/infrastructure/presentation/hooks/useTodayContainer.tsx
+++ b/packages/today-screen/infrastructure/presentation/hooks/useTodayContainer.tsx
@@ -10,9 +10,13 @@ type UseTodayContainer = () => {
 };
 
 export const useTodayContainer: UseTodayContainer = () => {
-  const { userId, userLastReading } = useTodayContext();
+  const { readingHistory } = useTodayContext();
+  const status = readingHistory.value.status;
   const { Component, style } = useMemo(() => {
-    if (!userId || !userLastReading.value) {
+    // Welcome is a definite state — shown only when the user is known to have
+    // no history (`empty`). `loading` and `ready` both render the personalized
+    // layout, so a returning user never sees Welcome while history loads.
+    if (status === "empty") {
       return {
         Component: Welcome,
         style: { alignItems: "safe center" },
@@ -22,7 +26,7 @@ export const useTodayContainer: UseTodayContainer = () => {
       Component: TodayContent,
       style: { alignItems: "flex-start" },
     };
-  }, [userId, userLastReading.value]);
+  }, [status]);
 
   return {
     Component,

--- a/packages/today-screen/infrastructure/presentation/hooks/useTodayContent.tsx
+++ b/packages/today-screen/infrastructure/presentation/hooks/useTodayContent.tsx
@@ -9,9 +9,13 @@ type UseTodayContent = () => {
 };
 
 export const useTodayContent: UseTodayContent = () => {
-  const { userLastReading, bookmarks } = useTodayContext();
+  const { readingHistory, bookmarks } = useTodayContext();
 
-  const showResumeReading = !!userLastReading.value;
+  // Show the resume section (as a placeholder) while history is still loading,
+  // and (with real data) once it is ready. `empty` renders Welcome instead, so
+  // it never reaches here.
+  const status = readingHistory.value.status;
+  const showResumeReading = status === "loading" || status === "ready";
   const showBookmarks = bookmarks.value.length > 0;
   const showSearch = true;
   const showRecommendations = false;

--- a/packages/today-screen/infrastructure/presentation/hooks/useWelcome.tsx
+++ b/packages/today-screen/infrastructure/presentation/hooks/useWelcome.tsx
@@ -21,8 +21,6 @@ type UseWelcome = () => {
   startButtonText: string;
   startButtonIcon: string;
   handleStartButtonClick: () => void;
-  footerTitle: string;
-  footerContent: string;
   seedBibleIconStyle: React.CSSProperties;
 };
 
@@ -80,15 +78,12 @@ export const useWelcome: UseWelcome = () => {
     };
   }, [lastTranslationId.value]);
 
-  const { selectorText, startButtonText, footerTitle, footerContent } =
-    useMemo(() => {
-      return {
-        selectorText: translate("open-bible"),
-        startButtonText: translate("read-first-chapter"),
-        footerTitle: translate("everything-begins-small"),
-        footerContent: translate("no-rush"),
-      };
-    }, [translate]);
+  const { selectorText, startButtonText } = useMemo(() => {
+    return {
+      selectorText: translate("open-bible"),
+      startButtonText: translate("read-first-chapter"),
+    };
+  }, [translate]);
 
   const handleStartButtonClick = useCallback(() => {
     const defaultTranslation = getDefaultTranslation();
@@ -115,8 +110,6 @@ export const useWelcome: UseWelcome = () => {
     startButtonText,
     startButtonIcon: STRAT_BUTTON_ICON,
     handleStartButtonClick,
-    footerTitle,
-    footerContent,
     seedBibleIconStyle,
   };
 };

--- a/packages/today-screen/infrastructure/presentation/styles/styles.css
+++ b/packages/today-screen/infrastructure/presentation/styles/styles.css
@@ -115,8 +115,7 @@
 }
 
 .welcome-screen .welcome-screen-greeting,
-.welcome-screen .welcome-screen-book,
-.welcome-screen-footer-content {
+.welcome-screen .welcome-screen-book {
   color: var(--grey);
 }
 
@@ -174,23 +173,6 @@
 
 .welcome-screen .welcome-screen-start-button > span {
   font-size: 1rem;
-}
-
-.welcome-screen .welcome-screen-footer {
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  flex-direction: column;
-  gap: 0.5rem;
-  margin-top: 0.75rem;
-}
-
-.welcome-screen .welcome-screen-footer-title {
-  margin: 0.5rem 0 0;
-  font-family: "Newsreader";
-}
-
-.welcome-screen .welcome-screen-footer-content {
 }
 
 .today-content * {
@@ -307,6 +289,70 @@
 
 .today-container .today-resume-card > button > span {
   color: var(--sb-background);
+}
+
+/* Loading placeholder for the resume card — shown while the reading-history
+   fetch is in flight so a returning user sees the personalized layout rather
+   than the Welcome page. Reuses the card's grid; the shimmering bars stand in
+   for the label, book/chapter, and the open button. */
+.today-container .today-resume-card--loading {
+  align-items: center;
+}
+
+.today-resume-skeleton {
+  position: relative;
+  overflow: hidden;
+  border-radius: 0.25rem;
+  background: rgba(128, 128, 128, 0.2);
+}
+
+.today-resume-skeleton::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  transform: translateX(-100%);
+  background: linear-gradient(
+    90deg,
+    transparent,
+    rgba(255, 255, 255, 0.18),
+    transparent
+  );
+  animation: today-resume-shimmer 1.4s ease-in-out infinite;
+}
+
+@keyframes today-resume-shimmer {
+  100% {
+    transform: translateX(100%);
+  }
+}
+
+.today-container
+  .today-resume-card--loading
+  > .today-resume-skeleton:nth-child(1) {
+  grid-column: 1 / 2;
+  grid-row: 1 / 2;
+}
+
+.today-container
+  .today-resume-card--loading
+  > .today-resume-skeleton:nth-child(2) {
+  grid-column: 1 / 2;
+  grid-row: 2 / 3;
+}
+
+.today-resume-skeleton--button {
+  grid-column: 2 / 3;
+  grid-row: 1 / 3;
+  align-self: center;
+  width: 3rem;
+  height: 3rem;
+  border-radius: 50%;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .today-resume-skeleton::after {
+    animation: none;
+  }
 }
 
 .today-container .titled-section {

--- a/packages/today-screen/infrastructure/presentation/styles/styles.css
+++ b/packages/today-screen/infrastructure/presentation/styles/styles.css
@@ -293,66 +293,20 @@
 
 /* Loading placeholder for the resume card — shown while the reading-history
    fetch is in flight so a returning user sees the personalized layout rather
-   than the Welcome page. Reuses the card's grid; the shimmering bars stand in
-   for the label, book/chapter, and the open button. */
+   than the Welcome page. Overrides the card's grid with a simple row so the
+   shared <Skeleton> blocks (text stack + round button) mirror the real card. */
 .today-container .today-resume-card--loading {
+  display: flex;
   align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
 }
 
-.today-resume-skeleton {
-  position: relative;
-  overflow: hidden;
-  border-radius: 0.25rem;
-  background: rgba(128, 128, 128, 0.2);
-}
-
-.today-resume-skeleton::after {
-  content: "";
-  position: absolute;
-  inset: 0;
-  transform: translateX(-100%);
-  background: linear-gradient(
-    90deg,
-    transparent,
-    rgba(255, 255, 255, 0.18),
-    transparent
-  );
-  animation: today-resume-shimmer 1.4s ease-in-out infinite;
-}
-
-@keyframes today-resume-shimmer {
-  100% {
-    transform: translateX(100%);
-  }
-}
-
-.today-container
-  .today-resume-card--loading
-  > .today-resume-skeleton:nth-child(1) {
-  grid-column: 1 / 2;
-  grid-row: 1 / 2;
-}
-
-.today-container
-  .today-resume-card--loading
-  > .today-resume-skeleton:nth-child(2) {
-  grid-column: 1 / 2;
-  grid-row: 2 / 3;
-}
-
-.today-resume-skeleton--button {
-  grid-column: 2 / 3;
-  grid-row: 1 / 3;
-  align-self: center;
-  width: 3rem;
-  height: 3rem;
-  border-radius: 50%;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .today-resume-skeleton::after {
-    animation: none;
-  }
+.today-container .today-resume-card--loading .today-resume-card-loading-text {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+  flex: 1;
 }
 
 .today-container .titled-section {

--- a/test/unit/today-screen/infrastructure/di/createReadingHistoryState.test.ts
+++ b/test/unit/today-screen/infrastructure/di/createReadingHistoryState.test.ts
@@ -1,0 +1,204 @@
+import { signal } from "@preact/signals";
+import { createReadingHistoryState } from "../../../../../packages/today-screen/infrastructure/di/createReadingHistoryState";
+import type { UserLastReading } from "../../../../../packages/today-screen/domain/models/readingHistory";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+/** Flush all pending microtasks (a macrotask tick drains the promise queue). */
+const flush = () => new Promise<void>((r) => setTimeout(r, 0));
+
+describe("createReadingHistoryState", () => {
+  it("is empty and fetches nothing when there is no user", () => {
+    const userId = signal<string | null>(null);
+    const refetchTrigger = signal(0);
+    const getUserLastReading = vi.fn();
+
+    const { readingHistory, dispose } = createReadingHistoryState({
+      userId,
+      refetchTrigger,
+      getUserLastReading,
+    });
+
+    expect(readingHistory.value).toEqual({ status: "empty" });
+    expect(getUserLastReading).not.toHaveBeenCalled();
+    dispose();
+  });
+
+  it("goes loading → ready when the user has history", async () => {
+    const userId = signal<string | null>("A");
+    const refetchTrigger = signal(0);
+    const d = deferred<UserLastReading>();
+    const getUserLastReading = vi.fn(() => d.promise);
+
+    const { readingHistory, dispose } = createReadingHistoryState({
+      userId,
+      refetchTrigger,
+      getUserLastReading,
+    });
+
+    expect(readingHistory.value).toEqual({ status: "loading" });
+    expect(getUserLastReading).toHaveBeenCalledWith("A", expect.any(Object));
+
+    d.resolve({ bookId: "GEN", chapter: 2 });
+    await flush();
+
+    expect(readingHistory.value).toEqual({
+      status: "ready",
+      lastReading: { bookId: "GEN", chapter: 2 },
+    });
+    dispose();
+  });
+
+  it("goes loading → empty when the logged-in user has never read", async () => {
+    const userId = signal<string | null>("A");
+    const refetchTrigger = signal(0);
+    const d = deferred<UserLastReading>();
+    const getUserLastReading = vi.fn(() => d.promise);
+
+    const { readingHistory, dispose } = createReadingHistoryState({
+      userId,
+      refetchTrigger,
+      getUserLastReading,
+    });
+
+    expect(readingHistory.value).toEqual({ status: "loading" });
+
+    d.resolve(undefined);
+    await flush();
+
+    expect(readingHistory.value).toEqual({ status: "empty" });
+    dispose();
+  });
+
+  it("resets to loading on an account switch and ignores the previous user's late result", async () => {
+    const userId = signal<string | null>("A");
+    const refetchTrigger = signal(0);
+    const dA = deferred<UserLastReading>();
+    const dB = deferred<UserLastReading>();
+    const getUserLastReading = vi.fn((id: string) =>
+      id === "A" ? dA.promise : dB.promise
+    );
+
+    const { readingHistory, dispose } = createReadingHistoryState({
+      userId,
+      refetchTrigger,
+      getUserLastReading,
+    });
+
+    expect(readingHistory.value).toEqual({ status: "loading" });
+
+    // Switch to a second account before A's fetch resolves.
+    userId.value = "B";
+    expect(readingHistory.value).toEqual({ status: "loading" });
+
+    // B resolves first and becomes the live state.
+    dB.resolve({ bookId: "JHN", chapter: 1 });
+    await flush();
+    expect(readingHistory.value).toEqual({
+      status: "ready",
+      lastReading: { bookId: "JHN", chapter: 1 },
+    });
+
+    // A's stale, in-flight fetch must NOT overwrite B's state.
+    dA.resolve({ bookId: "GEN", chapter: 9 });
+    await flush();
+    expect(readingHistory.value).toEqual({
+      status: "ready",
+      lastReading: { bookId: "JHN", chapter: 1 },
+    });
+    dispose();
+  });
+
+  it("returns to empty on sign-out and ignores the previous user's late result", async () => {
+    const userId = signal<string | null>("A");
+    const refetchTrigger = signal(0);
+    const d = deferred<UserLastReading>();
+    const getUserLastReading = vi.fn(() => d.promise);
+
+    const { readingHistory, dispose } = createReadingHistoryState({
+      userId,
+      refetchTrigger,
+      getUserLastReading,
+    });
+
+    expect(readingHistory.value).toEqual({ status: "loading" });
+
+    userId.value = null;
+    expect(readingHistory.value).toEqual({ status: "empty" });
+
+    // A's fetch resolving after sign-out must not resurrect the old position.
+    d.resolve({ bookId: "GEN", chapter: 1 });
+    await flush();
+    expect(readingHistory.value).toEqual({ status: "empty" });
+    dispose();
+  });
+
+  it("refetches without flashing a placeholder when the same user reads on", async () => {
+    const userId = signal<string | null>("A");
+    const refetchTrigger = signal(0);
+    const d1 = deferred<UserLastReading>();
+    const d2 = deferred<UserLastReading>();
+    let call = 0;
+    const getUserLastReading = vi.fn(() =>
+      ++call === 1 ? d1.promise : d2.promise
+    );
+
+    const { readingHistory, dispose } = createReadingHistoryState({
+      userId,
+      refetchTrigger,
+      getUserLastReading,
+    });
+
+    d1.resolve({ bookId: "GEN", chapter: 1 });
+    await flush();
+    expect(readingHistory.value).toEqual({
+      status: "ready",
+      lastReading: { bookId: "GEN", chapter: 1 },
+    });
+
+    // Reading progresses: refetch, but the current card stays visible.
+    refetchTrigger.value = 1;
+    expect(readingHistory.value).toEqual({
+      status: "ready",
+      lastReading: { bookId: "GEN", chapter: 1 },
+    });
+    expect(getUserLastReading).toHaveBeenCalledTimes(2);
+
+    d2.resolve({ bookId: "JHN", chapter: 4 });
+    await flush();
+    expect(readingHistory.value).toEqual({
+      status: "ready",
+      lastReading: { bookId: "JHN", chapter: 4 },
+    });
+    dispose();
+  });
+
+  it("falls back to empty when the fetch fails", async () => {
+    const userId = signal<string | null>("A");
+    const refetchTrigger = signal(0);
+    const d = deferred<UserLastReading>();
+    const getUserLastReading = vi.fn(() => d.promise);
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { readingHistory, dispose } = createReadingHistoryState({
+      userId,
+      refetchTrigger,
+      getUserLastReading,
+    });
+
+    d.reject(new Error("boom"));
+    await flush();
+
+    expect(readingHistory.value).toEqual({ status: "empty" });
+    errSpy.mockRestore();
+    dispose();
+  });
+});

--- a/test/unit/today-screen/infrastructure/di/createReadingHistoryState.test.ts
+++ b/test/unit/today-screen/infrastructure/di/createReadingHistoryState.test.ts
@@ -181,7 +181,7 @@ describe("createReadingHistoryState", () => {
     dispose();
   });
 
-  it("falls back to empty when the fetch fails", async () => {
+  it("falls back to empty when the initial load fails", async () => {
     const userId = signal<string | null>("A");
     const refetchTrigger = signal(0);
     const d = deferred<UserLastReading>();
@@ -199,6 +199,80 @@ describe("createReadingHistoryState", () => {
 
     expect(readingHistory.value).toEqual({ status: "empty" });
     errSpy.mockRestore();
+    dispose();
+  });
+
+  it("keeps the current card when a same-user refetch fails", async () => {
+    const userId = signal<string | null>("A");
+    const refetchTrigger = signal(0);
+    const d1 = deferred<UserLastReading>();
+    const d2 = deferred<UserLastReading>();
+    let call = 0;
+    const getUserLastReading = vi.fn(() =>
+      ++call === 1 ? d1.promise : d2.promise
+    );
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { readingHistory, dispose } = createReadingHistoryState({
+      userId,
+      refetchTrigger,
+      getUserLastReading,
+    });
+
+    d1.resolve({ bookId: "GEN", chapter: 1 });
+    await flush();
+    expect(readingHistory.value).toEqual({
+      status: "ready",
+      lastReading: { bookId: "GEN", chapter: 1 },
+    });
+
+    // Reading progresses; the refetch fails on a transient error. A returning
+    // user must NOT be flashed back to Welcome — the existing card stays.
+    refetchTrigger.value = 1;
+    d2.reject(new Error("network blip"));
+    await flush();
+    expect(readingHistory.value).toEqual({
+      status: "ready",
+      lastReading: { bookId: "GEN", chapter: 1 },
+    });
+
+    errSpy.mockRestore();
+    dispose();
+  });
+
+  it("keeps the current card when a same-user refetch returns no history", async () => {
+    const userId = signal<string | null>("A");
+    const refetchTrigger = signal(0);
+    const d1 = deferred<UserLastReading>();
+    const d2 = deferred<UserLastReading>();
+    let call = 0;
+    const getUserLastReading = vi.fn(() =>
+      ++call === 1 ? d1.promise : d2.promise
+    );
+
+    const { readingHistory, dispose } = createReadingHistoryState({
+      userId,
+      refetchTrigger,
+      getUserLastReading,
+    });
+
+    d1.resolve({ bookId: "GEN", chapter: 1 });
+    await flush();
+    expect(readingHistory.value).toEqual({
+      status: "ready",
+      lastReading: { bookId: "GEN", chapter: 1 },
+    });
+
+    // A spurious empty result on a same-user refetch must not erase a
+    // known-good position.
+    refetchTrigger.value = 1;
+    d2.resolve(undefined);
+    await flush();
+    expect(readingHistory.value).toEqual({
+      status: "ready",
+      lastReading: { bookId: "GEN", chapter: 1 },
+    });
+
     dispose();
   });
 });

--- a/test/unit/today-screen/infrastructure/presentation/components/containers/Welcome.test.tsx
+++ b/test/unit/today-screen/infrastructure/presentation/components/containers/Welcome.test.tsx
@@ -13,13 +13,6 @@ vi.mock(
 );
 
 vi.mock(
-  "../../../../../../../packages/today-screen/infrastructure/presentation/components/ui/SpinnerIcon",
-  () => ({
-    SpinnerIcon: vi.fn(() => <div data-testid="spinner" />),
-  })
-);
-
-vi.mock(
   "../../../../../../../packages/today-screen/infrastructure/presentation/components/ui/SeedBibleIcon",
   () => ({
     SeedBibleIcon: vi.fn(() => <div data-testid="seed-bible-icon" />),
@@ -37,8 +30,6 @@ interface Options {
   selectorText?: string;
   startButtonText?: string;
   startButtonIcon?: string;
-  footerTitle?: string;
-  footerContent?: string;
   seedBibleIconStyle?: Record<string, string>;
   openBookSelector?: () => void;
   handleStartButtonClick?: () => void;
@@ -61,8 +52,6 @@ function makeResult(options: Options = {}): Result {
     startButtonText: options.startButtonText ?? "Read the first chapter",
     startButtonIcon: options.startButtonIcon ?? "arrow_forward",
     handleStartButtonClick: options.handleStartButtonClick ?? vi.fn(),
-    footerTitle: options.footerTitle ?? "Everything begins small.",
-    footerContent: options.footerContent ?? "Take your time.",
     seedBibleIconStyle: options.seedBibleIconStyle ?? { width: "32px" },
   } as unknown as Result;
 }
@@ -143,22 +132,6 @@ describe("Welcome", () => {
       const result = setup();
       act(() => btn(".welcome-screen-start-button")!.click());
       expect(result.handleStartButtonClick).toHaveBeenCalledTimes(1);
-    });
-  });
-
-  describe("footer", () => {
-    it("renders the spinner, footer title and footer content", () => {
-      setup({
-        footerTitle: "Everything begins small.",
-        footerContent: "Take your time.",
-      });
-      expect(q("[data-testid='spinner']")).not.toBeNull();
-      expect(q(".welcome-screen-footer-title")!.textContent).toBe(
-        "Everything begins small."
-      );
-      expect(q(".welcome-screen-footer-content")!.textContent).toBe(
-        "Take your time."
-      );
     });
   });
 });

--- a/test/unit/today-screen/infrastructure/presentation/hooks/useResumeReadingSection.test.tsx
+++ b/test/unit/today-screen/infrastructure/presentation/hooks/useResumeReadingSection.test.tsx
@@ -37,12 +37,21 @@ describe("useResumeReadingSection", () => {
   });
 
   function setup(options: {
+    status?: "loading" | "ready";
     lastReading?: { bookId: string; chapter: number };
     bookNames?: Map<string, string>;
   }) {
+    const status = options.status ?? "ready";
+    const readingHistory =
+      status === "ready"
+        ? signal({
+            status: "ready" as const,
+            lastReading: options.lastReading ?? { bookId: "GEN", chapter: 1 },
+          })
+        : signal({ status: "loading" as const });
     (useTodayContext as Mock).mockReturnValue({
       MaterialIcon,
-      userLastReading: signal(options.lastReading),
+      readingHistory,
       translate: vi.fn((key: string) => key),
       bookNames: signal(options.bookNames ?? new Map([["GEN", "Genesis"]])),
       addTab,
@@ -58,27 +67,39 @@ describe("useResumeReadingSection", () => {
     return result;
   }
 
-  it("throws when there is no last reading", () => {
-    const consoleError = vi
-      .spyOn(console, "error")
-      .mockImplementation(() => {});
-    expect(() => setup({ lastReading: undefined })).toThrow(
-      "useResumeReadingSection: userLastReading.value is undefined"
-    );
-    consoleError.mockRestore();
+  it("reports a loading placeholder with no card data while loading", () => {
+    const result = setup({ status: "loading" });
+    expect(result.current.isLoading).toBe(true);
+    expect(result.current.cardData).toBeNull();
+  });
+
+  it("is not loading and has card data when ready", () => {
+    const result = setup({
+      status: "ready",
+      lastReading: { bookId: "GEN", chapter: 1 },
+    });
+    expect(result.current.isLoading).toBe(false);
+    expect(result.current.cardData).not.toBeNull();
+  });
+
+  it("does nothing on button click while loading", () => {
+    const result = setup({ status: "loading" });
+    act(() => result.current.handleButtonClick());
+    expect(addTab).not.toHaveBeenCalled();
+    expect(closeToday).not.toHaveBeenCalled();
   });
 
   describe("cardData", () => {
     it("translates the resume title and uses a fixed button icon", () => {
       const result = setup({ lastReading: { bookId: "GEN", chapter: 3 } });
-      expect(result.current.cardData.title).toBe("resume-reading");
-      expect(result.current.cardData.buttonIcon).toBe("arrow_right_alt");
+      expect(result.current.cardData?.title).toBe("resume-reading");
+      expect(result.current.cardData?.buttonIcon).toBe("arrow_right_alt");
     });
 
     it("resolves the book name and chapter from the last reading", () => {
       const result = setup({ lastReading: { bookId: "GEN", chapter: 7 } });
-      expect(result.current.cardData.book).toBe("Genesis");
-      expect(result.current.cardData.chapter).toBe(7);
+      expect(result.current.cardData?.book).toBe("Genesis");
+      expect(result.current.cardData?.chapter).toBe(7);
     });
 
     it("falls back to the bookId when the name is unknown", () => {
@@ -86,7 +107,7 @@ describe("useResumeReadingSection", () => {
         lastReading: { bookId: "XYZ", chapter: 1 },
         bookNames: new Map(),
       });
-      expect(result.current.cardData.book).toBe("XYZ");
+      expect(result.current.cardData?.book).toBe("XYZ");
     });
   });
 

--- a/test/unit/today-screen/infrastructure/presentation/hooks/useTodayContainer.test.tsx
+++ b/test/unit/today-screen/infrastructure/presentation/hooks/useTodayContainer.test.tsx
@@ -45,13 +45,17 @@ describe("useTodayContainer", () => {
   });
 
   function setup(options: {
-    userId?: string | undefined;
-    lastReading?: { bookId: string; chapter: number } | undefined;
+    status: "loading" | "empty" | "ready";
+    lastReading?: { bookId: string; chapter: number };
   }) {
-    (useTodayContext as Mock).mockReturnValue({
-      userId: options.userId,
-      userLastReading: signal(options.lastReading),
-    });
+    const readingHistory =
+      options.status === "ready"
+        ? signal({
+            status: "ready" as const,
+            lastReading: options.lastReading ?? { bookId: "JHN", chapter: 3 },
+          })
+        : signal({ status: options.status });
+    (useTodayContext as Mock).mockReturnValue({ readingHistory });
     const result = { current: null as unknown as Result };
     function TestComponent() {
       result.current = useTodayContainer();
@@ -61,24 +65,21 @@ describe("useTodayContainer", () => {
     return result;
   }
 
-  it("shows Welcome (safe-centered) when there is no user", () => {
-    const result = setup({
-      userId: undefined,
-      lastReading: { bookId: "GEN", chapter: 1 },
-    });
+  it("shows Welcome (safe-centered) when history is empty", () => {
+    const result = setup({ status: "empty" });
     expect(result.current.Component).toBe(Welcome);
     expect(result.current.style).toEqual({ alignItems: "safe center" });
   });
 
-  it("shows Welcome when the user has no last reading", () => {
-    const result = setup({ userId: "user-1", lastReading: undefined });
-    expect(result.current.Component).toBe(Welcome);
-    expect(result.current.style).toEqual({ alignItems: "safe center" });
+  it("shows TodayContent (top-aligned) while history is loading", () => {
+    const result = setup({ status: "loading" });
+    expect(result.current.Component).toBe(TodayContent);
+    expect(result.current.style).toEqual({ alignItems: "flex-start" });
   });
 
-  it("shows TodayContent (top-aligned) when the user has a last reading", () => {
+  it("shows TodayContent (top-aligned) when history is ready", () => {
     const result = setup({
-      userId: "user-1",
+      status: "ready",
       lastReading: { bookId: "JHN", chapter: 3 },
     });
     expect(result.current.Component).toBe(TodayContent);

--- a/test/unit/today-screen/infrastructure/presentation/hooks/useTodayContent.test.tsx
+++ b/test/unit/today-screen/infrastructure/presentation/hooks/useTodayContent.test.tsx
@@ -29,11 +29,19 @@ describe("useTodayContent", () => {
   });
 
   function setup(options: {
-    lastReading?: { bookId: string; chapter: number } | undefined;
+    status?: "loading" | "empty" | "ready";
     bookmarks?: unknown[];
   }) {
+    const status = options.status ?? "ready";
+    const readingHistory =
+      status === "ready"
+        ? signal({
+            status: "ready" as const,
+            lastReading: { bookId: "GEN", chapter: 1 },
+          })
+        : signal({ status });
     (useTodayContext as Mock).mockReturnValue({
-      userLastReading: signal(options.lastReading),
+      readingHistory,
       bookmarks: signal(options.bookmarks ?? []),
     });
     const result = { current: null as unknown as Result };
@@ -46,13 +54,18 @@ describe("useTodayContent", () => {
   }
 
   describe("showResumeReading", () => {
-    it("is true when there is a last reading", () => {
-      const result = setup({ lastReading: { bookId: "GEN", chapter: 1 } });
+    it("is true when history is ready", () => {
+      const result = setup({ status: "ready" });
       expect(result.current.showResumeReading).toBe(true);
     });
 
-    it("is false when there is no last reading", () => {
-      const result = setup({ lastReading: undefined });
+    it("is true (placeholder) while history is loading", () => {
+      const result = setup({ status: "loading" });
+      expect(result.current.showResumeReading).toBe(true);
+    });
+
+    it("is false when history is empty", () => {
+      const result = setup({ status: "empty" });
       expect(result.current.showResumeReading).toBe(false);
     });
   });

--- a/test/unit/today-screen/infrastructure/presentation/hooks/useWelcome.test.tsx
+++ b/test/unit/today-screen/infrastructure/presentation/hooks/useWelcome.test.tsx
@@ -114,12 +114,10 @@ describe("useWelcome", () => {
   });
 
   describe("static content", () => {
-    it("translates the selector, button, and footer texts", () => {
+    it("translates the selector and button texts", () => {
       const result = setup();
       expect(result.current.selectorText).toBe("open-bible");
       expect(result.current.startButtonText).toBe("read-first-chapter");
-      expect(result.current.footerTitle).toBe("everything-begins-small");
-      expect(result.current.footerContent).toBe("no-rush");
       expect(result.current.startButtonIcon).toBe("arrow_right_alt");
     });
 


### PR DESCRIPTION
## Summary

On a cold load, returning users briefly saw the new-user **Welcome** page inside the Today screen before it flipped to their personalized **Today** content. The switch was driven by whether reading history had loaded yet, not by whether the user is actually new — so anyone with history was flashed the wrong screen while their history was still being fetched.

The root cause was a single binary gate in `useTodayContainer`: `if (!userId || !userLastReading.value) → Welcome`. Because `userLastReading` was `undefined` for **both** "still loading" and "no history," a returning user rendered Welcome (spinner and all) until the fetch resolved, then snapped to `TodayContent`. That snap was the flash.

Closes #1490.

## The fix: a three-state gate

Reading history is now an explicit status — `loading | empty | ready` — instead of `{ bookId, chapter } | undefined` ([readingHistory.tsx](packages/today-screen/domain/models/readingHistory.tsx)):

- **`loading`** — a `userId` is known and the fetch is in flight → renders the personalized layout with placeholders.
- **`empty`** — no `userId` (new/anonymous), or the fetch confirmed no history → renders Welcome.
- **`ready`** — the fetch found a resume position → renders the real content.

Only `empty` renders Welcome. Because `userId` is parsed synchronously from the cached session key at startup, a returning user starts in `loading` and never touches the Welcome screen. "Has history" and "userId known at first paint" are the same condition, which is exactly the invariant called out in the issue.

## Cross-account correctness

The state logic lives in a new, testable factory, [createReadingHistoryState.tsx](packages/today-screen/infrastructure/di/createReadingHistoryState.tsx), which closes the latent A→B leak the issue described:

- On any `userId` **change** it resets to `loading`, clearing the previous account's position before the new fetch resolves.
- Any in-flight fetch whose `userId` is no longer current is **ignored**, so account A's late result can never overwrite account B's state.
- Sign-out (`userId → null`) returns to `empty` (Welcome) immediately, dropping any cached position.
- A same-user refetch (reading progressed) keeps the current card visible while revalidating — no placeholder flicker.

## Loading placeholder

[useResumeReadingSection](packages/today-screen/infrastructure/presentation/hooks/useResumeReadingSection.tsx) no longer throws when there is no value; in the `loading` branch it reports a placeholder, and [ResumeReadingSection](packages/today-screen/infrastructure/presentation/components/containers/ResumeReadingSection.tsx) renders a self-contained shimmer skeleton (local CSS, `rgba`-based to stay baseline-clean). So the wait for reading history now happens behind a skeleton in the real layout instead of behind the Welcome page.

## Welcome cleanup

Removed the fake loading affordance from Welcome, which no longer makes sense now that Welcome is a definite state: the footer spinner and the "Everything begins small" / "No rush" text ([Welcome.tsx](packages/today-screen/infrastructure/presentation/components/containers/Welcome.tsx), [useWelcome.tsx](packages/today-screen/infrastructure/presentation/hooks/useWelcome.tsx)), the now-dead footer CSS, and the `everything-begins-small` / `no-rush` keys from the `en` block of `extension.json` (other locales left for the translators, per convention).

## Testing

- `pnpm check:ts`, `pnpm lint`, and `pnpm test` all pass. `check:ts` and `lint` report 0 errors.
- New unit coverage in [createReadingHistoryState.test.ts](test/unit/today-screen/infrastructure/di/createReadingHistoryState.test.ts) pins the tricky timing cases: the three states, an account switch, the stale-fetch guard, sign-out, and same-user refetch. Container/content/resume hook tests were updated to the status model.
- Manually verified in the browser under throttled network: returning-with-history shows the placeholder and never Welcome; new/anonymous shows Welcome instantly; sign-out returns to Welcome with no leftover data; signing in as a different account shows that account's own state.

## Acceptance criteria

- [x] A returning user with reading history never renders the Welcome page on a cold load (verified under throttled network).
- [x] A new/anonymous user (`userId === null`) sees Welcome immediately, with no placeholder detour.
- [x] No Welcome ↔ personalized screen swap occurs during load.
- [x] The personalized layout renders a loading state (placeholders) while history is still fetching.
- [x] Signing out immediately returns to Welcome with no leftover resume/personalized data.
- [x] Signing in as a different user shows that user's own state — never the previous user's.
- [x] An in-flight history fetch for a previous user cannot overwrite the current user's state.
- [x] The Welcome screen no longer shows the spinner or the footer text.
- [x] `pnpm check:ts`, `pnpm lint`, and `pnpm test` pass; container logic has test coverage for the three states and an account switch.

## Out of scope / follow-up

- The optional per-`userId` `localStorage` hint (issue item 6) is **not** in this PR. Without it, the one remaining ambiguous case — a logged-in user who has never read — degrades to placeholder→Welcome (not the jarring Welcome→personalized), so it is safe to ship the core fix first.
- While investigating, I confirmed the resume card is the slowest section on the screen because "find where you left off" currently means opening a Yjs shared document and scanning a full year of reading events (up to two year-docs), versus already-loaded signal data for the other sections. The `localStorage` hint is the natural follow-up: paint the card instantly from a cached pointer and use the year-scan only to reconcile.
- Still out of scope (separate issues): removing the first-run welcome modal, full skeleton designs for each Today section, and the `render()` → `hydrate()` SSR conversion.
