### PR TITLE
The audio reader tool now only shows on desktop.

### DIFF
--- a/packages/audio-reader-extension/ext_audioReader/host/init.tsx
+++ b/packages/audio-reader-extension/ext_audioReader/host/init.tsx
@@ -120,6 +120,7 @@ export default function initAudioReaderExtension() {
         isVisible: (ctx) =>
           computed(
             () =>
+              !ctx.playlists.isMobile.value &&
               !ctx.playlists.playing.value &&
               chapterAudioUrl(ctx.readingState) !== null
           ),


### PR DESCRIPTION
Tte tool now uses ctx.playlists.isMobile to determine wheter to show or not in the quick toolbar.

Fixes #1491 