### PR TITLE
Floating chat panel polish + dedicated link theme colors

### DIFF
--- a/packages/seed-bible/seed-bible/app/styles/base.css
+++ b/packages/seed-bible/seed-bible/app/styles/base.css
@@ -91,6 +91,9 @@
   --sb-secondary-color: #faddd1;
   --sb-secondary-font-color: #333;
 
+  --sb-link-color: #b34d1c;
+  --sb-link-visited-color: #8d5a6b;
+
   --sb-sidebar-background: transparent;
   --sb-sidebar-font-family: inherit;
   --sb-sidebar-font-color: inherit;
@@ -349,11 +352,11 @@ h6 {
 }
 
 a {
-  color: var(--sb-primary-color);
+  color: var(--sb-link-color);
 }
 
 a:visited {
-  color: var(--sb-secondary-color);
+  color: var(--sb-link-visited-color);
 }
 
 .sb-font-size-xs {

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
@@ -446,7 +446,7 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
       chats,
       openSidebar: sidebar.openSidebar,
       openSearch: sidebar.openSearch,
-      openChat: sidebar.openChatPanel,
+      openChat: sidebar.toggleChatPanel,
       openDiscover: props.state.app.openDiscover,
       toast: props.state.app.toast,
       modals: props.state.modals,

--- a/packages/seed-bible/seed-bible/components/ChatView/ChatView.css
+++ b/packages/seed-bible/seed-bible/components/ChatView/ChatView.css
@@ -1,7 +1,6 @@
 .sb-chat-view {
   display: flex;
   flex-direction: column;
-  gap: 0.75rem;
   min-height: 13.75rem;
   flex: 1 1 auto;
 }
@@ -9,7 +8,6 @@
 .sb-chat-view-messages {
   flex: 1;
   min-height: 0;
-  max-height: 17.5rem;
   overflow: auto;
   display: flex;
   flex-direction: column;

--- a/packages/seed-bible/seed-bible/components/ChatView/ChatView.css
+++ b/packages/seed-bible/seed-bible/components/ChatView/ChatView.css
@@ -5,6 +5,14 @@
   flex: 1 1 auto;
 }
 
+/* Verse reference links were getting inconsistently colored — some looked
+   visited (book/chapter references) while others (verse or range references)
+   didn't, for reasons that aren't clear. Keeping every link in chat the
+   normal link color sidesteps that inconsistency until it's understood. */
+.sb-chat-view a:visited {
+  color: var(--sb-link-color);
+}
+
 .sb-chat-view-messages {
   flex: 1;
   min-height: 0;

--- a/packages/seed-bible/seed-bible/components/ChatView/ChatView.css
+++ b/packages/seed-bible/seed-bible/components/ChatView/ChatView.css
@@ -1,7 +1,7 @@
 .sb-chat-view {
   display: flex;
   flex-direction: column;
-  min-height: 13.75rem;
+  min-height: 0;
   flex: 1 1 auto;
 }
 

--- a/packages/seed-bible/seed-bible/components/ContextMenu/ContextMenu.css
+++ b/packages/seed-bible/seed-bible/components/ContextMenu/ContextMenu.css
@@ -31,7 +31,8 @@
   min-width: 12.5rem;
   max-width: 17.5rem;
   padding: 0.375rem;
-  border: 1px solid var(--sb-secondary-color);
+  border: 1px solid
+    color-mix(in srgb, var(--sb-menu-font-color), transparent 80%);
   border-radius: 0.5rem;
   background: var(--sb-menu-background);
   color: var(--sb-menu-font-color);

--- a/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.css
+++ b/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.css
@@ -249,9 +249,10 @@
   inset-inline-start: auto;
   inset-inline-end: 1rem;
   transform: none;
-  bottom: 0.5rem;
-  width: min(20rem, calc(100vw - 2rem));
-  min-height: 25rem;
+  bottom: 1rem;
+  width: 25rem;
+  height: calc(100dvh - 2rem);
+  max-height: 40rem;
   padding: 0;
   display: flex;
   flex-direction: column;
@@ -274,7 +275,7 @@
   display: flex;
   align-items: center;
   gap: 0.625rem;
-  min-height: 1.625rem;
+  min-height: 3.35rem;
   padding: 0.75rem;
   border-bottom: 1px solid var(--sb-divider-color);
 }
@@ -397,7 +398,7 @@
 .sb-floating-chat-list {
   display: flex;
   flex-direction: column;
-  max-height: 22.5rem;
+  max-height: 36.25rem;
   overflow: auto;
   padding: 0.25rem;
   flex: 1 1 auto;

--- a/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.css
+++ b/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.css
@@ -256,7 +256,7 @@
   padding: 0;
   display: flex;
   flex-direction: column;
-  border-radius: 0.5rem;
+  border-radius: 0.75rem;
   animation: sb-floating-chat-panel-rise 0.18s ease-out;
 }
 

--- a/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.css
+++ b/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.css
@@ -693,6 +693,7 @@
     left: 50%;
     right: auto;
     bottom: 6.25rem;
+    height: calc(100dvh - 8.25rem);
     transform: translateX(-50%);
     animation: sb-floating-panel-rise 0.18s ease-out;
   }

--- a/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.css
+++ b/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.css
@@ -315,6 +315,35 @@
   text-overflow: ellipsis;
 }
 
+.sb-floating-chat-header-icon {
+  flex-shrink: 0;
+  font-size: 1.25rem;
+  color: color-mix(in srgb, var(--sb-font-color), transparent 22%);
+}
+
+.sb-floating-chat-header-close {
+  flex-shrink: 0;
+  width: 1.75rem;
+  height: 1.75rem;
+  border: none;
+  border-radius: 0.5rem;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: color-mix(in srgb, var(--sb-font-color), transparent 22%);
+  background: color-mix(in srgb, var(--sb-font-color), transparent 93%);
+  cursor: pointer;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.sb-floating-chat-header-close:hover,
+.sb-floating-chat-header-close:focus-visible {
+  color: var(--sb-font-color);
+  background: color-mix(in srgb, var(--sb-font-color), transparent 88%);
+}
+
 @media (max-width: 480px) {
   /* Search is a bottom-anchored sheet on mobile: the input sits just above the
      5-tab bar and results grow upward. It is capped to the *small* viewport

--- a/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.tsx
+++ b/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.tsx
@@ -786,7 +786,16 @@ export function FloatingChatPanel(props: FloatingReaderPanelsProps) {
           </button>
         ) : null}
 
-        {selectedChat && <ChatListAvatarCluster chat={selectedChat} />}
+        {selectedChat ? (
+          <ChatListAvatarCluster chat={selectedChat} />
+        ) : (
+          <span
+            className="material-symbols-outlined sb-floating-chat-header-icon"
+            aria-hidden="true"
+          >
+            chat_bubble_outline
+          </span>
+        )}
         <p className="sb-floating-chat-header-title">
           {selectedChat
             ? getChatTitle(selectedChat, t)
@@ -873,6 +882,20 @@ export function FloatingChatPanel(props: FloatingReaderPanelsProps) {
             )}
           </ContextMenuWithButton>
         ) : null}
+
+        <button
+          type="button"
+          className="sb-floating-chat-header-close"
+          onClick={() => {
+            sidebar.closeChatPanel();
+          }}
+          aria-label={t("close", { defaultValue: "Close" })}
+          title={t("close", { defaultValue: "Close" })}
+        >
+          <span className="material-symbols-outlined" aria-hidden="true">
+            close
+          </span>
+        </button>
       </header>
 
       {selectedChat ? (

--- a/packages/seed-bible/seed-bible/managers/ThemeManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ThemeManager.tsx
@@ -21,6 +21,9 @@ export interface BibleThemeVariables {
 
   tertiaryColor: string;
 
+  linkColor: string;
+  linkVisitedColor: string;
+
   /**
    * The background color for the entire app. This is used as the background for the body element, so it will be visible in areas that don't have a specific background set (e.g. when a pane is detached or when there are gaps between panes). It should generally match the readerBackground color to create a seamless look, but can be set to a different color if desired.
    */
@@ -485,6 +488,9 @@ const LIGHT_THEME: BibleTheme = {
 
     tertiaryColor: "#f0f0f0",
 
+    linkColor: "#b34d1c",
+    linkVisitedColor: "#8d5a6b",
+
     background: "#f8fafc",
 
     sidebarBackground: "transparent",
@@ -626,6 +632,9 @@ const DARK_THEME: BibleTheme = {
     secondaryFontColor: "#f5f5f5",
 
     tertiaryColor: "#1c1c1c",
+
+    linkColor: "#ff9e80",
+    linkVisitedColor: "#d99bb0",
 
     background: "#0a0a0a",
 
@@ -775,6 +784,8 @@ export type ThemeColorKey =
   | "secondaryColor"
   | "secondaryFontColor"
   | "tertiaryColor"
+  | "linkColor"
+  | "linkVisitedColor"
   | "background"
   | "fontColor"
   | "sidebarBackground"
@@ -815,6 +826,8 @@ export const THEME_COLOR_GROUPS: ThemeColorGroup[] = [
       { key: "secondaryColor", label: "Secondary" },
       { key: "secondaryFontColor", label: "Secondary text" },
       { key: "tertiaryColor", label: "Tertiary" },
+      { key: "linkColor", label: "Link" },
+      { key: "linkVisitedColor", label: "Visited link" },
     ],
   },
   {

--- a/packages/seed-bible/seed-bible/managers/ThemeManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ThemeManager.tsx
@@ -488,7 +488,7 @@ const LIGHT_THEME: BibleTheme = {
 
     tertiaryColor: "#f0f0f0",
 
-    linkColor: "#b34d1c",
+    linkColor: "#e07b4c",
     linkVisitedColor: "#8d5a6b",
 
     background: "#f8fafc",
@@ -633,7 +633,7 @@ const DARK_THEME: BibleTheme = {
 
     tertiaryColor: "#1c1c1c",
 
-    linkColor: "#ff9e80",
+    linkColor: "#e07b4c",
     linkVisitedColor: "#d99bb0",
 
     background: "#0a0a0a",


### PR DESCRIPTION
## Summary

- Floating chat panel is bigger, rounder, and no longer overflows or hides its input bar on short screens.
- Chat header now has an icon, a close button, and the toolbar's Chat button toggles the panel instead of only opening it.
- Links now use their own theme colors instead of reusing brand colors that had poor contrast, especially in dark mode.
- Chat links stay a consistent color, ignoring the inconsistent visited-link state.

## Changes

- Floating chat panel: bigger size, rounder corners, and a fix for the compose/input bar getting pushed off-screen on short viewports.
- Chat header: added a chat icon, a close (X) button, and made the toolbar's Chat button toggle the panel open/closed.
- Theming: added --sb-link-color / --sb-link-visited-color, and made chat links ignore :visited since that state was showing up inconsistently there.
- Small context menu border color tweak.