### PR TITLE
Fix feature flags

### DIFF
--- a/packages/seed-bible/seed-bible/app/initPostHog.tsx
+++ b/packages/seed-bible/seed-bible/app/initPostHog.tsx
@@ -14,6 +14,7 @@ if (
   (globalThis as any).posthog = {
     init: () => {},
     capture: () => {},
+    onFeatureFlags: () => {},
     identify: () => {},
     setPersonProperties: () => {},
   };
@@ -24,10 +25,13 @@ if (
   !(function (t, e) {
     var o, n, p, r;
     e.__SV ||
-      (((window as any).posthog = e),
+      // @ts-ignore
+      (window.posthog && window.posthog.__loaded) ||
+      // @ts-ignore
+      ((window.posthog = e),
       (e._i = []),
-      (e.init = function (i: any, s: any, a: any) {
-        function g(t: any, e: any) {
+      (e.init = function (i, s, a) {
+        function g(t, e) {
           var o = e.split(".");
           (2 == o.length && ((t = t[o[0]]), (e = o[1])),
             (t[e] = function () {
@@ -50,7 +54,7 @@ if (
         for (
           void 0 !== a ? (u = e[a] = []) : (a = "posthog"),
             u.people = u.people || [],
-            u.toString = function (t: any) {
+            u.toString = function (t) {
               var e = "posthog";
               return (
                 "posthog" !== a && (e += "." + a),
@@ -62,7 +66,7 @@ if (
               return u.toString(1) + ".people (stub)";
             },
             o =
-              "init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagPayload isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(
+              "init capture register register_once register_for_session unregister unregister_for_session getFeatureFlag getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSessionId getSurveys getActiveMatchingSurveys renderSurvey canRenderSurvey getNextSurveyStep identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException loadToolbar get_property getSessionProperty createPersonProfile opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing clear_opt_in_out_capturing debug".split(
                 " "
               ),
             n = 0;
@@ -73,13 +77,14 @@ if (
         e._i.push([i, s, a]);
       }),
       (e.__SV = 1));
-  })(document, (window as any).posthog || []);
+    // @ts-ignore
+  })(document, window.posthog || []);
 
   const seedBibleApiKey = "phc_rEUogfrnXkdTitOTrfWK2laEINF1QwNtGNQizzuMW0";
   posthog.init(seedBibleApiKey, {
     api_host: "https://i.ao.bot",
     ui_host: "https://us.posthog.com",
-    defaults: "2025-05-24",
+    defaults: "2026-05-30",
   });
 
   posthog.register({});

--- a/packages/seed-bible/seed-bible/app/initPostHog.tsx
+++ b/packages/seed-bible/seed-bible/app/initPostHog.tsx
@@ -30,7 +30,9 @@ if (
       // @ts-ignore
       ((window.posthog = e),
       (e._i = []),
+      // @ts-ignore
       (e.init = function (i, s, a) {
+        // @ts-ignore
         function g(t, e) {
           var o = e.split(".");
           (2 == o.length && ((t = t[o[0]]), (e = o[1])),
@@ -54,6 +56,7 @@ if (
         for (
           void 0 !== a ? (u = e[a] = []) : (a = "posthog"),
             u.people = u.people || [],
+            // @ts-ignore
             u.toString = function (t) {
               var e = "posthog";
               return (

--- a/packages/seed-bible/seed-bible/managers/BibleToolsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/BibleToolsManager.tsx
@@ -690,7 +690,7 @@ function getDefaultToolbarTools(): ManagedBibleToolbarTool[] {
       icon: () => <MaterialIcon>menu_book</MaterialIcon>,
       isVisible: (context) =>
         !!context.readingPlans &&
-        context.features.isFeatureEnabled(FEATURE_KEY_READING_PLANS),
+        context.features.isFeatureEnabled(FEATURE_KEY_READING_PLANS).value,
       onSelect: (context) => {
         const readingPlans = context.readingPlans;
         if (!readingPlans) {

--- a/packages/seed-bible/seed-bible/managers/FeaturesManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/FeaturesManager.tsx
@@ -8,6 +8,7 @@ export interface PostHog {
 export const FEATURE_KEY_READING_PLANS = "reading-plans";
 
 export function createFeaturesManager(posthog: PostHog | null) {
+  const flags = signal<string[]>([]);
   const signals = new Map<string, Signal<boolean>>();
 
   const getFeatureSignal = (featureKey: string): Signal<boolean> => {
@@ -24,15 +25,18 @@ export function createFeaturesManager(posthog: PostHog | null) {
       s.value = true;
     } else if (import.meta.env.SSR || !posthog) {
       s.value = false;
+    } else {
+      s.value = flags.peek().includes(featureKey);
     }
 
     return s;
   };
 
   if (posthog) {
-    posthog.onFeatureFlags((flags) => {
+    posthog.onFeatureFlags((f) => {
+      flags.value = f;
       for (const [featureKey, s] of signals.entries()) {
-        const featureEnabled = flags.includes(featureKey);
+        const featureEnabled = flags.peek().includes(featureKey);
         s.value = featureEnabled ?? false;
       }
     });

--- a/packages/seed-bible/seed-bible/managers/FeaturesManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/FeaturesManager.tsx
@@ -2,7 +2,7 @@ import { signal, type ReadonlySignal, type Signal } from "@preact/signals";
 
 export interface PostHog {
   isFeatureEnabled: (featureKey: string) => boolean;
-  onFeatureFlags: (callback: () => void) => void;
+  onFeatureFlags: (callback: (flags: string[]) => void) => void;
 }
 
 export const FEATURE_KEY_READING_PLANS = "reading-plans";
@@ -24,17 +24,16 @@ export function createFeaturesManager(posthog: PostHog | null) {
       s.value = true;
     } else if (import.meta.env.SSR || !posthog) {
       s.value = false;
-    } else {
-      s.value = posthog.isFeatureEnabled(featureKey) ?? false;
     }
 
     return s;
   };
 
   if (posthog) {
-    posthog.onFeatureFlags(() => {
+    posthog.onFeatureFlags((flags) => {
       for (const [featureKey, s] of signals.entries()) {
-        s.value = posthog.isFeatureEnabled(featureKey) ?? false;
+        const featureEnabled = flags.includes(featureKey);
+        s.value = featureEnabled ?? false;
       }
     });
   }

--- a/packages/seed-bible/seed-bible/managers/FeaturesManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/FeaturesManager.tsx
@@ -1,25 +1,43 @@
+import { signal, type ReadonlySignal, type Signal } from "@preact/signals";
+
 export interface PostHog {
   isFeatureEnabled: (featureKey: string) => boolean;
+  onFeatureFlags: (callback: () => void) => void;
 }
 
 export const FEATURE_KEY_READING_PLANS = "reading-plans";
 
 export function createFeaturesManager(posthog: PostHog | null) {
-  const isFeatureEnabled = (featureKey: string): boolean => {
-    if (import.meta.env.DEV) {
-      return true;
-    }
+  const signals = new Map<string, Signal<boolean>>();
 
-    if (import.meta.env.SSR) {
-      return false;
+  const getFeatureSignal = (featureKey: string): Signal<boolean> => {
+    if (!signals.has(featureKey)) {
+      const s = signal(false);
+      signals.set(featureKey, s);
     }
-
-    if (!posthog) {
-      return true;
-    }
-
-    return posthog.isFeatureEnabled(featureKey) ?? false;
+    return signals.get(featureKey)!;
   };
+
+  const isFeatureEnabled = (featureKey: string): ReadonlySignal<boolean> => {
+    const s = getFeatureSignal(featureKey);
+    if (import.meta.env.DEV) {
+      s.value = true;
+    } else if (import.meta.env.SSR || !posthog) {
+      s.value = false;
+    } else {
+      s.value = posthog.isFeatureEnabled(featureKey) ?? false;
+    }
+
+    return s;
+  };
+
+  if (posthog) {
+    posthog.onFeatureFlags(() => {
+      for (const [featureKey, s] of signals.entries()) {
+        s.value = posthog.isFeatureEnabled(featureKey) ?? false;
+      }
+    });
+  }
 
   return {
     isFeatureEnabled,

--- a/test/integration/seed-bible/components/TabSlotReader.test.tsx
+++ b/test/integration/seed-bible/components/TabSlotReader.test.tsx
@@ -227,7 +227,7 @@ function createMobileState(): SeedBibleState {
       playing: signal(null),
     },
     features: {
-      isFeatureEnabled: vi.fn(() => true),
+      isFeatureEnabled: vi.fn(() => signal(true)),
     },
   } as any as SeedBibleState;
 }
@@ -257,7 +257,7 @@ function createDesktopState(): SeedBibleState {
       playing: signal(null),
     },
     features: {
-      isFeatureEnabled: vi.fn(() => true),
+      isFeatureEnabled: vi.fn(() => signal(true)),
     },
   } as any as SeedBibleState;
 }

--- a/test/unit/seed-bible/components/BibleReader.test.tsx
+++ b/test/unit/seed-bible/components/BibleReader.test.tsx
@@ -239,7 +239,7 @@ function createMobileState(): SeedBibleState {
       playing: signal(null),
     },
     features: {
-      isFeatureEnabled: vi.fn(() => true),
+      isFeatureEnabled: vi.fn(() => signal(true)),
     },
   } as any as SeedBibleState;
 }

--- a/test/unit/seed-bible/managers/BibleToolsManager.test.tsx
+++ b/test/unit/seed-bible/managers/BibleToolsManager.test.tsx
@@ -53,7 +53,7 @@ function createContext(): BibleToolContext {
       providers: signal([]),
     } as any,
     features: {
-      isFeatureEnabled: vi.fn().mockReturnValue(true),
+      isFeatureEnabled: vi.fn(() => signal(true)),
     },
   };
 }

--- a/test/unit/seed-bible/managers/FeaturesManager.test.ts
+++ b/test/unit/seed-bible/managers/FeaturesManager.test.ts
@@ -47,7 +47,13 @@ function makeFakePostHog(initialFlags: Record<string, boolean | undefined>) {
       flags[key] = value;
     },
     pushFlagsUpdate() {
-      listener?.(Object.keys(flags));
+      let f = [];
+      for (const [key, value] of Object.entries(flags)) {
+        if (value) {
+          f.push(key);
+        }
+      }
+      listener?.(f);
     },
   };
 }
@@ -98,10 +104,13 @@ describe("FeaturesManager", () => {
 
   it("reads the flag value from posthog outside of dev mode and SSR", () => {
     withEnv({ DEV: false, SSR: false }, () => {
-      const { posthog } = makeFakePostHog({
+      const { posthog, pushFlagsUpdate } = makeFakePostHog({
         [FEATURE_KEY_READING_PLANS]: true,
       });
       const manager = createFeaturesManager(posthog);
+
+      pushFlagsUpdate(); // Simulate PostHog pushing the initial flags
+
       expect(manager.isFeatureEnabled(FEATURE_KEY_READING_PLANS).value).toBe(
         true
       );
@@ -137,8 +146,10 @@ describe("FeaturesManager", () => {
 
       const flagA = manager.isFeatureEnabled("flag-a");
       const flagB = manager.isFeatureEnabled("flag-b");
+
+      // Flags aren't evaluated until the first push from PostHog
       expect(flagA.value).toBe(false);
-      expect(flagB.value).toBe(true);
+      expect(flagB.value).toBe(false);
 
       setFlag("flag-a", true);
       setFlag("flag-b", false);

--- a/test/unit/seed-bible/managers/FeaturesManager.test.ts
+++ b/test/unit/seed-bible/managers/FeaturesManager.test.ts
@@ -34,10 +34,10 @@ function withEnv<T>(
 // flags-updated push from PostHog.
 function makeFakePostHog(initialFlags: Record<string, boolean | undefined>) {
   const flags = { ...initialFlags };
-  let listener: (() => void) | null = null;
+  let listener: ((flags: string[]) => void) | null = null;
   const posthog: PostHog = {
     isFeatureEnabled: (key: string) => flags[key] ?? false,
-    onFeatureFlags: (callback: () => void) => {
+    onFeatureFlags: (callback: (flags: string[]) => void) => {
       listener = callback;
     },
   };
@@ -47,7 +47,7 @@ function makeFakePostHog(initialFlags: Record<string, boolean | undefined>) {
       flags[key] = value;
     },
     pushFlagsUpdate() {
-      listener?.();
+      listener?.(Object.keys(flags));
     },
   };
 }

--- a/test/unit/seed-bible/managers/FeaturesManager.test.ts
+++ b/test/unit/seed-bible/managers/FeaturesManager.test.ts
@@ -1,0 +1,157 @@
+import {
+  createFeaturesManager,
+  FEATURE_KEY_READING_PLANS,
+  type PostHog,
+} from "@packages/seed-bible/seed-bible/managers/FeaturesManager";
+
+// Temporarily overrides import.meta.env flags for the duration of `fn`,
+// restoring the previous values (or removing the key entirely if it was
+// unset) afterward. Mirrors the pattern used in I18nManager.test.ts.
+function withEnv<T>(
+  env: Partial<{ DEV: boolean; SSR: boolean }>,
+  fn: () => T
+): T {
+  const original: Partial<Record<"DEV" | "SSR", boolean | undefined>> = {};
+  for (const key of Object.keys(env) as Array<"DEV" | "SSR">) {
+    original[key] = import.meta.env[key] as any;
+    (import.meta.env as Record<string, boolean>)[key] = env[key]!;
+  }
+  try {
+    return fn();
+  } finally {
+    for (const key of Object.keys(env) as Array<"DEV" | "SSR">) {
+      if (original[key] === undefined) {
+        delete (import.meta.env as Record<string, boolean | undefined>)[key];
+      } else {
+        (import.meta.env as Record<string, boolean>)[key] = original[key]!;
+      }
+    }
+  }
+}
+
+// A fake PostHog client whose flags can be changed after construction, and
+// whose `onFeatureFlags` listener can be triggered on demand to simulate a
+// flags-updated push from PostHog.
+function makeFakePostHog(initialFlags: Record<string, boolean | undefined>) {
+  const flags = { ...initialFlags };
+  let listener: (() => void) | null = null;
+  const posthog: PostHog = {
+    isFeatureEnabled: (key: string) => flags[key] ?? false,
+    onFeatureFlags: (callback: () => void) => {
+      listener = callback;
+    },
+  };
+  return {
+    posthog,
+    setFlag(key: string, value: boolean | undefined) {
+      flags[key] = value;
+    },
+    pushFlagsUpdate() {
+      listener?.();
+    },
+  };
+}
+
+describe("FeaturesManager", () => {
+  it("enables every feature in dev mode, even with no posthog client", () => {
+    withEnv({ DEV: true }, () => {
+      const manager = createFeaturesManager(null);
+      expect(manager.isFeatureEnabled(FEATURE_KEY_READING_PLANS).value).toBe(
+        true
+      );
+      expect(manager.isFeatureEnabled("some-other-flag").value).toBe(true);
+    });
+  });
+
+  it("enables every feature in dev mode even if posthog says it's off", () => {
+    withEnv({ DEV: true }, () => {
+      const { posthog } = makeFakePostHog({
+        [FEATURE_KEY_READING_PLANS]: false,
+      });
+      const manager = createFeaturesManager(posthog);
+      expect(manager.isFeatureEnabled(FEATURE_KEY_READING_PLANS).value).toBe(
+        true
+      );
+    });
+  });
+
+  it("disables every feature during SSR, outside of dev mode", () => {
+    withEnv({ DEV: false, SSR: true }, () => {
+      const { posthog } = makeFakePostHog({
+        [FEATURE_KEY_READING_PLANS]: true,
+      });
+      const manager = createFeaturesManager(posthog);
+      expect(manager.isFeatureEnabled(FEATURE_KEY_READING_PLANS).value).toBe(
+        false
+      );
+    });
+  });
+
+  it("disables every feature when there is no posthog client, outside of dev/SSR", () => {
+    withEnv({ DEV: false, SSR: false }, () => {
+      const manager = createFeaturesManager(null);
+      expect(manager.isFeatureEnabled(FEATURE_KEY_READING_PLANS).value).toBe(
+        false
+      );
+    });
+  });
+
+  it("reads the flag value from posthog outside of dev mode and SSR", () => {
+    withEnv({ DEV: false, SSR: false }, () => {
+      const { posthog } = makeFakePostHog({
+        [FEATURE_KEY_READING_PLANS]: true,
+      });
+      const manager = createFeaturesManager(posthog);
+      expect(manager.isFeatureEnabled(FEATURE_KEY_READING_PLANS).value).toBe(
+        true
+      );
+    });
+  });
+
+  it("falls back to false when posthog returns undefined for a flag", () => {
+    withEnv({ DEV: false, SSR: false }, () => {
+      const { posthog } = makeFakePostHog({
+        [FEATURE_KEY_READING_PLANS]: undefined,
+      });
+      const manager = createFeaturesManager(posthog);
+      expect(manager.isFeatureEnabled(FEATURE_KEY_READING_PLANS).value).toBe(
+        false
+      );
+    });
+  });
+
+  it("returns the same signal instance for repeated calls with the same key", () => {
+    const manager = createFeaturesManager(null);
+    const first = manager.isFeatureEnabled(FEATURE_KEY_READING_PLANS);
+    const second = manager.isFeatureEnabled(FEATURE_KEY_READING_PLANS);
+    expect(first).toBe(second);
+  });
+
+  it("updates every tracked signal when posthog pushes new flag values", () => {
+    withEnv({ DEV: false, SSR: false }, () => {
+      const { posthog, setFlag, pushFlagsUpdate } = makeFakePostHog({
+        "flag-a": false,
+        "flag-b": true,
+      });
+      const manager = createFeaturesManager(posthog);
+
+      const flagA = manager.isFeatureEnabled("flag-a");
+      const flagB = manager.isFeatureEnabled("flag-b");
+      expect(flagA.value).toBe(false);
+      expect(flagB.value).toBe(true);
+
+      setFlag("flag-a", true);
+      setFlag("flag-b", false);
+      pushFlagsUpdate();
+
+      expect(flagA.value).toBe(true);
+      expect(flagB.value).toBe(false);
+    });
+  });
+
+  it("does not register a posthog flags listener when there is no posthog client", () => {
+    // Constructing the manager with a null client must not throw even though
+    // the real implementation would otherwise call `posthog.onFeatureFlags`.
+    expect(() => createFeaturesManager(null)).not.toThrow();
+  });
+});

--- a/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
+++ b/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
@@ -315,6 +315,7 @@ describe("createSeedBibleState", () => {
     const mockPosthogCapture = vi.fn();
     (globalThis as any).posthog = {
       capture: mockPosthogCapture,
+      onFeatureFlags: vi.fn(),
     };
 
     try {
@@ -374,6 +375,7 @@ describe("createSeedBibleState", () => {
     const mockPosthogCapture = vi.fn();
     (globalThis as any).posthog = {
       capture: mockPosthogCapture,
+      onFeatureFlags: vi.fn(),
     };
 
     try {
@@ -730,7 +732,10 @@ describe("createSeedBibleState", () => {
     beforeEach(() => {
       vi.useFakeTimers();
       mockPosthogCapture = vi.fn();
-      (globalThis as any).posthog = { capture: mockPosthogCapture };
+      (globalThis as any).posthog = {
+        capture: mockPosthogCapture,
+        onFeatureFlags: vi.fn(),
+      };
     });
 
     afterEach(() => {


### PR DESCRIPTION
Previously, every feature flag behaved as if it was disabled. Now, after this fix, feature flags that are configured in PostHog are detected correctly.