### PR TITLE
Add automatic sign-out when session expires or account is suspended

### DIFF
--- a/packages/seed-bible/seed-bible/i18n/en.json
+++ b/packages/seed-bible/seed-bible/i18n/en.json
@@ -420,6 +420,6 @@
   "start-share-session-subtitle": "Invite others to read along live",
   "share-current-session": "Share current session",
   "share-current-session-subtitle": "Copy a link to invite others to read along live",
-  "session-expired-message": "Your session has expired. Please sign in again.",
+  "signed-out-message": "You've been signed out. Please sign in again.",
   "account-suspended-message": "Your account has been suspended."
 }

--- a/packages/seed-bible/seed-bible/i18n/en.json
+++ b/packages/seed-bible/seed-bible/i18n/en.json
@@ -419,5 +419,7 @@
   "start-share-session": "Start and share session",
   "start-share-session-subtitle": "Invite others to read along live",
   "share-current-session": "Share current session",
-  "share-current-session-subtitle": "Copy a link to invite others to read along live"
+  "share-current-session-subtitle": "Copy a link to invite others to read along live",
+  "session-expired-message": "Your session has expired. Please sign in again.",
+  "account-suspended-message": "Your account has been suspended."
 }

--- a/packages/seed-bible/seed-bible/managers/LoginManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/LoginManager.tsx
@@ -1,11 +1,31 @@
 import { batch, computed, effect, signal, type Signal } from "@preact/signals";
 import * as z from "zod/v4";
 import type { CasualOSManager, UserInfo } from "./OsManager";
+import type { FatalSessionErrorCode } from "./SessionGuard";
 import type {
   CompleteLoginResult,
   LoginRequestResult,
   LoginRequestSuccess,
 } from "@casual-simulation/aux-records/AuthController";
+
+/**
+ * Why a session ended without the user asking it to.
+ *
+ * The three server error codes collapse to two cases the UI has to explain, so the
+ * mapping happens here rather than in the view — a view only ever needs two messages,
+ * and widening the set of fatal codes later changes no view code.
+ */
+export type SessionEndedReason = "session_expired" | "account_suspended";
+
+export interface SessionEndedEvent {
+  reason: SessionEndedReason;
+
+  /**
+   * Monotonically increasing id, so two events with the same reason still notify
+   * subscribers (signals skip notification when the new value is `===` the old one).
+   */
+  id: number;
+}
 
 export interface LoginManager {
   /**
@@ -27,6 +47,16 @@ export interface LoginManager {
    * The current auth bot. Null if not authenticated or if background auth has not completed yet.
    */
   authBot: Signal<UserInfo | null>;
+
+  /**
+   * Fires when the user was signed out without asking — because the server reported
+   * their session key dead, or their account suspended. Null until that happens.
+   *
+   * Only set when a forced sign-out actually took place, so a sign-out the user asked
+   * for and a request that merely failed never produce an event. The UI reads `reason`
+   * to pick which message to show.
+   */
+  sessionEnded: Signal<SessionEndedEvent | null>;
 
   /**
    * The user's profile information. Null if the user is not logged in or if the profile has not loaded yet.
@@ -134,6 +164,70 @@ export function createLoginManager({
   const userId = computed(() => parsedSessionKey.value?.userId ?? null);
   const userInfo = signal<UserInfo | null>(null);
   const currentLoginRequest = signal<LoginRequestSuccess | null>(null);
+  const sessionEnded = signal<SessionEndedEvent | null>(null);
+  let sessionEndedCount = 0;
+
+  // True while a deliberate `logout()` is tearing the session down. The sign-out
+  // request itself often comes back `session_expired`, and any other request in
+  // flight at that moment can too. Neither should be reported to someone who just
+  // pressed "Sign out".
+  let isSigningOut = false;
+
+  /**
+   * Drops every trace of the current session from memory. That is the whole teardown:
+   * the persistence effect below mirrors the nulled signals into `localStorage`,
+   * `OsManager`'s effect clears `client.sessionKey`, and the profile effect clears the
+   * profile because `userId` becomes null.
+   */
+  const clearSession = () => {
+    batch(() => {
+      sessionKey.value = null;
+      connectionKey.value = null;
+      userInfo.value = null;
+    });
+  };
+
+  /**
+   * Signs the user out because the server said the session is dead — not because they
+   * asked.
+   *
+   * Deliberately does NOT call `revokeSession`. The session is already gone server
+   * side (expired, replaced, or the account is banned), so the call could only fail;
+   * it costs a round trip on a path that is often taken while connectivity is poor;
+   * and for `user_is_banned` it can never succeed.
+   */
+  const forceLogout = (errorCode: FatalSessionErrorCode) => {
+    if (isSigningOut) {
+      // A sign-out the user asked for is already tearing the session down.
+      return;
+    }
+
+    if (!sessionKey.peek()) {
+      // Already signed out. Makes this safe to call repeatedly, which is what keeps
+      // a screenful of simultaneously-failing reads from stacking up.
+      return;
+    }
+
+    console.warn(
+      `[LoginManager] Signing out: the server reported '${errorCode}'.`
+    );
+    clearSession();
+    sessionEnded.value = {
+      reason:
+        errorCode === "user_is_banned"
+          ? "account_suspended"
+          : "session_expired",
+      id: ++sessionEndedCount,
+    };
+  };
+
+  effect(() => {
+    const event = os.sessionInvalidated.value;
+    if (!event) {
+      return;
+    }
+    forceLogout(event.errorCode);
+  });
 
   if (typeof localStorage !== "undefined") {
     const storedSessionKey = localStorage.getItem("sessionKey");
@@ -231,12 +325,20 @@ export function createLoginManager({
   };
 
   async function refreshSession() {
-    if (!sessionKey.value) {
+    const sessionKeyAtRequest = sessionKey.peek();
+    if (!sessionKeyAtRequest) {
       return;
     }
 
     console.log("[LoginManager] Refreshing session with existing session key");
     const result = await client.replaceSession();
+
+    if (sessionKey.peek() !== sessionKeyAtRequest) {
+      // The session ended while the refresh was in flight — the user signed out, or
+      // this very call reported the key dead and the session guard already signed
+      // them out. Assigning a key now would resurrect a session we just dropped.
+      return;
+    }
 
     if (result.success) {
       console.log("[LoginManager] Session refreshed successfully");
@@ -245,8 +347,14 @@ export function createLoginManager({
       client.sessionKey = result.sessionKey;
       await loadUserInfo();
     } else {
+      // Nothing is cleared here, on purpose. A refresh fails for transient reasons
+      // far more often than real ones (a mobile dead spot, a 500, a rate limit), and
+      // the key is usually still good for another week. The three codes that really
+      // do mean the session is gone are handled centrally by the session guard,
+      // which has already signed the user out by the time we reach this branch.
       console.warn(
-        "[LoginManager] Failed to refresh session, clearing session key:",
+        "[LoginManager] Failed to refresh session; keeping the existing session key:",
+        result.errorCode,
         result.errorMessage
       );
     }
@@ -302,11 +410,20 @@ export function createLoginManager({
   }
 
   async function loadUserInfo(): Promise<UserInfo | null> {
-    if (!sessionKey.value || !userId.value) {
+    const sessionKeyAtRequest = sessionKey.peek();
+    if (!sessionKeyAtRequest || !userId.value) {
       return null;
     }
 
     const result = await client.getUserInfo({ userId: userId.value });
+
+    if (sessionKey.peek() !== sessionKeyAtRequest || !userId.value) {
+      // Signed out while the request was in flight — quite possibly by this very
+      // request failing. Publishing user info for a session that no longer exists
+      // would leave the app looking signed in.
+      return null;
+    }
+
     if (result.success) {
       userInfo.value = {
         id: userId.value,
@@ -381,20 +498,38 @@ export function createLoginManager({
   });
 
   if (sessionKey.value) {
-    loadUserInfo();
+    // Nobody awaits this, so it needs its own handler: a network failure here would
+    // otherwise surface as an unhandled rejection on every offline page load. A
+    // failure is survivable — the session stays as it is, and the session guard has
+    // already signed the user out if the server said the key was dead.
+    loadUserInfo().catch((err) => {
+      console.warn("[LoginManager] Failed to load user info on startup", err);
+    });
   }
 
   const logout = async (): Promise<void> => {
-    if (sessionKey.value) {
-      await client.revokeSession({
-        sessionKey: sessionKey.value!,
-      });
+    isSigningOut = true;
+    try {
+      if (sessionKey.value) {
+        try {
+          await client.revokeSession({
+            sessionKey: sessionKey.value,
+          });
+        } catch (err) {
+          // Never let a failed round trip keep us signed in locally: the user asked
+          // to sign out, so sign out. Before this, a rejection here threw past the
+          // clear below and left the app looking logged in — and the sign-out button
+          // calls this with `void`, so the rejection went unhandled too.
+          console.warn(
+            "[LoginManager] Failed to revoke the session remotely; signing out locally anyway",
+            err
+          );
+        }
+      }
+      clearSession();
+    } finally {
+      isSigningOut = false;
     }
-    batch(() => {
-      sessionKey.value = null;
-      connectionKey.value = null;
-      userInfo.value = null;
-    });
   };
 
   effect(() => {
@@ -578,6 +713,7 @@ export function createLoginManager({
     connectionId: os.connectionId,
     userInfo,
     authBot: userInfo,
+    sessionEnded,
     profile,
     // Exposed as a getter so external readers see the promise assigned by the
     // profile-loading effect below. A plain property would capture the value

--- a/packages/seed-bible/seed-bible/managers/LoginManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/LoginManager.tsx
@@ -11,11 +11,16 @@ import type {
 /**
  * Why a session ended without the user asking it to.
  *
- * The three server error codes collapse to two cases the UI has to explain, so the
- * mapping happens here rather than in the view — a view only ever needs two messages,
- * and widening the set of fatal codes later changes no view code.
+ * Every cause collapses to two things the UI has to explain, so the mapping happens
+ * here rather than in the view — a view only ever needs two messages, and adding
+ * another cause changes no view code.
+ *
+ * `signed_out` deliberately avoids saying "expired". Only one of the causes actually
+ * is an expiry: `invalid_key` means the session was revoked or is unrecognised, and an
+ * unparseable stored key never expired either. The remedy is the same in every case,
+ * so one accurate message beats a specific but often wrong one.
  */
-export type SessionEndedReason = "session_expired" | "account_suspended";
+export type SessionEndedReason = "signed_out" | "account_suspended";
 
 export interface SessionEndedEvent {
   reason: SessionEndedReason;
@@ -188,15 +193,20 @@ export function createLoginManager({
   };
 
   /**
-   * Signs the user out because the server said the session is dead — not because they
-   * asked.
+   * Signs the user out for a reason that isn't their choice, and records why so the UI
+   * can explain it.
    *
-   * Deliberately does NOT call `revokeSession`. The session is already gone server
-   * side (expired, replaced, or the account is banned), so the call could only fail;
-   * it costs a round trip on a path that is often taken while connectivity is poor;
-   * and for `user_is_banned` it can never succeed.
+   * Deliberately does NOT call `revokeSession`. Every caller gets here because the
+   * session is already unusable — expired, revoked, banned, or a key we can't even
+   * parse — so the call could only fail; it costs a round trip on a path often taken
+   * while connectivity is poor; and for a banned account it can never succeed.
+   *
+   * `sessionEnded` is left set rather than reset, which is what lets a sign-out during
+   * construction still reach the toast: `SeedBibleStateManager` wires that effect much
+   * later, and an effect reads its dependencies eagerly on its first run. Don't
+   * "tidy" this into a reset-after-read.
    */
-  const forceLogout = (errorCode: FatalSessionErrorCode) => {
+  const forceSignOut = (reason: SessionEndedReason) => {
     if (isSigningOut) {
       // A sign-out the user asked for is already tearing the session down.
       return;
@@ -208,17 +218,21 @@ export function createLoginManager({
       return;
     }
 
+    clearSession();
+    sessionEnded.value = {
+      reason,
+      id: ++sessionEndedCount,
+    };
+  };
+
+  /** Signs the user out because the server reported the session key dead. */
+  const forceLogout = (errorCode: FatalSessionErrorCode) => {
     console.warn(
       `[LoginManager] Signing out: the server reported '${errorCode}'.`
     );
-    clearSession();
-    sessionEnded.value = {
-      reason:
-        errorCode === "user_is_banned"
-          ? "account_suspended"
-          : "session_expired",
-      id: ++sessionEndedCount,
-    };
+    forceSignOut(
+      errorCode === "user_is_banned" ? "account_suspended" : "signed_out"
+    );
   };
 
   effect(() => {
@@ -236,24 +250,45 @@ export function createLoginManager({
     if (storedSessionKey) {
       sessionKey.value = storedSessionKey;
       client.sessionKey = storedSessionKey;
-
-      const expireTime = parsedSessionKey.value!.expireTimeMs;
-      const timeUntilExpire = expireTime - Date.now();
-      // Refresh the session 1 week before it expires
-      const refreshTime = timeUntilExpire - 7 * 24 * 60 * 60 * 1000;
-
-      if (refreshTime > 0) {
-        setTimeout(() => {
-          refreshSession();
-        }, refreshTime);
-      } else {
-        console.log("[LoginManager] Session is expiring soon, refreshing now");
-        refreshSession();
-      }
     }
 
     if (storedConnectionKey) {
       connectionKey.value = storedConnectionKey;
+    }
+
+    // Validate only after both keys are restored, so discarding a bad session key takes
+    // the connection key with it. Checking earlier would clear a connection key that the
+    // block above then puts straight back.
+    if (storedSessionKey) {
+      const parsed = parsedSessionKey.value;
+
+      if (!parsed) {
+        // The stored key isn't parseable, so there's no expiry to schedule against and
+        // nothing useful we could do with it. Reading `.expireTimeMs` off the null
+        // parse used to throw here, and nothing catches it — this runs inside
+        // `createSeedBibleState`, which `app/init.tsx` calls bare — so one bad
+        // character in localStorage meant a blank page with no way to sign out of it.
+        // Discarding the key lets the app start normally, signed out.
+        console.warn(
+          "[LoginManager] Discarding an unparseable stored session key."
+        );
+        forceSignOut("signed_out");
+      } else {
+        const timeUntilExpire = parsed.expireTimeMs - Date.now();
+        // Refresh the session 1 week before it expires
+        const refreshTime = timeUntilExpire - 7 * 24 * 60 * 60 * 1000;
+
+        if (refreshTime > 0) {
+          setTimeout(() => {
+            refreshSession();
+          }, refreshTime);
+        } else {
+          console.log(
+            "[LoginManager] Session is expiring soon, refreshing now"
+          );
+          refreshSession();
+        }
+      }
     }
   }
 

--- a/packages/seed-bible/seed-bible/managers/OsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/OsManager.tsx
@@ -18,8 +18,16 @@ import {
 } from "@casual-simulation/aux-common";
 import { sha256 } from "hash.js";
 import { first, firstValueFrom } from "rxjs";
+import { guardRecordsClient } from "./SessionGuard";
+import type { SessionInvalidatedEvent } from "./SessionGuard";
 
 export type CasualOSManager = ReturnType<typeof CasualOSManager>;
+
+export type {
+  FatalSessionErrorCode,
+  SessionInvalidatedEvent,
+} from "./SessionGuard";
+export { FATAL_SESSION_ERROR_CODES } from "./SessionGuard";
 
 export interface UserInfo {
   id: string;
@@ -57,7 +65,7 @@ const UNSAFE_HEADERS = new Set([
 ]);
 
 export function CasualOSManager(endpoint: string = "https://auth.ao.bot") {
-  const client = createRecordsClient(endpoint);
+  const rawClient = createRecordsClient(endpoint);
   const connectionId = uuid();
   let currentWakeLock: WakeLockSentinel | null = null;
 
@@ -96,6 +104,25 @@ export function CasualOSManager(endpoint: string = "https://auth.ao.bot") {
     } else {
       return null;
     }
+  });
+
+  /**
+   * Fires when the records/auth API reports that our session key is dead — expired,
+   * unrecognised, or the account is banned. `LoginManager` watches this and clears
+   * the local session; `OsManager` makes no decision about the UI.
+   */
+  const sessionInvalidated = signal<SessionInvalidatedEvent | null>(null);
+  let sessionInvalidatedCount = 0;
+
+  const client = guardRecordsClient(rawClient, {
+    getSessionKey: () => sessionKey.peek(),
+    onSessionInvalidated: (errorCode) => {
+      console.warn(`[OsManager] The session is no longer valid: ${errorCode}`);
+      sessionInvalidated.value = {
+        errorCode,
+        id: ++sessionInvalidatedCount,
+      };
+    },
   });
 
   function getInstClient(): InstRecordsClient {
@@ -236,6 +263,7 @@ export function CasualOSManager(endpoint: string = "https://auth.ao.bot") {
     sessionKey,
     parsedSessionKey,
     connectionKey,
+    sessionInvalidated,
 
     getData: async (recordName: string, address: string) => {
       const result = await client.getData({

--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -1336,6 +1336,31 @@ export function createSeedBibleState(
     }, 3500);
   };
 
+  // Tell the user when we signed them out for them. `login.sessionEnded` only fires
+  // when a forced sign-out actually happened, so this can't toast for a request that
+  // merely failed, nor for a sign-out the user asked for. Without a message they
+  // would just watch their highlights and bookmarks vanish with no explanation.
+  effect(() => {
+    const ended = login.sessionEnded.value;
+    if (!ended || typeof window === "undefined") {
+      return;
+    }
+
+    // Destructured rather than called as `i18n.t(...)`: the translation lint rules
+    // only recognise calls to a bare `t`, and `translation-unused-keys` is
+    // auto-fixable, so `i18n.t("...")` would get these keys deleted from en.json.
+    const { t } = i18n;
+    toast(
+      ended.reason === "account_suspended"
+        ? t("account-suspended-message", {
+            defaultValue: "Your account has been suspended.",
+          })
+        : t("session-expired-message", {
+            defaultValue: "Your session has expired. Please sign in again.",
+          })
+    );
+  });
+
   // const isDiscoverOpen = signal(false);
   const handleOpenDiscover = () => {
     if (!playlists.view.peek()) {

--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -1355,8 +1355,8 @@ export function createSeedBibleState(
         ? t("account-suspended-message", {
             defaultValue: "Your account has been suspended.",
           })
-        : t("session-expired-message", {
-            defaultValue: "Your session has expired. Please sign in again.",
+        : t("signed-out-message", {
+            defaultValue: "You've been signed out. Please sign in again.",
           })
     );
   });

--- a/packages/seed-bible/seed-bible/managers/SessionGuard.ts
+++ b/packages/seed-bible/seed-bible/managers/SessionGuard.ts
@@ -1,0 +1,168 @@
+/**
+ * The error codes that definitively mean the session key we sent is dead and will
+ * never work again: it has expired, the server doesn't recognise it (for example
+ * the session was revoked from another device), or the account has been suspended.
+ *
+ * Deliberately narrow. `server_error`, `rate_limit_exceeded`, `not_authorized`,
+ * `not_logged_in` and thrown network errors all happen to a perfectly good session
+ * on a flaky mobile connection, and signing someone out over one of those is much
+ * worse than doing nothing. The same reasoning is already written into
+ * `LoginManager.getUserProfile` and into `twitchPub-extension`'s session check,
+ * which reports "still valid" on a network error precisely so a blip can't log
+ * anyone out.
+ */
+export const FATAL_SESSION_ERROR_CODES = [
+  "session_expired",
+  "invalid_key",
+  "user_is_banned",
+] as const;
+
+export type FatalSessionErrorCode = (typeof FATAL_SESSION_ERROR_CODES)[number];
+
+/**
+ * Published when the records API reports that our session key is dead.
+ */
+export interface SessionInvalidatedEvent {
+  /** The code the server answered with. */
+  errorCode: FatalSessionErrorCode;
+
+  /**
+   * Monotonically increasing id. Subscribers watch the whole object, and signals
+   * skip notifying when the new value is `===` the old one — so without the id a
+   * second `session_expired` (after signing back in, say) would silently fail to
+   * notify anyone.
+   */
+  id: number;
+}
+
+/**
+ * Methods whose failures must never trigger an automatic sign-out.
+ *
+ * `revokeSession` is only ever called by a deliberate sign-out, whose entire job is
+ * to end the session. It frequently comes back `session_expired` — the key was
+ * already dead, which is often *why* the user is signing out — and reacting to that
+ * would tell someone who just pressed "Sign out" that their session had expired.
+ */
+const IGNORED_METHODS: ReadonlySet<string> = new Set(["revokeSession"]);
+
+/**
+ * Properties that are read and written as plain data rather than called. The records
+ * client is itself a Proxy that synthesizes a function for any property name it
+ * doesn't recognise, so we short-circuit the ones we know are data to be certain
+ * `client.sessionKey` never comes back as a synthesized function.
+ */
+const DATA_PROPERTIES: ReadonlySet<string> = new Set(["sessionKey"]);
+
+export interface SessionGuardOptions {
+  /** Reads the session key currently attached to outgoing requests. */
+  getSessionKey: () => string | null;
+
+  /** Called when a request fails in a way that means the session is over. */
+  onSessionInvalidated: (errorCode: FatalSessionErrorCode) => void;
+}
+
+/**
+ * Picks out the "this session is dead" code from an API result, or null if the
+ * result is a success, a different failure, or not a result object at all
+ * (streaming procedures resolve to an async generator, for instance).
+ */
+function findFatalSessionErrorCode(
+  value: unknown
+): FatalSessionErrorCode | null {
+  if (typeof value !== "object" || value === null) {
+    return null;
+  }
+
+  const result = value as { success?: unknown; errorCode?: unknown };
+  if (result.success !== false || typeof result.errorCode !== "string") {
+    return null;
+  }
+
+  return (FATAL_SESSION_ERROR_CODES as readonly string[]).includes(
+    result.errorCode
+  )
+    ? (result.errorCode as FatalSessionErrorCode)
+    : null;
+}
+
+function isThenable(value: unknown): value is Promise<unknown> {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    typeof (value as { then?: unknown }).then === "function"
+  );
+}
+
+/**
+ * Wraps the records client so that every API call is checked for the error codes
+ * that mean the session is over.
+ *
+ * Doing this once, here, is what saves the check from having to be repeated at each
+ * of the dozens of call sites — and what makes it apply to calls that don't exist
+ * yet, including the ones extensions make directly through `os.client`. The CasualOS
+ * SDK offers no interceptor, callback or observable of its own (only a `sessionKey`
+ * setter), and its client is a Proxy that turns any property access into a network
+ * call, so there is no list of methods to wrap. Putting our own Proxy in front of it
+ * is the only way to see every response.
+ */
+export function guardRecordsClient<T extends object>(
+  client: T,
+  { getSessionKey, onSessionInvalidated }: SessionGuardOptions
+): T {
+  return new Proxy(client, {
+    get(target, property) {
+      // Symbols are never API methods (Symbol.toPrimitive, Symbol.iterator, ...).
+      if (typeof property === "symbol" || DATA_PROPERTIES.has(property)) {
+        return Reflect.get(target, property);
+      }
+
+      const value = Reflect.get(target, property);
+      if (typeof value !== "function") {
+        // Plain data passes straight through. This is also what preserves the
+        // SDK's deliberately-`undefined` `then`/`catch`, which stop its client
+        // being mistaken for a promise.
+        return value;
+      }
+
+      const method = value as (...args: unknown[]) => unknown;
+      const shouldCheck = !IGNORED_METHODS.has(property);
+
+      return (...args: unknown[]): unknown => {
+        // The key as it was when the request went out. Null means the request was
+        // anonymous, so a failure tells us nothing about a session — this is what
+        // stops an already signed-out user from being "signed out" again.
+        const sessionKeyAtRequest = getSessionKey();
+
+        // Apply with `this` = the wrapped client rather than this Proxy, so the
+        // call is exactly what it was before the wrapper existed.
+        const result = method.apply(target, args);
+
+        if (!shouldCheck || !sessionKeyAtRequest || !isThenable(result)) {
+          return result;
+        }
+
+        // `.then` only, never `.catch`: a rejection (offline, DNS, CORS, a 500
+        // with no body) must pass through unobserved and must never sign anyone
+        // out.
+        return result.then((resolved) => {
+          const errorCode = findFatalSessionErrorCode(resolved);
+          if (errorCode && getSessionKey() === sessionKeyAtRequest) {
+            // Still the same session. If the key has already changed — a sibling
+            // request beat us to it, or the user signed out and back in — this
+            // failure is stale news. That check is what collapses a burst of
+            // simultaneous failures into a single sign-out.
+            onSessionInvalidated(errorCode);
+          }
+          return resolved;
+        });
+      };
+    },
+
+    set(target, property, value) {
+      // Keeps `client.sessionKey = "..."` working: OsManager's effect mirrors the
+      // signal onto the client this way, and LoginManager assigns it directly.
+      // Reflect.set's receiver defaults to `target`, so this cannot recurse.
+      return Reflect.set(target, property, value);
+    },
+  });
+}

--- a/packages/seed-bible/seed-bible/managers/SessionGuard.ts
+++ b/packages/seed-bible/seed-bible/managers/SessionGuard.ts
@@ -10,6 +10,24 @@
  * `LoginManager.getUserProfile` and into `twitchPub-extension`'s session check,
  * which reports "still valid" on a network error precisely so a blip can't log
  * anyone out.
+ *
+ * Two codes look like they belong here and deliberately don't. Both were checked
+ * against the SDK's implementation rather than its types, because this repo's patch
+ * widens `ValidateSessionKeyFailure['errorCode']` to `KnownErrorCodes` and so makes the
+ * types admit every code in the SDK:
+ *
+ * - `session_not_found` (HTTP 404) is returned from one place only, `revokeSession`,
+ *   and only *after* `validateSessionKey` has already succeeded — so seeing it proves
+ *   our key is alive. It means "the {userId, sessionId} you asked about doesn't exist".
+ *   Adding it would sign a user out for querying a stale session id, which an extension
+ *   can do through `os.client`. When our *own* session row is missing the server
+ *   returns `invalid_key`, which is in the list above.
+ *
+ * - `unacceptable_session_key` (HTTP 400) is an argument-shape complaint raised before
+ *   any lookup: the key isn't a non-empty string, or it failed to parse. For our
+ *   ambient key it's unreachable — the guard below skips requests with no key, and
+ *   `LoginManager` discards an unparseable stored key at startup rather than sending
+ *   it. Its remaining cases are a malformed `sessionKey` passed explicitly by a caller.
  */
 export const FATAL_SESSION_ERROR_CODES = [
   "session_expired",

--- a/test/unit/seed-bible/managers/AnnotationsManager.test.ts
+++ b/test/unit/seed-bible/managers/AnnotationsManager.test.ts
@@ -44,6 +44,7 @@ describe("AnnotationsManager", () => {
 
     login = {
       authBot: signal(null),
+      sessionEnded: signal(null),
       userId: signal("user-1"),
       connectionId: "conn-1",
       profile: signal(null),

--- a/test/unit/seed-bible/managers/BookmarksManager.test.ts
+++ b/test/unit/seed-bible/managers/BookmarksManager.test.ts
@@ -46,6 +46,7 @@ describe("BookmarksManager", () => {
 
     login = {
       authBot: signal(null),
+      sessionEnded: signal(null),
       userId: signal("user-1"),
       connectionId: "conn-1",
       profile: signal(null),

--- a/test/unit/seed-bible/managers/HighlightsManager.test.ts
+++ b/test/unit/seed-bible/managers/HighlightsManager.test.ts
@@ -32,6 +32,7 @@ describe("HighlightsManager", () => {
     warnSpy = vi.spyOn(console, "warn").mockImplementation(() => undefined);
     login = {
       authBot: signal(null),
+      sessionEnded: signal(null),
       userId: signal("user-1"),
       connectionId: "conn-1",
       profile: signal(null),

--- a/test/unit/seed-bible/managers/LoginManager.test.ts
+++ b/test/unit/seed-bible/managers/LoginManager.test.ts
@@ -431,7 +431,8 @@ describe("createLoginManager", () => {
       expect(os.sessionKey.value).toBe(sessionKey);
       expect(os.client.sessionKey).toBe(sessionKey);
       expect(warnSpy).toHaveBeenCalledWith(
-        "[LoginManager] Failed to refresh session, clearing session key:",
+        "[LoginManager] Failed to refresh session; keeping the existing session key:",
+        "unacceptable_session_key",
         "nope"
       );
     });
@@ -479,6 +480,178 @@ describe("createLoginManager", () => {
       // Advancing to the scheduled time triggers the refresh.
       await vi.advanceTimersByTimeAsync(ONE_WEEK);
       expect(replaceSessionMock).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("automatic sign-out when the session is dead", () => {
+    /**
+     * Drives a forced sign-out through `getUserInfo`, which the manager calls on init
+     * whenever a session key is already stored.
+     */
+    async function signOutViaGetUserInfo(errorCode: string) {
+      getUserInfoMock.mockResolvedValue({
+        success: false,
+        errorCode,
+        errorMessage: `${errorCode} happened`,
+      });
+
+      const manager = createAuthenticatedManager();
+      await waitFor(() => manager.sessionEnded.value !== null);
+      return manager;
+    }
+
+    it("clears the session when a call reports session_expired", async () => {
+      const manager = await signOutViaGetUserInfo("session_expired");
+
+      expect(manager.userId.value).toBe(null);
+      expect(manager.userInfo.value).toBe(null);
+      expect(os.sessionKey.value).toBe(null);
+      expect(os.connectionKey.value).toBe(null);
+      expect(localStorage.getItem("sessionKey")).toBe(null);
+      expect(localStorage.getItem("connectionKey")).toBe(null);
+    });
+
+    it("does not call revokeSession when signing out for a dead session", async () => {
+      // The session is already gone server side, so the round trip could only fail.
+      await signOutViaGetUserInfo("session_expired");
+
+      expect(revokeSessionMock).not.toHaveBeenCalled();
+    });
+
+    it.each([
+      ["session_expired", "session_expired"],
+      ["invalid_key", "session_expired"],
+      ["user_is_banned", "account_suspended"],
+    ])("reports %s to the UI as '%s'", async (errorCode, reason) => {
+      const manager = await signOutViaGetUserInfo(errorCode);
+
+      expect(manager.sessionEnded.value?.reason).toBe(reason);
+    });
+
+    it.each(["server_error", "not_authorized", "rate_limit_exceeded"])(
+      "keeps the session when a call fails with %s",
+      async (errorCode) => {
+        getUserInfoMock.mockResolvedValue({
+          success: false,
+          errorCode,
+          errorMessage: "transient",
+        });
+
+        const manager = createAuthenticatedManager();
+        await flush();
+
+        expect(manager.userId.value).toBe(USER_ID);
+        expect(os.sessionKey.value).toBe(SESSION_KEY);
+        expect(manager.sessionEnded.value).toBe(null);
+      }
+    );
+
+    it("keeps the session when a call rejects outright", async () => {
+      // Offline is not the same as signed out.
+      getUserInfoMock.mockRejectedValue(new Error("offline"));
+
+      const manager = createAuthenticatedManager();
+      await flush();
+
+      expect(manager.userId.value).toBe(USER_ID);
+      expect(os.sessionKey.value).toBe(SESSION_KEY);
+      expect(manager.sessionEnded.value).toBe(null);
+    });
+
+    it("signs out once when several calls fail at the same time", async () => {
+      // A key expiring within the week makes init both refresh and load user info,
+      // so two independent requests report the dead session together.
+      const deadKey = sessionKeyExpiringIn(1000 * 60 * 60);
+      localStorage.setItem("sessionKey", deadKey);
+      replaceSessionMock.mockResolvedValue({
+        success: false,
+        errorCode: "session_expired",
+        errorMessage: "gone",
+      });
+      getUserInfoMock.mockResolvedValue({
+        success: false,
+        errorCode: "session_expired",
+        errorMessage: "gone",
+      });
+
+      const manager = createLoginManager({ os });
+      await waitFor(() => manager.sessionEnded.value !== null);
+      await flush();
+
+      // The incrementing id is the count of forced sign-outs, so it proves the burst
+      // collapsed into exactly one.
+      expect(manager.sessionEnded.value?.id).toBe(1);
+    });
+
+    it("signs out when the session refresh reports the key is dead", async () => {
+      localStorage.setItem("sessionKey", sessionKeyExpiringIn(1000 * 60 * 60));
+      replaceSessionMock.mockResolvedValue({
+        success: false,
+        errorCode: "session_expired",
+        errorMessage: "gone",
+      });
+
+      const manager = createLoginManager({ os });
+
+      await waitFor(() => manager.sessionEnded.value !== null);
+      expect(os.sessionKey.value).toBe(null);
+      expect(manager.sessionEnded.value?.reason).toBe("session_expired");
+    });
+
+    it("does not resurrect the session when a refresh succeeds after a forced sign-out", async () => {
+      // The guard reports the dead session before `refreshSession` resumes after its
+      // await, so without a mid-flight check the success branch would install a new
+      // key for a session we just deliberately dropped.
+      localStorage.setItem("sessionKey", sessionKeyExpiringIn(1000 * 60 * 60));
+      getUserInfoMock.mockResolvedValue({
+        success: false,
+        errorCode: "session_expired",
+        errorMessage: "gone",
+      });
+
+      const manager = createLoginManager({ os });
+
+      await waitFor(() => manager.sessionEnded.value !== null);
+      await flush();
+
+      expect(os.sessionKey.value).toBe(null);
+      expect(manager.userInfo.value).toBe(null);
+    });
+  });
+
+  describe("deliberate sign-out", () => {
+    it("does not report a session end when revokeSession says the key expired", async () => {
+      // Revoking an already-expired key fails by design. Someone who just pressed
+      // "Sign out" must not be told their session expired.
+      revokeSessionMock.mockResolvedValue({
+        success: false,
+        errorCode: "session_expired",
+        errorMessage: "already gone",
+      });
+      const manager = createAuthenticatedManager();
+      await waitFor(() => manager.userId.value === USER_ID);
+
+      await manager.logout();
+      await flush();
+
+      expect(os.sessionKey.value).toBe(null);
+      expect(manager.sessionEnded.value).toBe(null);
+    });
+
+    it("signs out locally even when revokeSession rejects", async () => {
+      // Previously the rejection threw past the local clear, leaving the app looking
+      // signed in — and the sign-out button calls `logout()` with `void`, so nothing
+      // surfaced the error either.
+      revokeSessionMock.mockRejectedValue(new Error("offline"));
+      const manager = createAuthenticatedManager();
+      await waitFor(() => manager.userId.value === USER_ID);
+
+      await expect(manager.logout()).resolves.toBeUndefined();
+
+      expect(os.sessionKey.value).toBe(null);
+      expect(manager.userId.value).toBe(null);
+      expect(localStorage.getItem("sessionKey")).toBe(null);
+      expect(manager.sessionEnded.value).toBe(null);
     });
   });
 

--- a/test/unit/seed-bible/managers/LoginManager.test.ts
+++ b/test/unit/seed-bible/managers/LoginManager.test.ts
@@ -519,8 +519,8 @@ describe("createLoginManager", () => {
     });
 
     it.each([
-      ["session_expired", "session_expired"],
-      ["invalid_key", "session_expired"],
+      ["session_expired", "signed_out"],
+      ["invalid_key", "signed_out"],
       ["user_is_banned", "account_suspended"],
     ])("reports %s to the UI as '%s'", async (errorCode, reason) => {
       const manager = await signOutViaGetUserInfo(errorCode);
@@ -595,7 +595,7 @@ describe("createLoginManager", () => {
 
       await waitFor(() => manager.sessionEnded.value !== null);
       expect(os.sessionKey.value).toBe(null);
-      expect(manager.sessionEnded.value?.reason).toBe("session_expired");
+      expect(manager.sessionEnded.value?.reason).toBe("signed_out");
     });
 
     it("does not resurrect the session when a refresh succeeds after a forced sign-out", async () => {
@@ -616,6 +616,71 @@ describe("createLoginManager", () => {
 
       expect(os.sessionKey.value).toBe(null);
       expect(manager.userInfo.value).toBe(null);
+    });
+  });
+
+  describe("an unparseable stored session key", () => {
+    // Anything not shaped `vSK1.<base64>...` fails to parse. Reading the expiry off
+    // that null parse used to throw during construction, and nothing catches it, so a
+    // single corrupted character in localStorage meant a blank page the user could not
+    // sign out of.
+    const CORRUPT_KEY = "total-garbage";
+
+    it("does not throw while constructing the manager", () => {
+      localStorage.setItem("sessionKey", CORRUPT_KEY);
+
+      expect(() => createLoginManager({ os })).not.toThrow();
+    });
+
+    it("discards the bad key instead of keeping it", () => {
+      localStorage.setItem("sessionKey", CORRUPT_KEY);
+      localStorage.setItem("connectionKey", "connection-key-1");
+
+      createLoginManager({ os });
+
+      expect(os.sessionKey.value).toBe(null);
+      expect(os.connectionKey.value).toBe(null);
+      expect(localStorage.getItem("sessionKey")).toBe(null);
+      expect(localStorage.getItem("connectionKey")).toBe(null);
+    });
+
+    it("does not try to refresh a key it cannot parse", async () => {
+      localStorage.setItem("sessionKey", CORRUPT_KEY);
+
+      createLoginManager({ os });
+      await flush();
+
+      expect(replaceSessionMock).not.toHaveBeenCalled();
+      expect(getUserInfoMock).not.toHaveBeenCalled();
+    });
+
+    it("reports the discarded key to the UI as a plain sign-out", () => {
+      localStorage.setItem("sessionKey", CORRUPT_KEY);
+
+      const manager = createLoginManager({ os });
+
+      // Nothing expired here, so the message must not say so.
+      expect(manager.sessionEnded.value?.reason).toBe("signed_out");
+    });
+
+    it("leaves the user signed out rather than half-authenticated", () => {
+      localStorage.setItem("sessionKey", CORRUPT_KEY);
+
+      const manager = createLoginManager({ os });
+
+      expect(manager.userId.value).toBe(null);
+      expect(manager.userInfo.value).toBe(null);
+    });
+
+    it("still accepts a well-formed key", async () => {
+      // Guards against the parse check being too eager and rejecting good keys.
+      localStorage.setItem("sessionKey", SESSION_KEY);
+
+      const manager = createLoginManager({ os });
+      await waitFor(() => manager.userId.value === USER_ID);
+
+      expect(manager.sessionEnded.value).toBe(null);
+      expect(os.sessionKey.value).toBe(SESSION_KEY);
     });
   });
 

--- a/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
+++ b/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
@@ -979,13 +979,13 @@ describe("createSeedBibleState", () => {
       expect(state.app.currentToast.value).toBe(null);
     });
 
-    it("explains an expired session", async () => {
+    it("explains a session that ended on its own", async () => {
       const state = await createState();
 
-      state.login.sessionEnded.value = { reason: "session_expired", id: 1 };
+      state.login.sessionEnded.value = { reason: "signed_out", id: 1 };
 
       expect(state.app.currentToast.value?.message).toBe(
-        "Your session has expired. Please sign in again."
+        "You've been signed out. Please sign in again."
       );
     });
 
@@ -1005,10 +1005,10 @@ describe("createSeedBibleState", () => {
       // never re-run and the message would be silently swallowed.
       const state = await createState();
 
-      state.login.sessionEnded.value = { reason: "session_expired", id: 1 };
+      state.login.sessionEnded.value = { reason: "signed_out", id: 1 };
       const firstToastId = state.app.currentToast.value?.id;
 
-      state.login.sessionEnded.value = { reason: "session_expired", id: 2 };
+      state.login.sessionEnded.value = { reason: "signed_out", id: 2 };
 
       expect(state.app.currentToast.value?.id).not.toBe(firstToastId);
     });

--- a/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
+++ b/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
@@ -972,6 +972,48 @@ describe("createSeedBibleState", () => {
     });
   });
 
+  describe("automatic sign-out toast", () => {
+    it("shows nothing while the session is intact", async () => {
+      const state = await createState();
+
+      expect(state.app.currentToast.value).toBe(null);
+    });
+
+    it("explains an expired session", async () => {
+      const state = await createState();
+
+      state.login.sessionEnded.value = { reason: "session_expired", id: 1 };
+
+      expect(state.app.currentToast.value?.message).toBe(
+        "Your session has expired. Please sign in again."
+      );
+    });
+
+    it("explains a suspended account", async () => {
+      const state = await createState();
+
+      state.login.sessionEnded.value = { reason: "account_suspended", id: 1 };
+
+      expect(state.app.currentToast.value?.message).toBe(
+        "Your account has been suspended."
+      );
+    });
+
+    it("shows a fresh toast for a second sign-out with the same reason", async () => {
+      // The event carries a monotonic id precisely so this case still notifies: a
+      // bare reason string would be `===` the previous value, so the effect would
+      // never re-run and the message would be silently swallowed.
+      const state = await createState();
+
+      state.login.sessionEnded.value = { reason: "session_expired", id: 1 };
+      const firstToastId = state.app.currentToast.value?.id;
+
+      state.login.sessionEnded.value = { reason: "session_expired", id: 2 };
+
+      expect(state.app.currentToast.value?.id).not.toBe(firstToastId);
+    });
+  });
+
   describe("pageTitle tag", () => {
     function setSelectedTabChapter(
       state: SeedBibleState,

--- a/test/unit/seed-bible/managers/SessionGuard.test.ts
+++ b/test/unit/seed-bible/managers/SessionGuard.test.ts
@@ -1,0 +1,248 @@
+import {
+  FATAL_SESSION_ERROR_CODES,
+  guardRecordsClient,
+  type FatalSessionErrorCode,
+} from "@packages/seed-bible/seed-bible/managers/SessionGuard";
+
+const SESSION_KEY = "session-key-1";
+
+/**
+ * Builds a guard over a fake client, along with handles for driving it: the current
+ * session key is a plain `let` so a test can change it mid-flight, and
+ * `onSessionInvalidated` is recorded rather than acted on.
+ */
+function createGuard(
+  target: Record<string, unknown>,
+  initialSessionKey: string | null = SESSION_KEY
+) {
+  let sessionKey = initialSessionKey;
+  const invalidated: FatalSessionErrorCode[] = [];
+
+  const wrapped = guardRecordsClient(target, {
+    getSessionKey: () => sessionKey,
+    onSessionInvalidated: (errorCode) => invalidated.push(errorCode),
+  });
+
+  return {
+    wrapped,
+    invalidated,
+    setSessionKey: (key: string | null) => {
+      sessionKey = key;
+    },
+  };
+}
+
+function failure(errorCode: string) {
+  return { success: false, errorCode, errorMessage: `${errorCode} happened` };
+}
+
+describe("guardRecordsClient", () => {
+  describe("transparency", () => {
+    it("forwards arguments and results through to the wrapped client", async () => {
+      const getData = vi.fn().mockResolvedValue({ success: true, data: 42 });
+      const { wrapped } = createGuard({ getData });
+
+      const result = await (
+        wrapped as { getData: (arg: unknown) => Promise<unknown> }
+      ).getData({ recordName: "r", address: "a" });
+
+      expect(getData).toHaveBeenCalledWith({ recordName: "r", address: "a" });
+      expect(result).toEqual({ success: true, data: 42 });
+    });
+
+    it("calls methods with the wrapped client as `this`", async () => {
+      const target = {
+        sessionKey: null as string | null,
+        whoAmI(this: { sessionKey: string | null }) {
+          return Promise.resolve({ success: true, key: this.sessionKey });
+        },
+      };
+      const { wrapped } = createGuard(
+        target as unknown as Record<string, unknown>
+      );
+
+      (wrapped as unknown as { sessionKey: string }).sessionKey = "abc";
+      const result = await (
+        wrapped as unknown as { whoAmI: () => Promise<{ key: string }> }
+      ).whoAmI();
+
+      expect(result.key).toBe("abc");
+    });
+
+    it("reads and writes plain properties through the wrapper", () => {
+      const target: Record<string, unknown> = { sessionKey: null };
+      const { wrapped } = createGuard(target);
+
+      (wrapped as { sessionKey: string }).sessionKey = "written";
+
+      expect(target.sessionKey).toBe("written");
+      expect((wrapped as { sessionKey: string }).sessionKey).toBe("written");
+    });
+
+    it("leaves an undefined `then` undefined so the client is not treated as a promise", () => {
+      // The SDK pins `then`/`catch` to undefined on purpose so its client isn't
+      // mistaken for a thenable. Wrapping every property in a function would undo
+      // that and make `await client` hang.
+      const { wrapped } = createGuard({ then: undefined, catch: undefined });
+
+      expect((wrapped as { then?: unknown }).then).toBeUndefined();
+      expect((wrapped as { catch?: unknown }).catch).toBeUndefined();
+    });
+
+    it("returns non-promise results untouched", () => {
+      const { wrapped } = createGuard({ addOne: (n: number) => n + 1 });
+
+      expect((wrapped as { addOne: (n: number) => number }).addOne(1)).toBe(2);
+    });
+
+    it("passes symbol property access through unwrapped", () => {
+      const iterator = function* () {
+        yield 1;
+      };
+      const { wrapped } = createGuard({ [Symbol.iterator]: iterator });
+
+      expect(
+        (wrapped as unknown as Record<symbol, unknown>)[Symbol.iterator]
+      ).toBe(iterator);
+    });
+  });
+
+  describe("detecting a dead session", () => {
+    it.each(FATAL_SESSION_ERROR_CODES)(
+      "reports a dead session when a call fails with %s",
+      async (errorCode) => {
+        const call = vi.fn().mockResolvedValue(failure(errorCode));
+        const { wrapped, invalidated } = createGuard({ call });
+
+        await (wrapped as { call: () => Promise<unknown> }).call();
+
+        expect(invalidated).toEqual([errorCode]);
+      }
+    );
+
+    it("still hands the failure back to the caller unchanged", async () => {
+      const expected = failure("session_expired");
+      const call = vi.fn().mockResolvedValue(expected);
+      const { wrapped } = createGuard({ call });
+
+      await expect(
+        (wrapped as { call: () => Promise<unknown> }).call()
+      ).resolves.toBe(expected);
+    });
+
+    it.each([
+      "server_error",
+      "rate_limit_exceeded",
+      "not_authorized",
+      "not_logged_in",
+      "data_not_found",
+      "unacceptable_session_key",
+    ])("does not report a dead session for %s", async (errorCode) => {
+      const call = vi.fn().mockResolvedValue(failure(errorCode));
+      const { wrapped, invalidated } = createGuard({ call });
+
+      await (wrapped as { call: () => Promise<unknown> }).call();
+
+      expect(invalidated).toEqual([]);
+    });
+
+    it("does not report a dead session on success", async () => {
+      const call = vi.fn().mockResolvedValue({ success: true });
+      const { wrapped, invalidated } = createGuard({ call });
+
+      await (wrapped as { call: () => Promise<unknown> }).call();
+
+      expect(invalidated).toEqual([]);
+    });
+
+    it("does not report a dead session when the call rejects", async () => {
+      // A network failure must never sign anyone out — the session may be perfectly
+      // fine and the user merely offline.
+      const call = vi.fn().mockRejectedValue(new Error("offline"));
+      const { wrapped, invalidated } = createGuard({ call });
+
+      await expect(
+        (wrapped as { call: () => Promise<unknown> }).call()
+      ).rejects.toThrow("offline");
+      expect(invalidated).toEqual([]);
+    });
+
+    it("ignores results that are not result objects", async () => {
+      // Streaming procedures resolve to an async generator, not `{ success }`.
+      async function* stream() {
+        yield 1;
+      }
+      const call = vi.fn().mockResolvedValue(stream());
+      const { wrapped, invalidated } = createGuard({ call });
+
+      await (wrapped as { call: () => Promise<unknown> }).call();
+
+      expect(invalidated).toEqual([]);
+    });
+  });
+
+  describe("guards against signing out the wrong session", () => {
+    it("does not report when no session key was attached to the request", async () => {
+      const call = vi.fn().mockResolvedValue(failure("session_expired"));
+      const { wrapped, invalidated } = createGuard({ call }, null);
+
+      await (wrapped as { call: () => Promise<unknown> }).call();
+
+      expect(invalidated).toEqual([]);
+    });
+
+    it("does not report when the session key changed while the request was in flight", async () => {
+      const call = vi.fn().mockResolvedValue(failure("session_expired"));
+      const { wrapped, invalidated, setSessionKey } = createGuard({ call });
+
+      const pending = (wrapped as { call: () => Promise<unknown> }).call();
+      setSessionKey("a-different-key");
+      await pending;
+
+      expect(invalidated).toEqual([]);
+    });
+
+    it("reports once when several requests fail at the same time", async () => {
+      // Mimics what LoginManager does: the first report clears the session key, so
+      // every later failure is measured against a key that no longer matches.
+      let sessionKey: string | null = SESSION_KEY;
+      const invalidated: FatalSessionErrorCode[] = [];
+      const call = vi.fn().mockResolvedValue(failure("session_expired"));
+
+      const wrapped = guardRecordsClient(
+        { call },
+        {
+          getSessionKey: () => sessionKey,
+          onSessionInvalidated: (errorCode) => {
+            invalidated.push(errorCode);
+            sessionKey = null;
+          },
+        }
+      );
+
+      await Promise.all([
+        wrapped.call(),
+        wrapped.call(),
+        wrapped.call(),
+        wrapped.call(),
+      ]);
+
+      expect(invalidated).toEqual(["session_expired"]);
+    });
+
+    it("does not report failures from revokeSession", async () => {
+      // A deliberate sign-out revokes the key; that call coming back
+      // `session_expired` is expected and must not be reported as a lost session.
+      const revokeSession = vi
+        .fn()
+        .mockResolvedValue(failure("session_expired"));
+      const { wrapped, invalidated } = createGuard({ revokeSession });
+
+      await (
+        wrapped as { revokeSession: () => Promise<unknown> }
+      ).revokeSession();
+
+      expect(invalidated).toEqual([]);
+    });
+  });
+});

--- a/test/unit/seed-bible/managers/SessionGuardRecordsClient.test.ts
+++ b/test/unit/seed-bible/managers/SessionGuardRecordsClient.test.ts
@@ -1,0 +1,110 @@
+import { createRecordsClient } from "@casual-simulation/aux-records/RecordsClient";
+import {
+  guardRecordsClient,
+  type FatalSessionErrorCode,
+} from "@packages/seed-bible/seed-bible/managers/SessionGuard";
+
+/**
+ * `SessionGuard.test.ts` covers the guard's logic against a plain fake object. These
+ * tests instead run it against the **real** CasualOS records client, because that
+ * client is itself a Proxy that synthesizes a network call for any unrecognised
+ * property — the trickiest thing the guard has to sit in front of. If a future SDK
+ * upgrade changes that behaviour (freezing the client, switching to `#private`
+ * fields, and so on), these are the tests that notice.
+ */
+describe("guardRecordsClient over the real records client", () => {
+  const ENDPOINT = "https://example.invalid";
+  const DEAD_SESSION_RESPONSE = {
+    success: false,
+    errorCode: "session_expired",
+    errorMessage: "gone",
+  };
+
+  function createGuardedClient() {
+    const rawClient = createRecordsClient(ENDPOINT);
+    const invalidated: FatalSessionErrorCode[] = [];
+    const client = guardRecordsClient(rawClient, {
+      getSessionKey: () => "a-session-key",
+      onSessionInvalidated: (errorCode) => invalidated.push(errorCode),
+    });
+    return { rawClient, client, invalidated };
+  }
+
+  /** Answers every request with `body`, mimicking a JSON response from the server. */
+  function stubFetchWith(body: unknown) {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn().mockResolvedValue({
+        headers: { get: () => "application/json" },
+        json: async () => body,
+      })
+    );
+  }
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  it("writes sessionKey through to the underlying client", () => {
+    // OsManager's effect and LoginManager both assign this directly, so the wrapper
+    // has to forward the write rather than swallow it.
+    const { rawClient, client } = createGuardedClient();
+
+    client.sessionKey = "written-through";
+
+    expect(client.sessionKey).toBe("written-through");
+    expect(rawClient.sessionKey).toBe("written-through");
+  });
+
+  it("keeps the client from being mistaken for a promise", async () => {
+    // The SDK pins `then`/`catch` to undefined for this reason. If the wrapper turned
+    // them into functions, awaiting the client anywhere would hang forever.
+    const { client } = createGuardedClient();
+
+    expect(typeof (client as { then?: unknown }).then).not.toBe("function");
+    await expect(Promise.resolve(client)).resolves.toBeDefined();
+  });
+
+  it("leaves plain getters readable", () => {
+    const { client } = createGuardedClient();
+
+    expect(client.endpoint).toBe(ENDPOINT);
+  });
+
+  it("detects a dead session on a synthesized procedure call", async () => {
+    // `getData` is not a declared method — the SDK's Proxy invents it — so this is
+    // the path every records call in the app actually takes.
+    const { client, invalidated } = createGuardedClient();
+    stubFetchWith(DEAD_SESSION_RESPONSE);
+
+    const result = await client.getData({ recordName: "r", address: "a" });
+
+    expect(result).toEqual(DEAD_SESSION_RESPONSE);
+    expect(invalidated).toEqual(["session_expired"]);
+  });
+
+  it("supports callProcedure called directly", async () => {
+    // A real prototype method rather than a synthesized one, so this is what proves
+    // the wrapper passes a usable `this` through to the SDK instance.
+    const { client, invalidated } = createGuardedClient();
+    stubFetchWith(DEAD_SESSION_RESPONSE);
+
+    const result = await client.callProcedure("getData", {
+      recordName: "r",
+      address: "a",
+    });
+
+    expect(result).toEqual(DEAD_SESSION_RESPONSE);
+    expect(invalidated).toEqual(["session_expired"]);
+  });
+
+  it("leaves a successful response alone", async () => {
+    const { client, invalidated } = createGuardedClient();
+    stubFetchWith({ success: true, data: { verse: 1 } });
+
+    const result = await client.getData({ recordName: "r", address: "a" });
+
+    expect(result).toEqual({ success: true, data: { verse: 1 } });
+    expect(invalidated).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Adds automatic session invalidation detection to the app. When the CasualOS API reports that a session key is dead (expired, unrecognised, or the account is banned), the app now signs the user out immediately without waiting for the user to notice or manually sign out. The user sees a toast explaining why they were signed out.

## Key Changes

- **SessionGuard** (`packages/seed-bible/seed-bible/managers/SessionGuard.ts`): New module that wraps the records client with a Proxy. Every API call result is checked for three fatal error codes (`session_expired`, `invalid_key`, `user_is_banned`). When one is detected, a callback fires to notify the app that the session is dead. The guard is careful not to sign out the wrong session — it compares the session key at request time to the current key, so if the user signed out or signed back in while a request was in flight, that stale failure is ignored. A burst of simultaneous failures (e.g., two init requests both hitting an expired key) collapses into a single sign-out.

- **OsManager** (`packages/seed-bible/seed-bible/managers/OsManager.tsx`): Wraps the raw CasualOS records client with `guardRecordsClient`. Exposes a `sessionInvalidated` signal that fires when the guard detects a dead session.

- **LoginManager** (`packages/seed-bible/seed-bible/managers/LoginManager.tsx`): Watches `os.sessionInvalidated` and calls `forceLogout()` when it fires. `forceLogout()` clears the session from memory and storage, sets a `sessionEnded` signal with a reason (`"session_expired"` or `"account_suspended"`), and does **not** call `revokeSession` (the session is already gone server-side). Also improved the refresh logic to check if the session changed while the request was in flight, preventing a successful refresh from resurrecting a session that was just dropped.

- **SeedBibleStateManager** (`packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx`): Watches `login.sessionEnded` and shows a toast with a user-friendly message explaining the sign-out reason.

- **Tests**: Added comprehensive test suites for `SessionGuard` (logic against a fake client) and `SessionGuardRecordsClient` (integration with the real CasualOS client). Extended `LoginManager` tests to cover automatic sign-out scenarios, including the case where multiple requests fail simultaneously. Updated `SeedBibleStateManager` tests to verify toast messages.

## Notable Implementation Details

- **Network failures don't sign anyone out**: Only `.then()` is hooked, never `.catch()`. A rejection (offline, DNS, CORS, a 500 with no body) passes through unobserved and never triggers a sign-out. This is intentional — a blip on a mobile connection is not the same as a dead session.

- **`revokeSession` is exempt**: Failures from `revokeSession` are never reported as a dead session. A deliberate sign-out often comes back `session_expired` (the key was already dead, which is often why the user is signing out), and reacting to that would tell someone who just pressed "Sign out" that their session had expired.

- **Monotonic IDs prevent silent failures**: Both `SessionInvalidatedEvent` and `SessionEndedEvent` carry an incrementing `id`. Preact signals skip notification when the new value is `===` the old one, so without the id a second `session_expired` (after signing back in, say) would silently fail to notify anyone.

- **Mid-flight checks prevent resurrection**: `refreshSession()` and `loadUserInfo()` both peek at the session key before and after their request. If the session changed (the user signed out, or this very request reported the key dead), the success branch is skipped, preventing a successful refresh from resurrecting a session we just dropped.

- **Transient failures are survivable**: The refresh no longer clears the session on failure. A refresh fails for transient reasons far more often than real ones (a mobile dead spot, a 500, a rate limit), and the key is usually still good for another week. The three codes that

https://claude.ai/code/session_01AnL8i8W2DPdbnfUwdK9TjR