### PR TITLE
Remove redundant welcome modal; reorder tutorial and install onboarding

### DIFF
--- a/packages/seed-bible/seed-bible/components/Onboarding/Onboarding.tsx
+++ b/packages/seed-bible/seed-bible/components/Onboarding/Onboarding.tsx
@@ -2,17 +2,13 @@ import "./Onboarding.css";
 import type { ComponentChildren } from "preact";
 import { useI18n } from "../../i18n/I18nManager";
 import { LANG_META } from "../../i18n/languageMeta";
-import {
-  SeedBibleWordmark,
-  InstallAppsIcon,
-  SafariIcon,
-} from "../../components/icons";
+import { InstallAppsIcon, SafariIcon } from "../../components/icons";
 import type { OnboardingManager } from "../../managers/OnboardingManager";
 import type { CasualOSManager } from "../../managers/OsManager";
 
 /**
- * First-run onboarding modals: a welcome notice, then a device-aware prompt to
- * install the app / add it to the home screen.
+ * First-run onboarding modal: a device-aware prompt to install the app / add it
+ * to the home screen.
  *
  * The install affordance differs per platform:
  *  - Android / PC: a real "Install App" button that triggers the native PWA
@@ -32,7 +28,6 @@ export function OnboardingModals({
   toast: (message: string) => void;
   className?: string;
 }) {
-  const { t } = useI18n();
   const step = onboarding.step.value;
 
   if (step === "done") {
@@ -51,39 +46,6 @@ export function OnboardingModals({
       </div>
     </div>
   );
-
-  if (step === "welcome") {
-    return card(
-      <>
-        <div className="sb-onboarding-logo">
-          <SeedBibleWordmark height={52} />
-        </div>
-        <h2 className="sb-onboarding-title">
-          {t("onboarding.welcomeTitle", { defaultValue: "Welcome!" })}
-        </h2>
-        {/* <p className="sb-onboarding-body">
-          {t("onboarding.welcomeBodyPre", {
-            defaultValue: "This scripture session is ",
-          })}
-          <strong>
-            {t("onboarding.welcomeBodyEmphasis", { defaultValue: "temporary" })}
-          </strong>
-          {t("onboarding.welcomeBodyPost", {
-            defaultValue: " and will erase in 12 hours for your privacy.",
-          })}
-        </p> */}
-        <div className="sb-onboarding-actions">
-          <button
-            type="button"
-            className="sb-onboarding-btn sb-onboarding-btn-primary"
-            onClick={onboarding.completeWelcome}
-          >
-            {t("onboarding.continue", { defaultValue: "Continue" })}
-          </button>
-        </div>
-      </>
-    );
-  }
 
   // step === "install" — but never prompt someone who already has the app
   // (e.g. the profile loaded after mount and reported it installed).

--- a/packages/seed-bible/seed-bible/i18n/en.json
+++ b/packages/seed-bible/seed-bible/i18n/en.json
@@ -229,8 +229,6 @@
   "tutorial.back": "Back",
   "tutorial.done": "Done",
   "tutorial.next": "Next",
-  "onboarding.welcomeTitle": "Welcome!",
-  "onboarding.continue": "Continue",
   "onboarding.installTargetDesktop": "desktop",
   "onboarding.installTargetMobile": "home screen",
   "onboarding.installThanks": "Thanks for installing!",

--- a/packages/seed-bible/seed-bible/managers/OnboardingManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/OnboardingManager.tsx
@@ -16,9 +16,8 @@ import {
 export type Platform = "android" | "ios" | "pc";
 
 /** Which onboarding modal is currently visible, if any. */
-export type OnboardingStep = "welcome" | "install" | "done";
+export type OnboardingStep = "install" | "done";
 
-const WELCOME_SEEN_KEY = "sb-welcome-seen";
 const INSTALL_DISMISSED_KEY = "sb-install-dismissed";
 const APP_INSTALLED_KEY = "sb-app-installed";
 
@@ -109,8 +108,6 @@ export interface OnboardingManager {
   installed: ReadonlySignal<boolean>;
   /** The onboarding modal that should currently be shown. */
   step: ReadonlySignal<OnboardingStep>;
-  /** Advances past the welcome screen, into the install prompt when relevant. */
-  completeWelcome: () => void;
   /** Dismisses the install prompt (either after installing or "maybe later"). */
   dismissInstall: () => void;
   /** Re-opens the install prompt on demand (e.g. from Settings). */
@@ -123,10 +120,9 @@ export interface OnboardingManager {
 }
 
 /**
- * Drives the first-run onboarding flow: a welcome notice followed by a
- * device-appropriate "install to home screen" prompt. Whether the user already
- * has the app is recorded on their profile so the prompt — and the Settings
- * entry — are hidden once installed.
+ * Drives the first-run onboarding flow: a device-appropriate "install to home
+ * screen" prompt. Whether the user already has the app is recorded on their
+ * profile so the prompt — and the Settings entry — are hidden once installed.
  */
 export function createOnboardingManager(
   login: LoginManager,
@@ -195,13 +191,9 @@ export function createOnboardingManager(
 
   const computeInitialStep = (): OnboardingStep => {
     // Opened via a shared-session invite link: don't interrupt the join with
-    // the first-run welcome/install prompts. We deliberately don't write
-    // WELCOME_SEEN_KEY, so a later visit without a session link still shows it.
+    // the first-run install prompt.
     if (joinedViaSessionLink) {
       return "done";
-    }
-    if (!readFlag(WELCOME_SEEN_KEY)) {
-      return "welcome";
     }
     if (installAvailable()) {
       return "install";
@@ -211,23 +203,18 @@ export function createOnboardingManager(
 
   const step = signal<OnboardingStep>(computeInitialStep());
 
-  const completeWelcome = () => {
-    writeFlag(WELCOME_SEEN_KEY);
-    step.value = installAvailable() ? "install" : "done";
-  };
-
-  // The onboarding prompts (welcome + install) are only auto-managed during the
-  // startup window. `startupSettled` flips true after the first resolution so
-  // later *explicit* opens (e.g. the "Install app" Settings entry) aren't
-  // auto-closed by the effect below.
+  // The onboarding install prompt is only auto-managed during the startup
+  // window. `startupSettled` flips true after the first resolution so later
+  // *explicit* opens (e.g. the "Install app" Settings entry) aren't auto-closed
+  // by the effect below.
   let startupSettled = false;
 
-  // Auth and the profile both resolve a moment after load, while a prompt may
-  // already be showing (the initial step is computed from localStorage alone).
-  // Mirror the welcome behavior for both prompts:
-  //  - login detected → a logged-in user isn't in a temporary session, so close
-  //    the welcome; likewise don't flash a stale install prompt (their real
-  //    state lives on the profile and they can install from Settings).
+  // Auth and the profile both resolve a moment after load, while the install
+  // prompt may already be showing (the initial step is computed from
+  // localStorage alone). Close the transient prompt when:
+  //  - login detected → a logged-in user's real install state lives on their
+  //    profile and they can install from Settings, so don't flash a stale
+  //    prompt.
   //  - profile says installed/dismissed → close the transient prompt.
   effect(() => {
     if (startupSettled) {
@@ -240,17 +227,11 @@ export function createOnboardingManager(
     const current = step.peek();
 
     if (loggedIn) {
-      if (current === "welcome") {
-        writeFlag(WELCOME_SEEN_KEY);
-      }
-      if (current === "welcome" || current === "install") {
+      if (current === "install") {
         step.value = "done";
       }
       startupSettled = true;
-    } else if (
-      knownInstalledOrDismissed &&
-      (current === "welcome" || current === "install")
-    ) {
+    } else if (knownInstalledOrDismissed && current === "install") {
       step.value = "done";
       startupSettled = true;
     }
@@ -275,7 +256,6 @@ export function createOnboardingManager(
     standalone,
     installed,
     step,
-    completeWelcome,
     dismissInstall,
     openInstall,
     markInstalled,

--- a/packages/seed-bible/seed-bible/managers/OnboardingManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/OnboardingManager.tsx
@@ -108,9 +108,15 @@ export interface OnboardingManager {
   installed: ReadonlySignal<boolean>;
   /** The onboarding modal that should currently be shown. */
   step: ReadonlySignal<OnboardingStep>;
+  /**
+   * Whether the install prompt could be shown right now — not yet installed
+   * and not previously dismissed. Used by the caller to decide whether to
+   * call `openInstall()` once the tutorial has been resolved.
+   */
+  installAvailable: ReadonlySignal<boolean>;
   /** Dismisses the install prompt (either after installing or "maybe later"). */
   dismissInstall: () => void;
-  /** Re-opens the install prompt on demand (e.g. from Settings). */
+  /** Re-opens the install prompt on demand (e.g. from Settings, or once the tutorial is resolved). */
   openInstall: () => void;
   /**
    * Records that the user has the app installed, persisting to their profile
@@ -123,10 +129,13 @@ export interface OnboardingManager {
  * Drives the first-run onboarding flow: a device-appropriate "install to home
  * screen" prompt. Whether the user already has the app is recorded on their
  * profile so the prompt — and the Settings entry — are hidden once installed.
+ *
+ * The prompt does not show itself on startup — the caller decides when to
+ * call `openInstall()` (e.g. once the tutorial has been resolved and the
+ * reader is visible). `step` starts at `"done"`.
  */
 export function createOnboardingManager(
-  login: LoginManager,
-  joinedViaSessionLink = false
+  login: LoginManager
 ): OnboardingManager {
   const platform = getPlatform();
   const standalone = isStandalone();
@@ -187,58 +196,15 @@ export function createOnboardingManager(
     return fromProfile === true || fromProfile === "true";
   });
 
-  const installAvailable = () => !installed.value && !dismissed.value;
+  const installAvailable = computed<boolean>(
+    () => !installed.value && !dismissed.value
+  );
 
-  const computeInitialStep = (): OnboardingStep => {
-    // Opened via a shared-session invite link: don't interrupt the join with
-    // the first-run install prompt.
-    if (joinedViaSessionLink) {
-      return "done";
-    }
-    if (installAvailable()) {
-      return "install";
-    }
-    return "done";
-  };
-
-  const step = signal<OnboardingStep>(computeInitialStep());
-
-  // The onboarding install prompt is only auto-managed during the startup
-  // window. `startupSettled` flips true after the first resolution so later
-  // *explicit* opens (e.g. the "Install app" Settings entry) aren't auto-closed
-  // by the effect below.
-  let startupSettled = false;
-
-  // Auth and the profile both resolve a moment after load, while the install
-  // prompt may already be showing (the initial step is computed from
-  // localStorage alone). Close the transient prompt when:
-  //  - login detected → a logged-in user's real install state lives on their
-  //    profile and they can install from Settings, so don't flash a stale
-  //    prompt.
-  //  - profile says installed/dismissed → close the transient prompt.
-  effect(() => {
-    if (startupSettled) {
-      return;
-    }
-    const loggedIn = login.userId.value !== null;
-    const knownInstalledOrDismissed = installed.value || dismissed.value;
-    // Read step without subscribing so this effect only re-runs on login /
-    // profile changes — not when a later openInstall() sets step to "install".
-    const current = step.peek();
-
-    if (loggedIn) {
-      if (current === "install") {
-        step.value = "done";
-      }
-      startupSettled = true;
-    } else if (knownInstalledOrDismissed && current === "install") {
-      step.value = "done";
-      startupSettled = true;
-    }
-  });
+  // The prompt no longer auto-shows on startup — it starts resolved and the
+  // caller opens it explicitly (Settings, or once the tutorial is resolved).
+  const step = signal<OnboardingStep>("done");
 
   const dismissInstall = () => {
-    startupSettled = true;
     writeFlag(INSTALL_DISMISSED_KEY);
     dismissedLocally.value = true;
     saveProfileConfigValue(login, PROFILE_INSTALL_DISMISSED, true);
@@ -246,8 +212,6 @@ export function createOnboardingManager(
   };
 
   const openInstall = () => {
-    // Explicit user action — opt out of startup auto-close so it stays open.
-    startupSettled = true;
     step.value = "install";
   };
 
@@ -256,6 +220,7 @@ export function createOnboardingManager(
     standalone,
     installed,
     step,
+    installAvailable,
     dismissInstall,
     openInstall,
     markInstalled,

--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -471,7 +471,7 @@ export function createSeedBibleState(
     (!!navigation.currentUrl.value.searchParams.get("sessionId") ||
       !!navigation.currentUrl.value.searchParams.get("playlist"));
 
-  const onboarding = createOnboardingManager(login, openedViaContentLink);
+  const onboarding = createOnboardingManager(login);
 
   // Terms of Service modal. Two-way bound to the `?terms=open` query param so
   // it can be deep-linked: setting the param opens the modal, and closing the
@@ -619,15 +619,96 @@ export function createSeedBibleState(
     panes.closeFullscreenPanes();
   });
 
+  // Whether Today will auto-open over the reader on this cold load — mirrors
+  // the predicate in `today-screen`'s bootstrap (an explicit `?today` param
+  // wins; otherwise it opens unless the boot URL already points somewhere
+  // specific). Read from `initialUrl`, not the live `currentUrl`, for the same
+  // reason today-screen does: TabsManager echoes the reader's book/chapter
+  // into the live URL before extensions finish loading.
+  const initialUrlParams = navigation.initialUrl.searchParams;
+  const todayWillAutoOpen =
+    initialUrlParams.get("today") !== null
+      ? initialUrlParams.get("today") === "open"
+      : !(
+          initialUrlParams.has("book") ||
+          initialUrlParams.has("chapter") ||
+          initialUrlParams.has("verse") ||
+          initialUrlParams.has("sessionId")
+        );
+
+  // Latches true the first time Today's pane is observed open, so the
+  // "about to be covered by Today" window (the gap between the chapter
+  // loading and Today's pane actually opening) doesn't read as reader-visible.
+  const todayHasOpened = signal(false);
+  effect(() => {
+    if (panes.panes.value.some((pane) => pane.id === "today-screen-pane")) {
+      todayHasOpened.value = true;
+    }
+  });
+
+  // The reader is visible when a chapter is loaded, no fullscreen pane covers
+  // it (matching `isFullscreenPaneVisible` in BibleReaderToolbar — on mobile
+  // any open pane covers the reader), and Today isn't about to auto-open over
+  // it for this load.
+  const readerVisible = computed<boolean>(() => {
+    const chapterLoaded =
+      selectedTab.value?.readingState.chapterData.value != null;
+    if (!chapterLoaded) {
+      return false;
+    }
+    const coveredByPane = panes.panes.value.some(
+      (pane) => pane.placement === "fullscreen" || isMobile.value
+    );
+    if (coveredByPane) {
+      return false;
+    }
+    if (todayWillAutoOpen && !todayHasOpened.value) {
+      return false;
+    }
+    return true;
+  });
+
   const tutorial = createTutorialManager(
     login,
-    onboarding,
+    readerVisible,
     selector,
     isMobile,
     panes,
     sidebar,
     openedViaContentLink
   );
+
+  // Once the tutorial has been resolved (seen, skipped, declined, or opted
+  // out) and the reader is visible, offer the install prompt — to any
+  // not-yet-installed user, logged in or not. Deferring past the tutorial
+  // means the profile has had time to load, so there's no "stale prompt"
+  // concern the way there was on startup. One-shot via `installOfferChecked`.
+  let installOfferChecked = false;
+  effect(() => {
+    if (installOfferChecked) {
+      return;
+    }
+    if (openedViaContentLink) {
+      return;
+    }
+    if (login.userId.value && login.profile.value === null) {
+      return;
+    }
+    if (!readerVisible.value) {
+      return;
+    }
+    const tutorialResolved =
+      !tutorial.promptVisible.value &&
+      !tutorial.running.value &&
+      (tutorial.completed.value || tutorial.optedOut.value);
+    if (!tutorialResolved) {
+      return;
+    }
+    installOfferChecked = true;
+    if (onboarding.installAvailable.value) {
+      onboarding.openInstall();
+    }
+  });
 
   // A phone held sideways: landscape orientation with the short viewport
   // height typical of phones. Tablets/desktops in landscape have more

--- a/packages/seed-bible/seed-bible/managers/TutorialManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/TutorialManager.tsx
@@ -1,6 +1,5 @@
 import { computed, effect, signal, type ReadonlySignal } from "@preact/signals";
 import type { LoginManager } from "../managers/LoginManager";
-import type { OnboardingManager } from "../managers/OnboardingManager";
 import type { BibleSelectorState } from "../managers/BibleSelectorManager";
 import type { PanesManager } from "../managers/PanesManager";
 import { createSidebar } from "../managers/SidebarManager";
@@ -341,13 +340,14 @@ export interface TutorialManager {
 }
 
 /**
- * Drives the guided coachmark tour. Auto-starts once for new users after the
- * welcome/install onboarding has finished, and can be replayed from Settings.
- * Completion is recorded on the user's profile (backend) plus a local cache.
+ * Drives the guided coachmark tour. Offers itself once for new users once the
+ * reader is open to a chapter and visible (no fullscreen pane covering it),
+ * and can be replayed from Settings. Completion is recorded on the user's
+ * profile (backend) plus a local cache.
  */
 export function createTutorialManager(
   login: LoginManager,
-  onboarding: OnboardingManager,
+  readerVisible: ReadonlySignal<boolean>,
   selector: BibleSelectorState,
   isMobile: ReadonlySignal<boolean>,
   panes: PanesManager,
@@ -629,12 +629,12 @@ export function createTutorialManager(
     }
   };
 
-  // Offer the tour once for new users, but only after the welcome/install
-  // onboarding is out of the way, and (when logged in) after the profile has
-  // loaded — otherwise a returning user could see the offer flash before their
-  // recorded completion arrives. Rather than launching the tour unannounced we
-  // surface the offer card; accepting it starts the tour. One-shot via
-  // `autoStartChecked`.
+  // Offer the tour once for new users, but only once the reader is open to a
+  // chapter and visible — no fullscreen pane (e.g. Today) covering it — and
+  // (when logged in) after the profile has loaded, otherwise a returning user
+  // could see the offer flash before their recorded completion arrives.
+  // Rather than launching the tour unannounced we surface the offer card;
+  // accepting it starts the tour. One-shot via `autoStartChecked`.
   let autoStartChecked = false;
   effect(() => {
     if (autoStartChecked || running.value) {
@@ -646,7 +646,7 @@ export function createTutorialManager(
     if (joinedViaSessionLink) {
       return;
     }
-    if (onboarding.step.value !== "done") {
+    if (!readerVisible.value) {
       return;
     }
     if (login.userId.value && login.profile.value === null) {

--- a/test/unit/seed-bible/managers/OnboardingManager.test.tsx
+++ b/test/unit/seed-bible/managers/OnboardingManager.test.tsx
@@ -3,12 +3,10 @@ import { signal } from "@preact/signals";
 import { createOnboardingManager } from "@packages/seed-bible/seed-bible/managers/OnboardingManager";
 import type { LoginManager } from "@packages/seed-bible/seed-bible/managers/LoginManager";
 
-const WELCOME_SEEN_KEY = "sb-welcome-seen";
-
-// Logged out: the startup effect that can auto-close prompts / write the
-// welcome flag only fires for logged-in users (or when install is already
-// known), so this keeps the initial `step` equal to what computeInitialStep
-// returned — which is what we're asserting.
+// Logged out: the startup effect that can auto-close the install prompt only
+// fires for logged-in users (or when install is already known), so this keeps
+// the initial `step` equal to what computeInitialStep returned — which is what
+// we're asserting.
 function createLogin(): LoginManager {
   return {
     userId: signal(null),
@@ -17,16 +15,16 @@ function createLogin(): LoginManager {
   } as unknown as LoginManager;
 }
 
-describe("createOnboardingManager — session-link joins", () => {
+describe("createOnboardingManager — initial step", () => {
   beforeEach(() => {
     // Flags persist in localStorage; start each test clean so a leftover
-    // WELCOME_SEEN_KEY doesn't mask the welcome vs. done distinction.
+    // install-dismissed flag doesn't mask the install vs. done distinction.
     window.localStorage.clear();
   });
 
-  it("starts at 'done' when joined via a session link, even with no welcome-seen flag", () => {
-    // No WELCOME_SEEN_KEY set — a normal visit would land on "welcome". The
-    // session-link flag must override that and skip straight to "done".
+  it("starts at 'done' when joined via a session link", () => {
+    // A session-link join must not interrupt with the install prompt, even
+    // though a normal first visit would show it.
     const onboarding = createOnboardingManager(
       createLogin(),
       /* joinedViaSessionLink */ true
@@ -35,19 +33,11 @@ describe("createOnboardingManager — session-link joins", () => {
     expect(onboarding.step.value).toBe("done");
   });
 
-  it("does NOT persist the welcome-seen flag when joined via a session link", () => {
-    // The suppression is per-visit only: skipping the welcome must not record
-    // it as seen, so a later visit without a session link still shows it.
-    createOnboardingManager(createLogin(), /* joinedViaSessionLink */ true);
-
-    expect(window.localStorage.getItem(WELCOME_SEEN_KEY)).toBeNull();
-  });
-
-  it("starts at 'welcome' on a normal (non-session-link) first visit", () => {
-    // Control for the tests above: same clean state, only the flag differs —
-    // proving it's the session-link flag that skips the welcome, not the setup.
+  it("starts at 'install' on a normal (non-session-link) first visit", () => {
+    // Clean state: not installed, not dismissed — so the install prompt is the
+    // first thing shown (there is no longer a welcome step ahead of it).
     const onboarding = createOnboardingManager(createLogin());
 
-    expect(onboarding.step.value).toBe("welcome");
+    expect(onboarding.step.value).toBe("install");
   });
 });

--- a/test/unit/seed-bible/managers/OnboardingManager.test.tsx
+++ b/test/unit/seed-bible/managers/OnboardingManager.test.tsx
@@ -3,10 +3,6 @@ import { signal } from "@preact/signals";
 import { createOnboardingManager } from "@packages/seed-bible/seed-bible/managers/OnboardingManager";
 import type { LoginManager } from "@packages/seed-bible/seed-bible/managers/LoginManager";
 
-// Logged out: the startup effect that can auto-close the install prompt only
-// fires for logged-in users (or when install is already known), so this keeps
-// the initial `step` equal to what computeInitialStep returned — which is what
-// we're asserting.
 function createLogin(): LoginManager {
   return {
     userId: signal(null),
@@ -15,29 +11,49 @@ function createLogin(): LoginManager {
   } as unknown as LoginManager;
 }
 
-describe("createOnboardingManager — initial step", () => {
+describe("createOnboardingManager", () => {
   beforeEach(() => {
     // Flags persist in localStorage; start each test clean so a leftover
-    // install-dismissed flag doesn't mask the install vs. done distinction.
+    // install-dismissed/installed flag doesn't leak between cases.
     window.localStorage.clear();
   });
 
-  it("starts at 'done' when joined via a session link", () => {
-    // A session-link join must not interrupt with the install prompt, even
-    // though a normal first visit would show it.
-    const onboarding = createOnboardingManager(
-      createLogin(),
-      /* joinedViaSessionLink */ true
-    );
+  it("starts at 'done' — the install prompt no longer auto-shows on load", () => {
+    const onboarding = createOnboardingManager(createLogin());
 
     expect(onboarding.step.value).toBe("done");
   });
 
-  it("starts at 'install' on a normal (non-session-link) first visit", () => {
-    // Clean state: not installed, not dismissed — so the install prompt is the
-    // first thing shown (there is no longer a welcome step ahead of it).
+  it("reports installAvailable when not installed and not dismissed", () => {
     const onboarding = createOnboardingManager(createLogin());
 
+    expect(onboarding.installAvailable.value).toBe(true);
+  });
+
+  it("openInstall() shows the prompt on demand", () => {
+    const onboarding = createOnboardingManager(createLogin());
+
+    onboarding.openInstall();
+
     expect(onboarding.step.value).toBe("install");
+  });
+
+  it("dismissInstall() hides the prompt and clears installAvailable", () => {
+    const onboarding = createOnboardingManager(createLogin());
+
+    onboarding.openInstall();
+    onboarding.dismissInstall();
+
+    expect(onboarding.step.value).toBe("done");
+    expect(onboarding.installAvailable.value).toBe(false);
+  });
+
+  it("markInstalled() clears installAvailable", () => {
+    const onboarding = createOnboardingManager(createLogin());
+
+    onboarding.markInstalled();
+
+    expect(onboarding.installAvailable.value).toBe(false);
+    expect(onboarding.installed.value).toBe(true);
   });
 });

--- a/test/unit/seed-bible/managers/TutorialManager.test.tsx
+++ b/test/unit/seed-bible/managers/TutorialManager.test.tsx
@@ -1,8 +1,7 @@
-import { signal } from "@preact/signals";
+import { signal, type ReadonlySignal } from "@preact/signals";
 
 import { createTutorialManager } from "@packages/seed-bible/seed-bible/managers/TutorialManager";
 import type { LoginManager } from "@packages/seed-bible/seed-bible/managers/LoginManager";
-import type { OnboardingManager } from "@packages/seed-bible/seed-bible/managers/OnboardingManager";
 import type { BibleSelectorState } from "@packages/seed-bible/seed-bible/managers/BibleSelectorManager";
 import type { PanesManager } from "@packages/seed-bible/seed-bible/managers/PanesManager";
 import { createSidebar as createRealSidebar } from "@packages/seed-bible/seed-bible/managers/SidebarManager";
@@ -17,12 +16,10 @@ function createLogin(): LoginManager {
   } as unknown as LoginManager;
 }
 
-// Onboarding "done" is the state that lets the tutorial auto-start fire; the
-// tour is gated on the welcome/install flow having already resolved.
-function createOnboarding(step = "done"): OnboardingManager {
-  return {
-    step: signal(step),
-  } as unknown as OnboardingManager;
+// `readerVisible` true is the state that lets the tutorial auto-start fire;
+// the offer is gated on the reader being open to a chapter and unobscured.
+function createReaderVisible(visible = true): ReadonlySignal<boolean> {
+  return signal(visible);
 }
 
 function createSelector(): BibleSelectorState {
@@ -62,7 +59,7 @@ describe("createTutorialManager — session-link joins", () => {
     // (and so never reaches `running`).
     const tutorial = createTutorialManager(
       createLogin(),
-      createOnboarding("done"),
+      createReaderVisible(true),
       createSelector(),
       signal(false),
       createPanes(),
@@ -79,7 +76,7 @@ describe("createTutorialManager — session-link joins", () => {
     // it's the session-link flag that suppresses the offer, not the setup.
     const tutorial = createTutorialManager(
       createLogin(),
-      createOnboarding("done"),
+      createReaderVisible(true),
       createSelector(),
       signal(false),
       createPanes(),
@@ -96,7 +93,7 @@ describe("createTutorialManager — session-link joins", () => {
 
     const tutorial = createTutorialManager(
       createLogin(),
-      createOnboarding("done"),
+      createReaderVisible(true),
       createSelector(),
       signal(false),
       createPanes(),
@@ -114,7 +111,7 @@ describe("createTutorialManager — session-link joins", () => {
 
     const tutorial = createTutorialManager(
       createLogin(),
-      createOnboarding("done"),
+      createReaderVisible(true),
       createSelector(),
       signal(false),
       createPanes(),
@@ -124,5 +121,43 @@ describe("createTutorialManager — session-link joins", () => {
     tutorial.startContextual("search");
 
     expect(tutorial.running.value).toBe(true);
+  });
+});
+
+describe("createTutorialManager — reader visibility gate", () => {
+  beforeEach(() => {
+    window.localStorage.clear();
+  });
+
+  it("does NOT offer the tour while the reader isn't visible", () => {
+    const tutorial = createTutorialManager(
+      createLogin(),
+      createReaderVisible(false),
+      createSelector(),
+      signal(false),
+      createPanes(),
+      createSidebar()
+    );
+
+    expect(tutorial.promptVisible.value).toBe(false);
+  });
+
+  it("offers the tour once the reader becomes visible", () => {
+    const readerVisible = signal(false);
+
+    const tutorial = createTutorialManager(
+      createLogin(),
+      readerVisible,
+      createSelector(),
+      signal(false),
+      createPanes(),
+      createSidebar()
+    );
+
+    expect(tutorial.promptVisible.value).toBe(false);
+
+    readerVisible.value = true;
+
+    expect(tutorial.promptVisible.value).toBe(true);
   });
 });


### PR DESCRIPTION
## Summary

- Removes the separate first-run "Welcome" onboarding modal — it duplicated the install prompt's job of greeting a new user, so the install prompt now handles that first-run moment on its own.
- Defers the tutorial offer until the reader is actually open to a chapter and visible: no fullscreen pane (e.g. Today) covering it, and not in the brief startup gap before Today auto-opens on a cold load.
- Moves the PWA install prompt so it now appears after the tutorial has been resolved (accepted, declined, skipped, or opted out), instead of before it. It's now offered to any user who hasn't installed or dismissed it, including logged-in users, since by this point their profile has already loaded and there's no risk of flashing a stale prompt.

### Before / after

**Before:** on a fresh visit, the install prompt showed first (computed from localStorage alone, before login/profile even resolved), and the tutorial offer waited behind it. The tutorial could also appear while a fullscreen pane like Today was covering the reader, so its highlighted UI elements weren't even on screen.

**Now:** the tutorial offer only appears once the reader is genuinely visible — chapter loaded, nothing covering it, and (on a cold load into Today) only after Today has actually opened and been closed. Once the tutorial is resolved one way or another, the install prompt appears.

## Test plan

- [x] `pnpm check:ts` — clean
- [x] `pnpm test` — all 3062 tests pass, including updated/new cases in `OnboardingManager.test.tsx` and `TutorialManager.test.tsx`
- [x] `pnpm lint` — no new warnings or errors
- [x] Manual verification in the browser (recommended before merge):
  - [x] Fresh anonymous cold load: Today auto-opens, no tutorial offer flash; close Today → tutorial offer appears → decline/accept → install prompt appears
  - [x] Deep link (`?book=GEN&chapter=1`): Today doesn't auto-open, tutorial offer appears, then install prompt
  - [x] Session link (`?sessionId=...`): neither tutorial offer nor install prompt shows
  - [x] Returning user (tutorial already seen): install prompt appears once the reader is visible
  - [x] Logged-in, not installed: install prompt now appears after the tutorial resolves
  - [x] Settings → "Launch tutorial" and "Install app" replay entries still work