### PR TITLE
Prevent deployments from using special characters in branch names

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,7 @@ jobs:
         id: ids
         run: |
           RAW="${{ github.head_ref || github.ref_name }}"
-          BRANCH=$(echo "$RAW" | sed 's/\//_/g')
+          BRANCH=$(echo "$RAW" | sed 's/[^a-zA-Z0-9]/_/g')
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "build_id=${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
@@ -252,7 +252,7 @@ jobs:
         with:
           script: |
             const commentDeployment = require("./.github/scripts/comment-deployment.cjs");
-            const branch = "${{ github.head_ref }}".replace(/\//g, "_");
+            const branch = "${{ github.head_ref }}".replace(/[^a-zA-Z0-9]/g, "_");
             await commentDeployment({
               github,
               context,

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -249,10 +249,12 @@ jobs:
       - name: Comment on pull request with deployment link
         continue-on-error: true
         uses: actions/github-script@v7
+        env:
+          HEAD_REF: ${{ github.head_ref }}
         with:
           script: |
             const commentDeployment = require("./.github/scripts/comment-deployment.cjs");
-            const branch = "${{ github.head_ref }}".replace(/[^a-zA-Z0-9-]/g, "_");
+            const branch = process.env.HEAD_REF.replace(/[^a-zA-Z0-9-]/g, "_");
             await commentDeployment({
               github,
               context,

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -70,7 +70,7 @@ jobs:
         id: ids
         run: |
           RAW="${{ github.head_ref || github.ref_name }}"
-          BRANCH=$(echo "$RAW" | sed 's/[^a-zA-Z0-9]/_/g')
+          BRANCH=$(echo "$RAW" | sed 's/[^a-zA-Z0-9-]/_/g')
           echo "branch=$BRANCH" >> "$GITHUB_OUTPUT"
           echo "build_id=${{ github.sha }}" >> "$GITHUB_OUTPUT"
 
@@ -252,7 +252,7 @@ jobs:
         with:
           script: |
             const commentDeployment = require("./.github/scripts/comment-deployment.cjs");
-            const branch = "${{ github.head_ref }}".replace(/[^a-zA-Z0-9]/g, "_");
+            const branch = "${{ github.head_ref }}".replace(/[^a-zA-Z0-9-]/g, "_");
             await commentDeployment({
               github,
               context,


### PR DESCRIPTION
Currently, all special characters are allowed for the generated deployments. After this PR is merged, only alphanumeric (A-Z, a-z, 0-9), hyphen (-), and underscore (_) are allowed. All other symbols will be converted to an underscore (_).