### PR TITLE
fix: keep the swiped-to chapter on screen until its text arrives

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@
 
 ### 🐛 Fixed
 
+- Fix swiping between chapters on mobile flashing the chapter you just left. The swipe used to slide over to the next chapter's preview and then immediately snap back to the centre of the reader — which was still showing the previous chapter — while the new text downloaded. It now stays on the preview until the new chapter's text is ready, and only gives up and snaps back if the download is genuinely slow. ([#1558](https://github.com/HelloAOLab/seed-bible/issues/1558))
 - Changing chapter or book no longer waits on an in-flight text request. The position updates the moment you press, and repeated presses advance a chapter each, instead of the chevrons and arrow keys switching off until the download finished. ([#1551](https://github.com/HelloAOLab/seed-bible/pull/1551))
 - Fix shared sessions freezing and eventually crashing the tab with an out-of-memory error when another participant moved through chapters quickly. ([#1551](https://github.com/HelloAOLab/seed-bible/pull/1551))
 - Fix an out-of-range chapter in the address, such as `?chapter=99999`, leaving the address pointing at a chapter you are not on, so pressing Back returned you to it and bounced straight forward again. ([#1551](https://github.com/HelloAOLab/seed-bible/pull/1551))

--- a/packages/seed-bible/seed-bible/components/TabsLayout.tsx
+++ b/packages/seed-bible/seed-bible/components/TabsLayout.tsx
@@ -36,6 +36,14 @@ export function TabSlotReader(props: TabSlotReaderProps) {
   const swipeTouchStartY = useRef<number | null>(null);
   const swipeDirectionLocked = useRef<"h" | "v" | null>(null);
   const swipeCurrentDx = useRef(0);
+  // Identifies whoever currently owns the track's transform. Bumped by every
+  // new gesture, so a committed swipe still waiting to recentre knows it has
+  // been superseded and leaves the track to the gesture in progress.
+  const swipeCommitToken = useRef(0);
+  // True while a committed swipe is resting on a neighbouring panel waiting for
+  // the chapter it navigated to. The track is off-centre in that window, which
+  // a new gesture has to correct before it starts following the finger.
+  const swipeParked = useRef(false);
   const currentChapterRef = useRef(readingState.chapterData.value);
   const lastScrollTopRef = useRef(0);
   const scrollerCleanupRef = useRef<(() => void) | null>(null);
@@ -268,6 +276,31 @@ export function TabSlotReader(props: TabSlotReaderProps) {
     }
 
     const PANEL_PCT = 100 / 3;
+    // How long the track takes to slide over to a neighbouring panel.
+    const SWIPE_ANIMATION_MS = 250;
+    /**
+     * How long the track will rest on that neighbouring panel waiting for the
+     * text of the chapter it just navigated to, before recentring anyway.
+     *
+     * Navigation deliberately does not wait on a download (see
+     * `isChapterContentStale`), so for as long as the new chapter is in flight
+     * the *centre* panel still holds the chapter the reader just left.
+     * Recentring into that is what made a swipe flash the outgoing chapter.
+     * Waiting costs nothing in the usual case — the panel we are resting on is
+     * the prefetched preview of exactly the chapter being fetched, so it is
+     * already cached and settles in a few milliseconds — and the cap keeps a
+     * slow connection from stranding the reader on a static, unscrollable
+     * preview. Set to half the reader's own skeleton delay so a genuinely slow
+     * chapter falls back to the dimmed-text path well before the placeholder
+     * would appear.
+     */
+    const SWIPE_SETTLE_BUDGET_MS = 250;
+
+    const centreTransform = () => {
+      const isRtl =
+        readingState.chapterData.value?.translation.textDirection === "rtl";
+      return `translateX(${(isRtl ? 1 : -1) * PANEL_PCT}%)`;
+    };
 
     const onTouchStart = (event: TouchEvent) => {
       const touch = event.touches[0];
@@ -280,9 +313,19 @@ export function TabSlotReader(props: TabSlotReaderProps) {
       swipeDirectionLocked.current = null;
       swipeCurrentDx.current = 0;
 
+      // This gesture takes the track over from any committed swipe still
+      // waiting on its chapter.
+      swipeCommitToken.current += 1;
+
       const track = swipeTrackRef.current;
       if (track) {
         track.style.transition = "none";
+        if (swipeParked.current) {
+          // Bring the track back to centre before it starts following the
+          // finger, which `onTouchMove` measures from centre.
+          swipeParked.current = false;
+          track.style.transform = centreTransform();
+        }
       }
     };
 
@@ -344,6 +387,50 @@ export function TabSlotReader(props: TabSlotReaderProps) {
       }
     };
 
+    /**
+     * Finishes a swipe that crossed the threshold: slides the track over to the
+     * neighbouring panel, navigates once it arrives, and recentres only when
+     * the new chapter's text is actually on screen.
+     *
+     * The panel we land on is a static preview of the chapter being navigated
+     * to, so resting there shows the reader the right text throughout the wait.
+     */
+    const commitSwipe = (
+      track: HTMLDivElement,
+      landingTransform: string,
+      navigate: () => Promise<void>
+    ) => {
+      const commit = ++swipeCommitToken.current;
+      track.style.transition = `transform ${SWIPE_ANIMATION_MS}ms cubic-bezier(0.4, 0, 0.2, 1)`;
+      track.style.transform = landingTransform;
+      readingState.clearSelectedVerses();
+
+      window.setTimeout(() => {
+        // The navigation always runs, even if another gesture has since taken
+        // the track over: the reader completed the swipe that asked for it.
+        // Only the transform below is the superseding gesture's to own.
+        const settled = navigate().catch(() => undefined);
+        if (swipeCommitToken.current !== commit) {
+          return;
+        }
+
+        swipeParked.current = true;
+        void Promise.race([
+          settled,
+          new Promise<void>((resolve) =>
+            window.setTimeout(resolve, SWIPE_SETTLE_BUDGET_MS)
+          ),
+        ]).then(() => {
+          if (swipeCommitToken.current !== commit) {
+            return;
+          }
+          swipeParked.current = false;
+          track.style.transition = "none";
+          track.style.transform = centreTransform();
+        });
+      }, SWIPE_ANIMATION_MS);
+    };
+
     const onTouchEnd = () => {
       if (swipeDirectionLocked.current !== "h") {
         swipeTouchStartX.current = null;
@@ -371,32 +458,19 @@ export function TabSlotReader(props: TabSlotReaderProps) {
         return;
       }
 
+      const sign = isRtl ? 1 : -1;
+
       if (shouldLoadNext && hasNext) {
-        track.style.transition = "transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)";
-        const sign = isRtl ? 1 : -1;
-        const nextTransform = `translateX(${sign * PANEL_PCT * 2}%)`;
-        track.style.transform = nextTransform;
-        readingState.clearSelectedVerses();
-        window.setTimeout(async () => {
-          track.style.transition = "none";
-          track.style.transform = `translateX(${sign * PANEL_PCT}%)`;
-          await readingState.loadNextChapter();
-        }, 250);
+        commitSwipe(track, `translateX(${sign * PANEL_PCT * 2}%)`, () =>
+          readingState.loadNextChapter()
+        );
       } else if (shouldLoadPrev && hasPrev) {
-        track.style.transition = "transform 0.25s cubic-bezier(0.4, 0, 0.2, 1)";
-        const sign = isRtl ? 1 : -1;
-        const prevTransform = "translateX(0%)";
-        track.style.transform = prevTransform;
-        readingState.clearSelectedVerses();
-        window.setTimeout(async () => {
-          track.style.transition = "none";
-          track.style.transform = `translateX(${sign * PANEL_PCT}%)`;
-          await readingState.loadPreviousChapter();
-        }, 250);
+        commitSwipe(track, "translateX(0%)", () =>
+          readingState.loadPreviousChapter()
+        );
       } else {
         track.style.transition = "transform 0.3s cubic-bezier(0.4, 0, 0.2, 1)";
-        const sign = isRtl ? 1 : -1;
-        track.style.transform = `translateX(${sign * PANEL_PCT}%)`;
+        track.style.transform = centreTransform();
       }
     };
 
@@ -405,6 +479,10 @@ export function TabSlotReader(props: TabSlotReaderProps) {
     viewport.addEventListener("touchend", onTouchEnd, { passive: true });
 
     return () => {
+      // Retires any commit still waiting to recentre, so it doesn't write a
+      // transform onto a track this effect no longer owns.
+      swipeCommitToken.current += 1;
+      swipeParked.current = false;
       viewport.removeEventListener("touchstart", onTouchStart);
       viewport.removeEventListener("touchmove", onTouchMove);
       viewport.removeEventListener("touchend", onTouchEnd);

--- a/test/integration/seed-bible/components/TabSlotReader.test.tsx
+++ b/test/integration/seed-bible/components/TabSlotReader.test.tsx
@@ -302,6 +302,13 @@ function dispatchTouch(
   element.dispatchEvent(event);
 }
 
+// The swipe track is three panels wide: previous preview | current | next
+// preview. These are the transforms that park it over each one, written the
+// same way the component writes them so the float formatting matches.
+const SWIPE_PANEL_PCT = 100 / 3;
+const CENTRE_PANEL_TRANSFORM = `translateX(${-SWIPE_PANEL_PCT}%)`;
+const NEXT_PANEL_TRANSFORM = `translateX(${-SWIPE_PANEL_PCT * 2}%)`;
+
 describe("TabSlotReader integration", () => {
   let container: HTMLDivElement;
 
@@ -822,6 +829,183 @@ describe("TabSlotReader integration", () => {
 
       expect(readingState.loadPreviousChapter).not.toHaveBeenCalled();
       expect(readingState.clearSelectedVerses).not.toHaveBeenCalled();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // Navigation does not wait on the download, so the *centre* panel still holds
+  // the outgoing chapter while the new one is in flight. Recentring straight
+  // away is what made a swipe flash the chapter the reader just left.
+  it("rests on the swiped-to preview until the new chapter's text arrives, instead of recentring onto the outgoing chapter", async () => {
+    vi.useFakeTimers();
+    const { slot, readingState, chapterData } = createFixture();
+    const state = createMobileState();
+
+    let settleNavigation: () => void = () => {};
+    readingState.loadNextChapter = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settleNavigation = resolve;
+        })
+    );
+
+    chapterData.value = {
+      ...chapterData.value!,
+      previousChapterApiLink: "/api/BSB/GEN/0.json",
+      nextChapterApiLink: "/api/BSB/GEN/2.json",
+      translation: {
+        ...chapterData.value!.translation,
+        textDirection: "ltr",
+      },
+    };
+
+    try {
+      renderTabSlotReader(slot, readingState, state, container);
+
+      const viewport = container.querySelector(
+        ".sb-reader-swipe-viewport"
+      ) as HTMLDivElement;
+      const track = container.querySelector(
+        ".sb-reader-swipe-track"
+      ) as HTMLDivElement;
+
+      act(() => {
+        dispatchTouch(viewport, "touchstart", [{ clientX: 220, clientY: 50 }]);
+        dispatchTouch(viewport, "touchmove", [{ clientX: 100, clientY: 50 }]);
+        dispatchTouch(viewport, "touchend", []);
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(readingState.loadNextChapter).toHaveBeenCalledTimes(1);
+      expect(track.style.transform).toBe(NEXT_PANEL_TRANSFORM);
+
+      settleNavigation();
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(track.style.transform).toBe(CENTRE_PANEL_TRANSFORM);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // The cap is what keeps the promise of navigation that never waits on a
+  // download: a slow chapter must not strand the reader on a static,
+  // unscrollable preview panel.
+  it("recentres anyway once the settle budget runs out, even if the chapter is still downloading", async () => {
+    vi.useFakeTimers();
+    const { slot, readingState, chapterData } = createFixture();
+    const state = createMobileState();
+
+    // Never resolves — stands in for a chapter still on its way.
+    readingState.loadNextChapter = vi.fn(() => new Promise<void>(() => {}));
+
+    chapterData.value = {
+      ...chapterData.value!,
+      previousChapterApiLink: "/api/BSB/GEN/0.json",
+      nextChapterApiLink: "/api/BSB/GEN/2.json",
+      translation: {
+        ...chapterData.value!.translation,
+        textDirection: "ltr",
+      },
+    };
+
+    try {
+      renderTabSlotReader(slot, readingState, state, container);
+
+      const viewport = container.querySelector(
+        ".sb-reader-swipe-viewport"
+      ) as HTMLDivElement;
+      const track = container.querySelector(
+        ".sb-reader-swipe-track"
+      ) as HTMLDivElement;
+
+      act(() => {
+        dispatchTouch(viewport, "touchstart", [{ clientX: 220, clientY: 50 }]);
+        dispatchTouch(viewport, "touchmove", [{ clientX: 100, clientY: 50 }]);
+        dispatchTouch(viewport, "touchend", []);
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(track.style.transform).toBe(NEXT_PANEL_TRANSFORM);
+
+      await act(async () => {
+        vi.advanceTimersByTime(250);
+        await Promise.resolve();
+      });
+
+      expect(track.style.transform).toBe(CENTRE_PANEL_TRANSFORM);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  // A reader who swipes again while the previous chapter is still settling owns
+  // the track; the pending commit must not yank it back mid-gesture.
+  it("hands the track to a new gesture started while a commit is still waiting", async () => {
+    vi.useFakeTimers();
+    const { slot, readingState, chapterData } = createFixture();
+    const state = createMobileState();
+
+    let settleNavigation: () => void = () => {};
+    readingState.loadNextChapter = vi.fn(
+      () =>
+        new Promise<void>((resolve) => {
+          settleNavigation = resolve;
+        })
+    );
+
+    chapterData.value = {
+      ...chapterData.value!,
+      previousChapterApiLink: "/api/BSB/GEN/0.json",
+      nextChapterApiLink: "/api/BSB/GEN/2.json",
+      translation: {
+        ...chapterData.value!.translation,
+        textDirection: "ltr",
+      },
+    };
+
+    try {
+      renderTabSlotReader(slot, readingState, state, container);
+
+      const viewport = container.querySelector(
+        ".sb-reader-swipe-viewport"
+      ) as HTMLDivElement;
+      const track = container.querySelector(
+        ".sb-reader-swipe-track"
+      ) as HTMLDivElement;
+
+      act(() => {
+        dispatchTouch(viewport, "touchstart", [{ clientX: 220, clientY: 50 }]);
+        dispatchTouch(viewport, "touchmove", [{ clientX: 100, clientY: 50 }]);
+        dispatchTouch(viewport, "touchend", []);
+        vi.advanceTimersByTime(250);
+      });
+
+      expect(track.style.transform).toBe(NEXT_PANEL_TRANSFORM);
+
+      // A second gesture takes over: touching down recentres immediately, then
+      // the drag follows the finger from there.
+      act(() => {
+        dispatchTouch(viewport, "touchstart", [{ clientX: 220, clientY: 50 }]);
+      });
+      expect(track.style.transform).toBe(CENTRE_PANEL_TRANSFORM);
+
+      act(() => {
+        dispatchTouch(viewport, "touchmove", [{ clientX: 180, clientY: 50 }]);
+      });
+      const draggedTransform = track.style.transform;
+      expect(draggedTransform).not.toBe(CENTRE_PANEL_TRANSFORM);
+
+      // The superseded commit settling must not disturb the gesture in flight.
+      settleNavigation();
+      await act(async () => {
+        await Promise.resolve();
+      });
+
+      expect(track.style.transform).toBe(draggedTransform);
     } finally {
       vi.useRealTimers();
     }


### PR DESCRIPTION
Swiping between chapters on mobile flashed the chapter the reader had
just left. The gesture slid the track over to the neighbouring panel —
a static preview of the chapter being swiped to — and then, at the end
of the animation, snapped straight back to the centre panel *before*
navigating. Because navigation no longer waits on the download, the
centre panel still held the outgoing chapter at that moment, so it was
painted for at least a frame before the new text replaced it.

The track now rests on the neighbouring panel until the navigation
settles, then recentres. In the usual case that panel is the prefetched
preview of exactly the chapter being fetched, so the wait is a few
milliseconds. A settle budget caps it, so a slow download falls back to
the existing dimmed-text path rather than stranding the reader on a
static, unscrollable preview.

A commit token tracks who owns the track's transform, so a swipe still
waiting on its chapter cannot yank the track away from a gesture that
has since taken over, or write to a track the effect no longer owns.

Refs #1558

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Ez9cyKrfsnpuiaGt8cxiMD