### PR TITLE
feat: build info footer + automated release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -85,3 +85,19 @@ jobs:
             --target "$GITHUB_SHA" \
             $PRERELEASE
           echo "Published release **v$VERSION**." >> "$GITHUB_STEP_SUMMARY"
+
+      # Repost the release notes to the Discord #announcements channel with a
+      # link to the site. No-ops when DISCORD_ANNOUNCE_WEBHOOK is unset, and
+      # never fails the job (the release is already published). Skipped for
+      # pre-releases (e.g. 1.2.0-rc.1).
+      - name: Announce on Discord
+        if: steps.check.outputs.should_release == 'true' && !contains(steps.check.outputs.version, '-')
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
+          DISCORD_ANNOUNCE_WEBHOOK: ${{ secrets.DISCORD_ANNOUNCE_WEBHOOK }}
+        run: |
+          pnpm notify discord-release \
+            --version "$VERSION" \
+            --notes-file notes.md \
+            --site-url "https://seedbible.org" \
+            --release-url "https://github.com/$GITHUB_REPOSITORY/releases/tag/v$VERSION"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,20 +66,28 @@ jobs:
           corepack enable
           pnpm install
 
-      # Pull the release notes straight from the (already stamped) CHANGELOG. A
-      # missing/empty section is not a hard failure: we log a warning and skip
-      # the rest of the release (no tag, no GitHub Release, no announcement)
-      # rather than failing the job, so an accidental unstamped merge to `main`
-      # still deploys cleanly without a red X.
+      # Pull the release notes straight from the (already stamped) CHANGELOG.
+      # `changelog:extract` exits 2 for the expected "not stamped yet" case
+      # (see EXTRACT_NOT_FOUND_EXIT_CODE in script/lib/changelog.ts) — that's
+      # not a hard failure: we log a warning and skip the rest of the release
+      # (no tag, no GitHub Release, no announcement), so an accidental
+      # unstamped merge to `main` still deploys cleanly without a red X. Any
+      # OTHER non-zero exit is a genuine bug in the script, not an unstamped
+      # changelog, and is left to fail the job with its stack trace intact.
       - name: Extract release notes
         id: extract
         if: steps.check.outputs.should_release == 'true'
         env:
           VERSION: ${{ steps.check.outputs.version }}
         run: |
-          if pnpm --silent changelog:extract "$VERSION" > notes.md 2>extract-error.log; then
+          set +e
+          pnpm --silent changelog:extract "$VERSION" > notes.md 2>extract-error.log
+          EXIT_CODE=$?
+          set -e
+
+          if [ "$EXIT_CODE" -eq 0 ]; then
             echo "notes_available=true" >> "$GITHUB_OUTPUT"
-          else
+          elif [ "$EXIT_CODE" -eq 2 ]; then
             echo "notes_available=false" >> "$GITHUB_OUTPUT"
             cat extract-error.log
             echo "::warning::No stamped CHANGELOG section found for v$VERSION — skipping the release. Run 'pnpm release:prepare' on develop before merging to main next time."
@@ -90,6 +98,10 @@ jobs:
               echo ""
               echo "Run \`pnpm release:prepare\` on \`develop\` before merging to \`main\` next time."
             } >> "$GITHUB_STEP_SUMMARY"
+          else
+            cat extract-error.log
+            echo "::error::changelog:extract failed unexpectedly (exit $EXIT_CODE) for v$VERSION — this looks like a bug in the script, not an unstamped changelog. See the log above."
+            exit "$EXIT_CODE"
           fi
 
       # gh creates the tag `v<version>` at this commit (= the commit cd.yml

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,6 +10,12 @@
 # It is idempotent: if a release for the current version already exists, it does
 # nothing — so a push to `main` that didn't bump the version (e.g. a hotfix)
 # deploys but creates no release, and re-runs never duplicate one.
+#
+# It is also tolerant of an unstamped CHANGELOG: if `main`'s version has no
+# matching `## v<version>` section (e.g. someone merged without running
+# `pnpm release:prepare` on develop first), the job logs a warning and skips
+# the release rather than failing — a missed release shouldn't put a red X on
+# the protected branch.
 name: Release
 
 on:
@@ -60,20 +66,37 @@ jobs:
           corepack enable
           pnpm install
 
-      # Pull the release notes straight from the (already stamped) CHANGELOG.
-      # Fails the job if the section is missing/empty, so we never publish an
-      # empty release.
+      # Pull the release notes straight from the (already stamped) CHANGELOG. A
+      # missing/empty section is not a hard failure: we log a warning and skip
+      # the rest of the release (no tag, no GitHub Release, no announcement)
+      # rather than failing the job, so an accidental unstamped merge to `main`
+      # still deploys cleanly without a red X.
       - name: Extract release notes
+        id: extract
         if: steps.check.outputs.should_release == 'true'
         env:
           VERSION: ${{ steps.check.outputs.version }}
-        run: pnpm --silent changelog:extract "$VERSION" > notes.md
+        run: |
+          if pnpm --silent changelog:extract "$VERSION" > notes.md 2>extract-error.log; then
+            echo "notes_available=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "notes_available=false" >> "$GITHUB_OUTPUT"
+            cat extract-error.log
+            echo "::warning::No stamped CHANGELOG section found for v$VERSION — skipping the release. Run 'pnpm release:prepare' on develop before merging to main next time."
+            {
+              echo "### ⚠️ Release v$VERSION skipped"
+              echo ""
+              echo "No stamped \`## v$VERSION\` section was found in CHANGELOG.md, so no tag, GitHub Release, or Discord announcement was created."
+              echo ""
+              echo "Run \`pnpm release:prepare\` on \`develop\` before merging to \`main\` next time."
+            } >> "$GITHUB_STEP_SUMMARY"
+          fi
 
       # gh creates the tag `v<version>` at this commit (= the commit cd.yml
       # deploys) and the Release in one call. A pre-release suffix (e.g.
       # 1.2.0-rc.1) marks the Release as a pre-release.
       - name: Create GitHub Release + tag
-        if: steps.check.outputs.should_release == 'true'
+        if: steps.check.outputs.should_release == 'true' && steps.extract.outputs.notes_available == 'true'
         env:
           VERSION: ${{ steps.check.outputs.version }}
         run: |
@@ -91,7 +114,7 @@ jobs:
       # never fails the job (the release is already published). Skipped for
       # pre-releases (e.g. 1.2.0-rc.1).
       - name: Announce on Discord
-        if: steps.check.outputs.should_release == 'true' && !contains(steps.check.outputs.version, '-')
+        if: steps.check.outputs.should_release == 'true' && steps.extract.outputs.notes_available == 'true' && !contains(steps.check.outputs.version, '-')
         env:
           VERSION: ${{ steps.check.outputs.version }}
           DISCORD_ANNOUNCE_WEBHOOK: ${{ secrets.DISCORD_ANNOUNCE_WEBHOOK }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,87 @@
+# Release
+#
+# Publishes a GitHub Release when a version-bumped commit lands on `main`
+# (normally via a develop -> main merge). Deployment to prod.seedbible.org is
+# handled separately by cd.yml; this workflow only tags the commit and creates
+# the Release, using the version already bumped on develop
+# (packages/seed-bible/package.json) and the CHANGELOG section already stamped
+# there by `pnpm release:prepare`.
+#
+# It is idempotent: if a release for the current version already exists, it does
+# nothing — so a push to `main` that didn't bump the version (e.g. a hotfix)
+# deploys but creates no release, and re-runs never duplicate one.
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+concurrency:
+  group: release-main
+  cancel-in-progress: false
+
+permissions:
+  contents: write # create the tag + GitHub Release
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    env:
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Use Node.js 24.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24.x
+
+      # Resolve the app version and decide whether there's anything to release.
+      - name: Resolve version + check for existing release
+        id: check
+        run: |
+          VERSION=$(node -p "require('./packages/seed-bible/package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          if gh release view "v$VERSION" >/dev/null 2>&1; then
+            echo "Release v$VERSION already exists — nothing to do."
+            echo "should_release=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Will release v$VERSION."
+            echo "should_release=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Set up Bun
+        if: steps.check.outputs.should_release == 'true'
+        uses: oven-sh/setup-bun@v2
+
+      - name: Install
+        if: steps.check.outputs.should_release == 'true'
+        run: |
+          corepack enable
+          pnpm install
+
+      # Pull the release notes straight from the (already stamped) CHANGELOG.
+      # Fails the job if the section is missing/empty, so we never publish an
+      # empty release.
+      - name: Extract release notes
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
+        run: pnpm --silent changelog:extract "$VERSION" > notes.md
+
+      # gh creates the tag `v<version>` at this commit (= the commit cd.yml
+      # deploys) and the Release in one call. A pre-release suffix (e.g.
+      # 1.2.0-rc.1) marks the Release as a pre-release.
+      - name: Create GitHub Release + tag
+        if: steps.check.outputs.should_release == 'true'
+        env:
+          VERSION: ${{ steps.check.outputs.version }}
+        run: |
+          PRERELEASE=""
+          case "$VERSION" in *-*) PRERELEASE="--prerelease" ;; esac
+          gh release create "v$VERSION" \
+            --title "v$VERSION" \
+            --notes-file notes.md \
+            --target "$GITHUB_SHA" \
+            $PRERELEASE
+          echo "Published release **v$VERSION**." >> "$GITHUB_STEP_SUMMARY"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,46 @@
+# Changelog
+
+## TBD
+
+This release rebuilds the verse highlighting system on an SVG layer, smooths the first-run and onboarding experience, expands playlists, and fixes a wide range of chat, pane, context-menu, and mobile issues.
+
+### ✨ Added
+
+- Render highlights as a separate SVG layer behind the text, drawing contiguous same-color highlights as one continuous ribbon with rounded corners.
+- Fade highlight ribbons in and out when they genuinely appear or are removed.
+- Dim undecorated verses so decorated ones stand out.
+- Add drag-and-drop reordering for playlist items and the queue.
+- Add playlist icons, a save indicator, a large embed modal, full-height rows, and an unsaved-item warning.
+- Add unread and typing indicators for chat in the mobile More menu.
+- Add loading skeletons and a saving indicator for account settings.
+- Add a shared skeleton placeholder for the Today resume card.
+- Show the build version and commit hash in the Settings page footer.
+
+### 🔧 Changed
+
+- Change verse selection to a dotted text-decoration underline instead of a dashed border to prevent layout shift.
+- Tweak the dark theme's yellow highlight to be less gold and orange tinted.
+- Defer the tutorial until the reader is visible and move the install prompt after it.
+- Only show the audio reader in the toolbar when on desktop. Mobile has its own dedicated place for it on the navigation bar.
+- Port the Twitch apps to the system floating window and refine the pane component header.
+- Replace the Seed Bible icon with an SVG so it matches theme colors automatically.
+
+### 🐛 Fixed
+
+- Gate the Today screen on reading-history status rather than the last-reading value.
+- Rejoin the active shared session after a page refresh by persisting its ID in the URL, instead of silently dropping the user.
+- Fix a double-click-to-open issue in the AI transcript.
+- Fire pane `onClose` on every close path with a close reason.
+- Can now scroll long list of tabs in the sidebar.
+- Adjust sidebar settings padding and scrollbar styles for mobile.
+- Make empty-pane and mobile-tab toolbar icons follow the active theme.
+- Fixed login button not working after logging out until a refresh occured.
+- Fix the Twitch WebSocket reconnecting in a loop after closing and exhausting the connection limit, and purge unused connections.
+- Fix extensions being reinstalled after being uninstalled on another device.
+- Make playlist content embeds fill the largest available size.
+- Fixed numerous dark theme issues.
+
+### 🗑️ Removed
+
+- Remove the redundant welcome onboarding modal.
+- Twitch extension cleanup of dead code.

--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ This does three things in one commit's worth of edits:
 - rewrites the CHANGELOG's `## TBD` heading to `## v<version> — <YYYY-MM-DD>`, and
 - inserts a fresh, empty `## TBD` above it so `develop` is ready for the next cycle.
 
-Review the diff, commit on `develop`, and open a PR. Then merge `develop` → `main` as usual. On that push, [`release.yml`](./.github/workflows/release.yml) reads the version, tags the commit `v<version>`, and publishes a GitHub Release whose notes are that version's CHANGELOG section. It is idempotent — a push to `main` that didn't bump the version (e.g. a hotfix) deploys but creates no release.
+Review the diff, commit on `develop`, and open a PR. Then merge `develop` → `main` as usual. On that push, [`release.yml`](./.github/workflows/release.yml) reads the version, tags the commit `v<version>`, and publishes a GitHub Release whose notes are that version's CHANGELOG section. It is idempotent — a push to `main` that didn't bump the version (e.g. a hotfix) deploys but creates no release. If `main`'s version has no matching stamped CHANGELOG section (e.g. `release:prepare` was skipped before merging), the workflow logs a warning and skips the release instead of failing — the deploy still goes through cleanly.
 
 The same workflow reposts the release notes to the Discord #announcements channel with a link to [seedbible.org](https://seedbible.org). This requires a repo secret `DISCORD_ANNOUNCE_WEBHOOK` (a Discord channel webhook URL: Channel → Edit Channel → Integrations → Webhooks → New Webhook → Copy Webhook URL). If the secret is unset the announcement step simply no-ops, and a Discord failure never fails the release. Pre-releases (e.g. `1.2.0-rc.1`) are not announced.
 

--- a/README.md
+++ b/README.md
@@ -59,6 +59,26 @@ There are several utility scripts:
 1. Use the `pattern` CLI:
    - `pnpm pattern unpack SeedBible`
 
+## Releasing
+
+Production is deployed by merging `develop` into `main`: `cd.yml` builds and ships the merged commit to [seedbible.org](https://seedbible.org). Releasing adds a git tag, a GitHub Release, and a dated CHANGELOG entry on top of that deploy.
+
+Day to day, add notes to the `## TBD` section at the top of [CHANGELOG.md](./CHANGELOG.md) as you land changes (Added / Changed / Fixed / Removed).
+
+When you're ready to cut a release, run the prepare step **on `develop`**:
+
+```bash
+pnpm release:prepare minor    # or: patch | major | an explicit version like 1.4.0
+```
+
+This does three things in one commit's worth of edits:
+
+- bumps the `version` in `packages/seed-bible/package.json` (the version baked into the build),
+- rewrites the CHANGELOG's `## TBD` heading to `## v<version> — <YYYY-MM-DD>`, and
+- inserts a fresh, empty `## TBD` above it so `develop` is ready for the next cycle.
+
+Review the diff, commit on `develop`, and open a PR. Then merge `develop` → `main` as usual. On that push, [`release.yml`](./.github/workflows/release.yml) reads the version, tags the commit `v<version>`, and publishes a GitHub Release whose notes are that version's CHANGELOG section. It is idempotent — a push to `main` that didn't bump the version (e.g. a hotfix) deploys but creates no release.
+
 ## About Us
 
 [AO Lab](https://helloao.org/) is a non-profit company dedicated to loving and living out the Word of God. The goal of this project is to make the Bible (and related resources) freely available to anyone who should need it in a format that is optimized for use by applications.

--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ This does three things in one commit's worth of edits:
 
 Review the diff, commit on `develop`, and open a PR. Then merge `develop` → `main` as usual. On that push, [`release.yml`](./.github/workflows/release.yml) reads the version, tags the commit `v<version>`, and publishes a GitHub Release whose notes are that version's CHANGELOG section. It is idempotent — a push to `main` that didn't bump the version (e.g. a hotfix) deploys but creates no release.
 
+The same workflow reposts the release notes to the Discord #announcements channel with a link to [seedbible.org](https://seedbible.org). This requires a repo secret `DISCORD_ANNOUNCE_WEBHOOK` (a Discord channel webhook URL: Channel → Edit Channel → Integrations → Webhooks → New Webhook → Copy Webhook URL). If the secret is unset the announcement step simply no-ops, and a Discord failure never fails the release. Pre-releases (e.g. `1.2.0-rc.1`) are not announced.
+
 ## About Us
 
 [AO Lab](https://helloao.org/) is a non-profit company dedicated to loving and living out the Word of God. The goal of this project is to make the Bible (and related resources) freely available to anyone who should need it in a format that is optimized for use by applications.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seed-bible",
-  "version": "1.1.0",
+  "version": "1.0.0",
   "description": "The source code behind the Seed Bible.",
   "type": "module",
   "main": "server/dist/index.js",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,8 @@
     "check:patterns": "tsc --project ./patterns/tsconfig.json",
     "pattern": "tsx script/pattern.ts",
     "notify": "tsx script/notify.ts",
+    "release:prepare": "tsx script/release.ts prepare",
+    "changelog:extract": "tsx script/changelog.ts extract",
     "build-size-report": "tsx script/build-size-report.ts",
     "i18n": "tsx script/i18n.ts",
     "list-bible-translations": "tsx script/list-bible-translations.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seed-bible",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "The source code behind the Seed Bible.",
   "type": "module",
   "main": "server/dist/index.js",

--- a/packages/seed-bible/package.json
+++ b/packages/seed-bible/package.json
@@ -1,6 +1,6 @@
 {
   "name": "seed-bible",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "",
   "type": "module",
   "exports": {

--- a/packages/seed-bible/seed-bible/components/SettingsPage/SettingsPage.css
+++ b/packages/seed-bible/seed-bible/components/SettingsPage/SettingsPage.css
@@ -1187,6 +1187,24 @@
   white-space: nowrap;
 }
 
+.sb-settings-version {
+  align-self: center;
+  margin-top: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background: none;
+  border: none;
+  cursor: pointer;
+  font-size: 0.6875rem;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+  color: color-mix(in srgb, var(--sb-font-color), transparent 60%);
+}
+
+@media (hover: hover) {
+  .sb-settings-version:hover {
+    color: color-mix(in srgb, var(--sb-font-color), transparent 40%);
+  }
+}
+
 .sb-theme-color-row-controls {
   display: flex;
   align-items: center;

--- a/packages/seed-bible/seed-bible/components/SettingsPage/SettingsPage.tsx
+++ b/packages/seed-bible/seed-bible/components/SettingsPage/SettingsPage.tsx
@@ -1915,6 +1915,38 @@ function AllSettingsView(props: { state: SeedBibleState }) {
   );
 }
 
+function SettingsVersionFooter() {
+  const { t } = useI18n();
+  const copied = useSignal(false);
+
+  const onCopy = () => {
+    void navigator.clipboard?.writeText(
+      `v${__APP_VERSION__} (${__GIT_COMMIT__})`
+    );
+    copied.value = true;
+    setTimeout(() => {
+      copied.value = false;
+    }, 1500);
+  };
+
+  return (
+    <button
+      type="button"
+      className="sb-settings-version"
+      onClick={onCopy}
+      title={t("copy", { defaultValue: "Copy" })}
+    >
+      {copied.value
+        ? t("copied", { defaultValue: "Copied" })
+        : t("app-version", {
+            version: __APP_VERSION__,
+            commit: __GIT_COMMIT__.slice(0, 7),
+            defaultValue: "v{{version}} · {{commit}}",
+          })}
+    </button>
+  );
+}
+
 function SettingsMainView(props: { state: SeedBibleState }) {
   const { state } = props;
   const { t, language, availableLanguages, setLanguage } = useI18n();
@@ -2219,6 +2251,7 @@ function SettingsMainView(props: { state: SeedBibleState }) {
             </div>
           </li>
         </ul>
+        <SettingsVersionFooter />
       </section>
     </div>
   );

--- a/packages/seed-bible/seed-bible/components/SettingsPage/SettingsPage.tsx
+++ b/packages/seed-bible/seed-bible/components/SettingsPage/SettingsPage.tsx
@@ -1920,13 +1920,18 @@ function SettingsVersionFooter() {
   const copied = useSignal(false);
 
   const onCopy = () => {
-    void navigator.clipboard?.writeText(
-      `v${__APP_VERSION__} (${__GIT_COMMIT__})`
-    );
-    copied.value = true;
-    setTimeout(() => {
-      copied.value = false;
-    }, 1500);
+    navigator.clipboard
+      ?.writeText(`v${__APP_VERSION__} (${__GIT_COMMIT__})`)
+      .then(() => {
+        copied.value = true;
+        setTimeout(() => {
+          copied.value = false;
+        }, 1500);
+      })
+      .catch(() => {
+        // Clipboard write was denied/unsupported — leave the label unchanged
+        // rather than falsely reporting success.
+      });
   };
 
   return (

--- a/packages/seed-bible/seed-bible/i18n/en.json
+++ b/packages/seed-bible/seed-bible/i18n/en.json
@@ -134,6 +134,7 @@
   "keep-screen-awake": "Keep screen awake",
   "language": "Language",
   "report-a-bug": "Report a bug",
+  "app-version": "v{{version}} · {{commit}}",
   "session-settings-host-only_note": "Only the session host can change these settings.",
   "session-settings-host-only_navigate": "Only host can navigate",
   "session-settings-host-only_highlight": "Only host can highlight",

--- a/script/changelog.ts
+++ b/script/changelog.ts
@@ -1,0 +1,23 @@
+import { program } from "commander";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import { extractSection } from "./lib/changelog";
+
+const CHANGELOG_PATH = path.resolve("CHANGELOG.md");
+
+program
+  .name("changelog")
+  .description("Commands for working with the CHANGELOG.");
+
+program
+  .command("extract <version>")
+  .description(
+    "Prints the CHANGELOG section for the given version to stdout (an optional leading 'v' is ignored). Used by the release workflow to build the GitHub Release notes."
+  )
+  .action(async (version: string) => {
+    const normalized = version.startsWith("v") ? version.slice(1) : version;
+    const text = await readFile(CHANGELOG_PATH, "utf-8");
+    process.stdout.write(`${extractSection(text, normalized)}\n`);
+  });
+
+await program.parseAsync();

--- a/script/changelog.ts
+++ b/script/changelog.ts
@@ -1,7 +1,11 @@
 import { program } from "commander";
 import { readFile } from "node:fs/promises";
 import path from "node:path";
-import { extractSection } from "./lib/changelog";
+import {
+  ChangelogSectionNotFoundError,
+  EXTRACT_NOT_FOUND_EXIT_CODE,
+  extractSection,
+} from "./lib/changelog";
 
 const CHANGELOG_PATH = path.resolve("CHANGELOG.md");
 
@@ -12,12 +16,26 @@ program
 program
   .command("extract <version>")
   .description(
-    "Prints the CHANGELOG section for the given version to stdout (an optional leading 'v' is ignored). Used by the release workflow to build the GitHub Release notes."
+    "Prints the CHANGELOG section for the given version to stdout (an optional leading 'v' is ignored). Used by the release workflow to build the GitHub Release notes. Exits with a distinct status " +
+      `(${EXTRACT_NOT_FOUND_EXIT_CODE}) when the version has no stamped section, so callers can tell that apart from a genuine failure.`
   )
   .action(async (version: string) => {
     const normalized = version.startsWith("v") ? version.slice(1) : version;
     const text = await readFile(CHANGELOG_PATH, "utf-8");
-    process.stdout.write(`${extractSection(text, normalized)}\n`);
+    let section: string;
+    try {
+      section = extractSection(text, normalized);
+    } catch (error) {
+      if (error instanceof ChangelogSectionNotFoundError) {
+        console.error(error.message);
+        process.exitCode = EXTRACT_NOT_FOUND_EXIT_CODE;
+        return;
+      }
+      // A genuine bug (not "unstamped changelog") — rethrow so it surfaces
+      // with its full stack trace and the default non-zero exit code.
+      throw error;
+    }
+    process.stdout.write(`${section}\n`);
   });
 
 await program.parseAsync();

--- a/script/lib/changelog.ts
+++ b/script/lib/changelog.ts
@@ -1,0 +1,141 @@
+/**
+ * Pure helpers for working with the repo CHANGELOG and version numbers.
+ *
+ * The release flow keeps these free of file I/O so they can be unit-tested and
+ * reused: `script/release.ts` calls `bumpVersion` + `stampChangelog` when
+ * preparing a release on `develop`, and `script/changelog.ts extract` calls
+ * `extractSection` in CI to build the GitHub Release notes on `main`.
+ */
+
+/** The heading that marks the unreleased section at the top of the changelog. */
+export const TBD_HEADING = "## TBD";
+
+/**
+ * A fresh, empty "unreleased" section dropped in above a newly-stamped version
+ * so the next cycle always starts with the emoji subsections ready to fill in.
+ * The subsection headings must stay in sync with the ones authored in
+ * CHANGELOG.md.
+ */
+export const FRESH_TBD_SECTION = `## TBD
+
+### ✨ Added
+
+### 🔧 Changed
+
+### 🐛 Fixed
+
+### 🗑️ Removed
+`;
+
+export type ReleaseType = "major" | "minor" | "patch";
+
+// A plain MAJOR.MINOR.PATCH version (what we can bump from).
+const SEMVER_CORE = /^(\d+)\.(\d+)\.(\d+)$/;
+// A full semver, allowing an optional pre-release and build-metadata suffix.
+const SEMVER_FULL = /^\d+\.\d+\.\d+(?:-[0-9A-Za-z-.]+)?(?:\+[0-9A-Za-z-.]+)?$/;
+
+/** Returns today's date as an ISO `YYYY-MM-DD` string (UTC). */
+export function today(): string {
+  return new Date().toISOString().slice(0, 10);
+}
+
+/** Whether `version` is a syntactically valid semver string. */
+export function isValidVersion(version: string): boolean {
+  return SEMVER_FULL.test(version);
+}
+
+/** Whether `version` carries a pre-release suffix (e.g. `1.2.0-rc.1`). */
+export function isPrerelease(version: string): boolean {
+  return version.includes("-");
+}
+
+/**
+ * Resolves the next version from a bump keyword or an explicit version.
+ *
+ * `spec` is one of "major" | "minor" | "patch" (bumped relative to `current`),
+ * or an explicit version like "1.4.0" (an optional leading "v" is stripped).
+ * Throws on an unbumpable current version or an invalid explicit version.
+ */
+export function bumpVersion(current: string, spec: string): string {
+  if (spec === "major" || spec === "minor" || spec === "patch") {
+    const parts = SEMVER_CORE.exec(current);
+    if (!parts) {
+      throw new Error(
+        `Cannot ${spec}-bump "${current}": expected a MAJOR.MINOR.PATCH version.`
+      );
+    }
+    const major = Number(parts[1]);
+    const minor = Number(parts[2]);
+    const patch = Number(parts[3]);
+    if (spec === "major") return `${major + 1}.0.0`;
+    if (spec === "minor") return `${major}.${minor + 1}.0`;
+    return `${major}.${minor}.${patch + 1}`;
+  }
+
+  const explicit = spec.startsWith("v") ? spec.slice(1) : spec;
+  if (!isValidVersion(explicit)) {
+    throw new Error(
+      `Invalid version "${spec}". Use "major", "minor", "patch", or an explicit X.Y.Z version.`
+    );
+  }
+  return explicit;
+}
+
+/**
+ * Converts the first `## TBD` heading into `## v<version> — <date>` (em dash)
+ * and inserts a fresh empty TBD section above it, so `develop` is ready for the
+ * next cycle. Returns the new changelog text. Throws if there is no TBD section.
+ */
+export function stampChangelog(
+  text: string,
+  version: string,
+  date: string
+): string {
+  const lines = text.split("\n");
+  const index = lines.findIndex((line) => line.trim() === TBD_HEADING);
+  if (index === -1) {
+    throw new Error(
+      `No "${TBD_HEADING}" section found in the changelog. Add one before releasing.`
+    );
+  }
+
+  const stampedHeading = `## v${version} — ${date}`;
+  // Replace the single TBD heading line with a fresh empty TBD block followed by
+  // the stamped heading. FRESH_TBD_SECTION already ends in a newline; the extra
+  // blank line keeps Markdown spacing before the stamped heading.
+  const replacement = `${FRESH_TBD_SECTION}\n${stampedHeading}`;
+  lines.splice(index, 1, replacement);
+  return lines.join("\n");
+}
+
+/**
+ * Returns the release notes for `version`: the lines under the
+ * `## v<version> …` heading up to (but excluding) the next `## ` heading,
+ * trimmed. Throws if the section is missing or empty so CI never publishes an
+ * empty release.
+ */
+export function extractSection(text: string, version: string): string {
+  const lines = text.split("\n");
+  const escaped = version.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+  const headingRe = new RegExp(`^##\\s+v${escaped}(?:\\s|$)`);
+  const start = lines.findIndex((line) => headingRe.test(line));
+  if (start === -1) {
+    throw new Error(`No changelog section found for version "v${version}".`);
+  }
+
+  const body: string[] = [];
+  // Stop at the next level-2 heading ("## "); subsection headings ("### ")
+  // don't match and are kept as part of the notes.
+  for (const line of lines.slice(start + 1)) {
+    if (/^##\s/.test(line)) break;
+    body.push(line);
+  }
+
+  const section = body.join("\n").trim();
+  if (!section) {
+    throw new Error(
+      `The changelog section for "v${version}" is empty. Add release notes before releasing.`
+    );
+  }
+  return section;
+}

--- a/script/lib/changelog.ts
+++ b/script/lib/changelog.ts
@@ -29,6 +29,31 @@ export const FRESH_TBD_SECTION = `## TBD
 
 export type ReleaseType = "major" | "minor" | "patch";
 
+/**
+ * Thrown by `extractSection` when a version has no stamped changelog section
+ * (or the section is empty) — the *expected* failure mode when someone merges
+ * to `main` without running `pnpm release:prepare` on `develop` first.
+ *
+ * `script/changelog.ts extract` catches this specifically and exits with a
+ * distinct, documented status (see EXTRACT_NOT_FOUND_EXIT_CODE) so callers —
+ * namely release.yml — can tell "changelog isn't stamped" apart from a genuine
+ * bug in the script, which should surface as a real failure instead of being
+ * silently treated the same way.
+ */
+export class ChangelogSectionNotFoundError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "ChangelogSectionNotFoundError";
+  }
+}
+
+/**
+ * The process exit code `script/changelog.ts extract` uses for a
+ * `ChangelogSectionNotFoundError` — the expected "not stamped yet" outcome.
+ * Any other non-zero exit code from that command indicates a real bug.
+ */
+export const EXTRACT_NOT_FOUND_EXIT_CODE = 2;
+
 // A plain MAJOR.MINOR.PATCH version (what we can bump from).
 const SEMVER_CORE = /^(\d+)\.(\d+)\.(\d+)$/;
 // A full semver, allowing an optional pre-release and build-metadata suffix.
@@ -111,8 +136,9 @@ export function stampChangelog(
 /**
  * Returns the release notes for `version`: the lines under the
  * `## v<version> …` heading up to (but excluding) the next `## ` heading,
- * trimmed. Throws if the section is missing or empty so CI never publishes an
- * empty release.
+ * trimmed. Throws a `ChangelogSectionNotFoundError` if the section is missing
+ * or empty, so CI never publishes an empty release and can distinguish this
+ * expected outcome from a genuine bug.
  */
 export function extractSection(text: string, version: string): string {
   const lines = text.split("\n");
@@ -120,7 +146,9 @@ export function extractSection(text: string, version: string): string {
   const headingRe = new RegExp(`^##\\s+v${escaped}(?:\\s|$)`);
   const start = lines.findIndex((line) => headingRe.test(line));
   if (start === -1) {
-    throw new Error(`No changelog section found for version "v${version}".`);
+    throw new ChangelogSectionNotFoundError(
+      `No changelog section found for version "v${version}".`
+    );
   }
 
   const body: string[] = [];
@@ -133,7 +161,7 @@ export function extractSection(text: string, version: string): string {
 
   const section = body.join("\n").trim();
   if (!section) {
-    throw new Error(
+    throw new ChangelogSectionNotFoundError(
       `The changelog section for "v${version}" is empty. Add release notes before releasing.`
     );
   }

--- a/script/lib/discord.ts
+++ b/script/lib/discord.ts
@@ -38,19 +38,25 @@ export interface DiscordWebhookPayload {
   allowed_mentions: { parse: string[] };
 }
 
+// Appended directly to the cut text (no separating space/newline) when notes
+// are truncated, so a mid-sentence cutoff reads as clearly intentional rather
+// than looking like a rendering bug.
+const TRUNCATION_ELLIPSIS = "…";
+
 /**
  * Builds the webhook payload for a release announcement: an embed titled with
  * the version and linked to the site, whose description is the release notes
- * (truncated to fit Discord's limit) followed by a direct link to the site.
+ * (truncated to fit Discord's limit, with an ellipsis marking the cutoff)
+ * followed by a direct link to the site.
  */
 export function buildReleaseEmbed(
   options: DiscordReleaseOptions
 ): DiscordWebhookPayload {
   const siteLink = `**[Open Seed Bible →](${options.siteUrl})**`;
   const footer = `\n\n${siteLink}`;
-  const truncNotice = options.releaseUrl
-    ? `\n\n… [read the full release notes](${options.releaseUrl})`
-    : "\n\n…";
+  const readMoreLine = options.releaseUrl
+    ? `\n\n[read the full release notes](${options.releaseUrl})`
+    : "";
 
   const notes = options.notes.trim();
   let description: string;
@@ -58,8 +64,12 @@ export function buildReleaseEmbed(
     description = `${notes}${footer}`;
   } else {
     const budget =
-      DISCORD_DESCRIPTION_LIMIT - footer.length - truncNotice.length;
-    description = `${notes.slice(0, budget).trimEnd()}${truncNotice}${footer}`;
+      DISCORD_DESCRIPTION_LIMIT -
+      footer.length -
+      readMoreLine.length -
+      TRUNCATION_ELLIPSIS.length;
+    const truncated = notes.slice(0, budget).trimEnd();
+    description = `${truncated}${TRUNCATION_ELLIPSIS}${readMoreLine}${footer}`;
   }
 
   return {

--- a/script/lib/discord.ts
+++ b/script/lib/discord.ts
@@ -1,0 +1,116 @@
+/**
+ * Posts a release announcement to a Discord channel via an incoming webhook.
+ *
+ * Like the Telegram helper, this is a no-op when the webhook URL is missing, and
+ * it logs failures rather than throwing — a failed announcement must never break
+ * a release that has already been tagged and published.
+ */
+
+// Discord's hard limit for an embed description. We keep the rendered notes
+// under this and link out to the full GitHub release when they don't fit.
+export const DISCORD_DESCRIPTION_LIMIT = 4096;
+
+// Seed Bible green, used as the embed's accent bar.
+const EMBED_COLOR = 0x4caf50;
+
+export interface DiscordReleaseOptions {
+  /** The released version, without a leading "v" (e.g. "1.2.0"). */
+  version: string;
+  /** The release notes as markdown (a CHANGELOG section). */
+  notes: string;
+  /** The site link to surface in the announcement. */
+  siteUrl: string;
+  /** Optional link to the full GitHub release, used when notes are truncated. */
+  releaseUrl?: string;
+}
+
+interface DiscordEmbed {
+  title: string;
+  url: string;
+  description: string;
+  color: number;
+}
+
+export interface DiscordWebhookPayload {
+  username: string;
+  embeds: DiscordEmbed[];
+  // Suppress any @mentions that might appear inside the release notes.
+  allowed_mentions: { parse: string[] };
+}
+
+/**
+ * Builds the webhook payload for a release announcement: an embed titled with
+ * the version and linked to the site, whose description is the release notes
+ * (truncated to fit Discord's limit) followed by a direct link to the site.
+ */
+export function buildReleaseEmbed(
+  options: DiscordReleaseOptions
+): DiscordWebhookPayload {
+  const siteLink = `**[Open Seed Bible →](${options.siteUrl})**`;
+  const footer = `\n\n${siteLink}`;
+  const truncNotice = options.releaseUrl
+    ? `\n\n… [read the full release notes](${options.releaseUrl})`
+    : "\n\n…";
+
+  const notes = options.notes.trim();
+  let description: string;
+  if (notes.length + footer.length <= DISCORD_DESCRIPTION_LIMIT) {
+    description = `${notes}${footer}`;
+  } else {
+    const budget =
+      DISCORD_DESCRIPTION_LIMIT - footer.length - truncNotice.length;
+    description = `${notes.slice(0, budget).trimEnd()}${truncNotice}${footer}`;
+  }
+
+  return {
+    username: "Seed Bible",
+    embeds: [
+      {
+        title: `Seed Bible v${options.version} 🎉`,
+        url: options.siteUrl,
+        description,
+        color: EMBED_COLOR,
+      },
+    ],
+    allowed_mentions: { parse: [] },
+  };
+}
+
+/**
+ * Posts a release announcement to Discord.
+ *
+ * No-ops (and resolves successfully) when `webhookUrl` is missing, so the caller
+ * can pass optional configuration through without guarding. Failures are logged
+ * but never thrown.
+ */
+export async function sendDiscordRelease(
+  webhookUrl: string | undefined,
+  options: DiscordReleaseOptions
+): Promise<void> {
+  if (!webhookUrl) {
+    console.log("No Discord webhook configured — skipping announcement.");
+    return;
+  }
+
+  const payload = buildReleaseEmbed(options);
+
+  try {
+    const response = await fetch(webhookUrl, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(payload),
+    });
+
+    if (!response.ok) {
+      console.error(
+        `Failed to post Discord announcement (${response.status}): ${await response.text()}`
+      );
+    } else {
+      console.log(
+        `Posted release announcement for v${options.version} to Discord.`
+      );
+    }
+  } catch (error) {
+    console.error("DiscordError:", error);
+  }
+}

--- a/script/notify.ts
+++ b/script/notify.ts
@@ -1,5 +1,7 @@
 import { program } from "commander";
+import { readFile } from "node:fs/promises";
 import { sendTelegramMessage, telegramTimestamp } from "./lib/telegram";
+import { sendDiscordRelease } from "./lib/discord";
 
 program.name("notify").description("Commands for sending notifications.");
 
@@ -32,4 +34,44 @@ program
     );
   });
 
-program.parse();
+program
+  .command("discord-release")
+  .description(
+    "Posts a release announcement to Discord via an incoming webhook."
+  )
+  .requiredOption(
+    "--version <version>",
+    "The released version (a leading 'v' is ignored)."
+  )
+  .requiredOption(
+    "--notes-file <path>",
+    "Path to a file containing the release notes (markdown)."
+  )
+  .option(
+    "--site-url <url>",
+    "The site link to include in the announcement.",
+    "https://seedbible.org"
+  )
+  .option(
+    "--release-url <url>",
+    "Link to the full GitHub release, used when the notes are truncated."
+  )
+  .option(
+    "--webhook <url>",
+    "Discord webhook URL. Defaults to the DISCORD_ANNOUNCE_WEBHOOK environment variable. If missing, nothing is posted.",
+    process.env.DISCORD_ANNOUNCE_WEBHOOK
+  )
+  .action(async (options) => {
+    const version = options.version.startsWith("v")
+      ? options.version.slice(1)
+      : options.version;
+    const notes = await readFile(options.notesFile, "utf-8");
+    await sendDiscordRelease(options.webhook, {
+      version,
+      notes,
+      siteUrl: options.siteUrl,
+      releaseUrl: options.releaseUrl,
+    });
+  });
+
+await program.parseAsync();

--- a/script/release.ts
+++ b/script/release.ts
@@ -1,0 +1,73 @@
+import { program } from "commander";
+import { readFile, writeFile } from "node:fs/promises";
+import path from "node:path";
+import { bumpVersion, stampChangelog, today } from "./lib/changelog";
+
+// The authoritative app version: this is the one Vite bakes into the build as
+// __APP_VERSION__ (see vite.config.ts) and shows in the Settings footer. The
+// root package.json version is intentionally separate and left untouched.
+const APP_PACKAGE_PATH = path.resolve("packages", "seed-bible", "package.json");
+const CHANGELOG_PATH = path.resolve("CHANGELOG.md");
+
+async function readAppVersion(): Promise<string> {
+  const parsed = JSON.parse(await readFile(APP_PACKAGE_PATH, "utf-8")) as {
+    version?: string;
+  };
+  if (!parsed.version) {
+    throw new Error(`No "version" field found in ${APP_PACKAGE_PATH}.`);
+  }
+  return parsed.version;
+}
+
+async function writeAppVersion(version: string): Promise<void> {
+  const text = await readFile(APP_PACKAGE_PATH, "utf-8");
+  // Rewrite only the first "version" field so the file's formatting, key order,
+  // and trailing newline are preserved exactly.
+  const updated = text.replace(/("version"\s*:\s*)"[^"]*"/, `$1"${version}"`);
+  if (updated === text) {
+    throw new Error(
+      `Could not find a "version" field to update in ${APP_PACKAGE_PATH}.`
+    );
+  }
+  await writeFile(APP_PACKAGE_PATH, updated, "utf-8");
+}
+
+program.name("release").description("Commands for preparing a release.");
+
+program
+  .command("prepare <bump>")
+  .description(
+    'Bumps the app version and stamps the CHANGELOG on develop. <bump> is "major", "minor", "patch", or an explicit X.Y.Z version.'
+  )
+  .option(
+    "--date <date>",
+    "Release date (YYYY-MM-DD). Defaults to today (UTC)."
+  )
+  .action(async (bump: string, options: { date?: string }) => {
+    const current = await readAppVersion();
+    const next = bumpVersion(current, bump);
+    const date = options.date ?? today();
+
+    // Compute the stamped changelog first: stampChangelog throws when there is
+    // no "## TBD" section, so we fail before touching any file.
+    const changelog = await readFile(CHANGELOG_PATH, "utf-8");
+    const stamped = stampChangelog(changelog, next, date);
+
+    await writeAppVersion(next);
+    await writeFile(CHANGELOG_PATH, stamped, "utf-8");
+
+    console.log(`Prepared release v${next} (${date}).`);
+    console.log(`  - packages/seed-bible/package.json: ${current} -> ${next}`);
+    console.log(
+      `  - CHANGELOG.md: "## TBD" -> "## v${next} — ${date}" (+ fresh TBD)`
+    );
+    console.log("");
+    console.log("Next steps:");
+    console.log("  1. Review the diff (git diff).");
+    console.log("  2. Commit on develop and open a PR.");
+    console.log(
+      "  3. Merge develop -> main; the tag + GitHub Release publish automatically."
+    );
+  });
+
+await program.parseAsync();

--- a/test/unit/script/lib/changelog.test.ts
+++ b/test/unit/script/lib/changelog.test.ts
@@ -1,5 +1,6 @@
 import {
   bumpVersion,
+  ChangelogSectionNotFoundError,
   extractSection,
   isPrerelease,
   isValidVersion,
@@ -114,13 +115,29 @@ describe("extractSection", () => {
     expect(notes).toBe("### ✨ Added\n\n- The very first release.");
   });
 
-  it("throws for a missing version", () => {
-    expect(() => extractSection(SAMPLE, "9.9.9")).toThrow();
+  it("throws a ChangelogSectionNotFoundError for a missing version", () => {
+    expect(() => extractSection(SAMPLE, "9.9.9")).toThrow(
+      ChangelogSectionNotFoundError
+    );
   });
 
-  it("throws for an empty section", () => {
+  it("throws a ChangelogSectionNotFoundError for an empty section", () => {
     const empty =
       "# Changelog\n\n## v1.0.0 — 2026-01-01\n\n## v0.9.0 — 2025-12-01\n";
-    expect(() => extractSection(empty, "1.0.0")).toThrow();
+    expect(() => extractSection(empty, "1.0.0")).toThrow(
+      ChangelogSectionNotFoundError
+    );
+  });
+
+  it("distinguishes the not-found case from other errors by type", () => {
+    // This is the property release.yml relies on to tell "changelog isn't
+    // stamped" (skip gracefully) apart from a genuine bug (fail the job).
+    try {
+      extractSection(SAMPLE, "9.9.9");
+      expect.unreachable();
+    } catch (error) {
+      expect(error).toBeInstanceOf(ChangelogSectionNotFoundError);
+      expect(error).toBeInstanceOf(Error);
+    }
   });
 });

--- a/test/unit/script/lib/changelog.test.ts
+++ b/test/unit/script/lib/changelog.test.ts
@@ -1,0 +1,126 @@
+import {
+  bumpVersion,
+  extractSection,
+  isPrerelease,
+  isValidVersion,
+  stampChangelog,
+  TBD_HEADING,
+} from "../../../../script/lib/changelog";
+
+const SAMPLE = `# Changelog
+
+## TBD
+
+Summary line for the unreleased work.
+
+### ✨ Added
+
+- Added a thing.
+
+### 🐛 Fixed
+
+- Fixed a thing.
+
+## v1.0.0 — 2026-01-01
+
+### ✨ Added
+
+- The very first release.
+`;
+
+describe("bumpVersion", () => {
+  it("bumps patch/minor/major", () => {
+    expect(bumpVersion("1.2.3", "patch")).toBe("1.2.4");
+    expect(bumpVersion("1.2.3", "minor")).toBe("1.3.0");
+    expect(bumpVersion("1.2.3", "major")).toBe("2.0.0");
+  });
+
+  it("accepts an explicit version and strips a leading v", () => {
+    expect(bumpVersion("1.2.3", "2.5.0")).toBe("2.5.0");
+    expect(bumpVersion("1.2.3", "v2.5.0")).toBe("2.5.0");
+    expect(bumpVersion("1.2.3", "2.0.0-rc.1")).toBe("2.0.0-rc.1");
+  });
+
+  it("throws when keyword-bumping a non-core version", () => {
+    expect(() => bumpVersion("1.2.3-rc.1", "patch")).toThrow();
+  });
+
+  it("throws on an invalid explicit version", () => {
+    expect(() => bumpVersion("1.2.3", "nope")).toThrow();
+    expect(() => bumpVersion("1.2.3", "1.2")).toThrow();
+  });
+});
+
+describe("isValidVersion / isPrerelease", () => {
+  it("validates semver strings", () => {
+    expect(isValidVersion("1.2.3")).toBe(true);
+    expect(isValidVersion("1.2.3-rc.1")).toBe(true);
+    expect(isValidVersion("1.2")).toBe(false);
+    expect(isValidVersion("v1.2.3")).toBe(false);
+  });
+
+  it("detects pre-release versions", () => {
+    expect(isPrerelease("1.2.0")).toBe(false);
+    expect(isPrerelease("1.2.0-rc.1")).toBe(true);
+  });
+});
+
+describe("stampChangelog", () => {
+  it("converts the first TBD into a dated version heading", () => {
+    const out = stampChangelog(SAMPLE, "1.1.0", "2026-07-22");
+    expect(out).toContain("## v1.1.0 — 2026-07-22");
+    // The old TBD content is preserved under the new version heading.
+    expect(out).toContain("Summary line for the unreleased work.");
+    // The previous release heading is untouched.
+    expect(out).toContain("## v1.0.0 — 2026-01-01");
+  });
+
+  it("inserts a fresh empty TBD above the stamped heading", () => {
+    const out = stampChangelog(SAMPLE, "1.1.0", "2026-07-22");
+    const tbdIndex = out.indexOf(TBD_HEADING);
+    const versionIndex = out.indexOf("## v1.1.0");
+    expect(tbdIndex).toBeGreaterThanOrEqual(0);
+    expect(tbdIndex).toBeLessThan(versionIndex);
+    // The fresh TBD carries the emoji subsection scaffold.
+    const freshTbd = out.slice(tbdIndex, versionIndex);
+    expect(freshTbd).toContain("### ✨ Added");
+    expect(freshTbd).toContain("### 🗑️ Removed");
+  });
+
+  it("stamping then extracting round-trips the notes", () => {
+    const out = stampChangelog(SAMPLE, "1.1.0", "2026-07-22");
+    const notes = extractSection(out, "1.1.0");
+    expect(notes).toContain("Summary line for the unreleased work.");
+    expect(notes).toContain("- Added a thing.");
+    expect(notes).toContain("- Fixed a thing.");
+    // Must not bleed into the next (older) release section.
+    expect(notes).not.toContain("The very first release.");
+  });
+
+  it("throws when there is no TBD section", () => {
+    expect(() =>
+      stampChangelog(
+        "# Changelog\n\n## v1.0.0 — 2026-01-01\n",
+        "1.1.0",
+        "2026-07-22"
+      )
+    ).toThrow();
+  });
+});
+
+describe("extractSection", () => {
+  it("returns a version's notes up to the next heading, trimmed", () => {
+    const notes = extractSection(SAMPLE, "1.0.0");
+    expect(notes).toBe("### ✨ Added\n\n- The very first release.");
+  });
+
+  it("throws for a missing version", () => {
+    expect(() => extractSection(SAMPLE, "9.9.9")).toThrow();
+  });
+
+  it("throws for an empty section", () => {
+    const empty =
+      "# Changelog\n\n## v1.0.0 — 2026-01-01\n\n## v0.9.0 — 2025-12-01\n";
+    expect(() => extractSection(empty, "1.0.0")).toThrow();
+  });
+});

--- a/test/unit/script/lib/discord.test.ts
+++ b/test/unit/script/lib/discord.test.ts
@@ -1,0 +1,54 @@
+import {
+  buildReleaseEmbed,
+  DISCORD_DESCRIPTION_LIMIT,
+} from "../../../../script/lib/discord";
+
+const BASE = {
+  version: "1.2.0",
+  siteUrl: "https://seedbible.org",
+  releaseUrl: "https://github.com/HelloAOLab/seed-bible/releases/tag/v1.2.0",
+};
+
+describe("buildReleaseEmbed", () => {
+  it("titles the embed with the version and links it to the site", () => {
+    const payload = buildReleaseEmbed({ ...BASE, notes: "Some notes." });
+    const embed = payload.embeds[0];
+    expect(embed?.title).toContain("v1.2.0");
+    expect(embed?.url).toBe("https://seedbible.org");
+    expect(payload.username).toBe("Seed Bible");
+  });
+
+  it("includes the notes and a direct site link in the description", () => {
+    const payload = buildReleaseEmbed({
+      ...BASE,
+      notes: "### ✨ Added\n\n- A new thing.",
+    });
+    const description = payload.embeds[0]?.description ?? "";
+    expect(description).toContain("- A new thing.");
+    expect(description).toContain("https://seedbible.org");
+  });
+
+  it("suppresses mentions so notes can't ping the channel", () => {
+    const payload = buildReleaseEmbed({
+      ...BASE,
+      notes: "Thanks @everyone for testing.",
+    });
+    expect(payload.allowed_mentions).toEqual({ parse: [] });
+  });
+
+  it("truncates long notes to fit Discord's limit and links to full notes", () => {
+    const notes = "x".repeat(DISCORD_DESCRIPTION_LIMIT * 2);
+    const payload = buildReleaseEmbed({ ...BASE, notes });
+    const description = payload.embeds[0]?.description ?? "";
+    expect(description.length).toBeLessThanOrEqual(DISCORD_DESCRIPTION_LIMIT);
+    expect(description).toContain(BASE.releaseUrl);
+    expect(description).toContain("https://seedbible.org");
+  });
+
+  it("does not truncate notes that already fit", () => {
+    const payload = buildReleaseEmbed({ ...BASE, notes: "Short and sweet." });
+    const description = payload.embeds[0]?.description ?? "";
+    expect(description).not.toContain("read the full release notes");
+    expect(description.startsWith("Short and sweet.")).toBe(true);
+  });
+});

--- a/test/unit/script/lib/discord.test.ts
+++ b/test/unit/script/lib/discord.test.ts
@@ -45,6 +45,29 @@ describe("buildReleaseEmbed", () => {
     expect(description).toContain("https://seedbible.org");
   });
 
+  it("appends an ellipsis directly to the cut text to mark an intentional truncation", () => {
+    const notes = "x".repeat(DISCORD_DESCRIPTION_LIMIT * 2);
+    const payload = buildReleaseEmbed({ ...BASE, notes });
+    const description = payload.embeds[0]?.description ?? "";
+    // The ellipsis sits immediately after the last kept "x" — no separating
+    // space or newline — so the cutoff reads as intentional, not a glitch.
+    expect(description).toContain("xx…");
+    expect(description).not.toMatch(/x\s+…/);
+  });
+
+  it("truncates without a releaseUrl by still marking the cutoff with an ellipsis", () => {
+    const notes = "x".repeat(DISCORD_DESCRIPTION_LIMIT * 2);
+    const payload = buildReleaseEmbed({
+      version: BASE.version,
+      siteUrl: BASE.siteUrl,
+      notes,
+    });
+    const description = payload.embeds[0]?.description ?? "";
+    expect(description.length).toBeLessThanOrEqual(DISCORD_DESCRIPTION_LIMIT);
+    expect(description).toContain("xx…");
+    expect(description).not.toContain("read the full release notes");
+  });
+
   it("does not truncate notes that already fit", () => {
     const payload = buildReleaseEmbed({ ...BASE, notes: "Short and sweet." });
     const description = payload.embeds[0]?.description ?? "";

--- a/typings/buildConstants.d.ts
+++ b/typings/buildConstants.d.ts
@@ -1,0 +1,2 @@
+declare const __APP_VERSION__: string;
+declare const __GIT_COMMIT__: string;

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -2,6 +2,8 @@
 import { defineConfig } from "vite";
 import preact from "@preact/preset-vite";
 import path from "path";
+import { execSync } from "child_process";
+import { readFileSync } from "fs";
 import { analyzer } from "vite-bundle-analyzer";
 import { VitePWA } from "vite-plugin-pwa";
 import { patternPlugin } from "./script/lib/vite-plugin-patterns";
@@ -38,12 +40,39 @@ function withTrailingSlash(url: string): string {
   return url.endsWith("/") ? url : `${url}/`;
 }
 
+// Baked into the client bundle so a build reports its own version/commit even
+// when a stale copy is being served — the value travels inside the JS chunk
+// rather than being fetched at request time.
+const appVersion = JSON.parse(
+  readFileSync(
+    path.resolve(__dirname, "packages/seed-bible/package.json"),
+    "utf-8"
+  )
+).version as string;
+
+// CI sets DEPLOY_BUILD_ID to the full commit SHA before `pnpm build` runs (see
+// cd.yml); falling back to `git rev-parse` covers local dev/build.
+function resolveGitCommit(): string {
+  if (deployBuildId) return deployBuildId;
+  try {
+    return execSync("git rev-parse HEAD").toString().trim();
+  } catch {
+    return "unknown";
+  }
+}
+const gitCommit = resolveGitCommit();
+
 export default defineConfig(({ isSsrBuild }) => ({
   // SSR builds must not treat index.html as an input; only the client build
   // is an HTML/SPA build.
   appType: "custom",
   publicDir: false,
   base: assetBaseUrl,
+
+  define: {
+    __APP_VERSION__: JSON.stringify(appVersion),
+    __GIT_COMMIT__: JSON.stringify(gitCommit),
+  },
 
   plugins: [
     preact(),


### PR DESCRIPTION
## Summary

This branch adds two related pieces of work, both centered on the app version: it shows the running build's version and commit in Settings, and it turns "merge `develop` → `main`" into a real release that tags the commit, publishes a GitHub Release, and dates the CHANGELOG.

## What's included

### 1. Build info in the Settings footer

The client bundle now bakes in its own version and commit at build time (`__APP_VERSION__` from `packages/seed-bible/package.json`, `__GIT_COMMIT__` from CI's `DEPLOY_BUILD_ID`, falling back to `git rev-parse` locally), and the Settings page shows them in a footer that copies the full `v<version> (<commit>)` string on click. Because the value travels inside the JS chunk, a build reports its own version even when a stale copy is being served.

### 2. CHANGELOG + automated releases

Production already ships by merging `develop` → `main` (cd.yml deploys the merged commit to seedbible.org). This adds everything around that deploy: a git tag, a GitHub Release, and a dated CHANGELOG entry.

Releasing is a two-step flow. On `develop`, `pnpm release:prepare <bump>` bumps the version, rewrites the CHANGELOG's `## TBD` heading to `## v<version> — <YYYY-MM-DD>`, and inserts a fresh empty `## TBD` above it so `develop` is ready for the next cycle. After that merges to `main`, the new `release.yml` workflow reads the version, tags the commit `v<version>`, and publishes a GitHub Release whose notes are that version's CHANGELOG section.

Stamping on `develop` (rather than automatically on `main`) keeps the git history clean: no bot commits on the protected branch, the tag points exactly at the deployed commit, and there's no next-cycle CHANGELOG merge conflict. The workflow is idempotent — a push to `main` that didn't bump the version (e.g. a hotfix) deploys but creates no release, and re-runs never duplicate one.

## Files of note

- `.github/workflows/release.yml` — tags + publishes the Release on push to `main`; install/publish steps are gated behind a "does this release already exist?" check so no-op pushes stay cheap.
- `script/lib/changelog.ts` — pure, tested helpers (`bumpVersion`, `stampChangelog`, `extractSection`).
- `script/release.ts` (`pnpm release:prepare`) and `script/changelog.ts` (`pnpm changelog:extract`, used by CI).
- `README.md` — a new "Releasing" section documenting the flow.

## Testing

- `pnpm vitest run changelog.test.ts` — 13 unit tests covering version bumping, TBD stamping, and note extraction (including the round-trip and the missing/empty-section failures).
- `pnpm check:ts` — clean (0 visible errors; the new script files aren't in the tsc-silent suppress list).
- Ran `pnpm release:prepare patch` end-to-end against the real files, confirmed the version bump, the `## v… — <date>` heading (em dash) with a fresh TBD, and that `pnpm changelog:extract` returned exactly that section — then reverted.

## Notes for the first release

The current CHANGELOG `## TBD` is not yet stamped and `packages/seed-bible/package.json` is already at `1.1.0`. To cut `v1.1.0` without a further bump, run `pnpm release:prepare 1.1.0` on `develop` (explicit version) to stamp the existing TBD, then merge as usual. If the changelog is left unstamped, `release.yml` fails the extract step rather than publishing empty notes.

`release.yml` is push-only. To test-run it safely before relying on it, temporarily add a `workflow_dispatch:` trigger (or test on a fork) against a throwaway `vX.Y.Z-test` tag, then remove it.

The root `package.json` version is intentionally left at `1.0.0` — only the app package version (`packages/seed-bible/package.json`) is bumped, matching the existing convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
