### PR TITLE
Split extension list translations into per-language chunks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,7 +105,10 @@ jobs:
 
       - name: Generate build size report
         run: |
-          ARGS=(report --head size-head.json --out size-report.md --threshold-kb 300)
+          # 50 KB rather than 300: the eager vendor chunk is now ~230 KB, so a
+          # 300 KB allowance would let it more than double without comment. A
+          # single mistakenly-eager import is the failure mode worth catching.
+          ARGS=(report --head size-head.json --out size-report.md --threshold-kb 50)
           if [ -f size-base.json ]; then
             ARGS+=(--base size-base.json)
           elif [ "${{ github.event_name }}" = "pull_request" ]; then

--- a/package.json
+++ b/package.json
@@ -134,7 +134,6 @@
     "i18next": "catalog:",
     "i18next-resources-to-backend": "catalog:",
     "imagetracerjs": "^1.2.6",
-    "luxon": "catalog:",
     "opentype.js": "^1.3.4",
     "preact-render-to-string": "catalog:",
     "prompts": "^2.4.2",

--- a/packages/seed-bible/package.json
+++ b/packages/seed-bible/package.json
@@ -30,7 +30,6 @@
     "@casual-simulation/websocket": "catalog:",
     "axios": "catalog:",
     "i18next": "catalog:",
-    "luxon": "catalog:",
     "preact": "catalog:",
     "preact-iso": "catalog:",
     "react": "catalog:",

--- a/packages/seed-bible/seed-bible/app/utils.tsx
+++ b/packages/seed-bible/seed-bible/app/utils.tsx
@@ -20,6 +20,134 @@ export const translateTitle = (
   });
 };
 
+/**
+ * How many whole calendar months separate two instants, signed and truncated
+ * toward zero. Calendar-aware rather than "every month is 30 days", so
+ * Jan 31 → Feb 28 counts as a whole month and Jan 1 → Jan 31 counts as none.
+ */
+function wholeMonthsBetween(fromMs: number, toMs: number): number {
+  // Always measure from the earlier instant forward, then re-apply the sign.
+  // Measuring backward from the later one is not symmetric: Feb 28 minus a
+  // month is Jan 28, which is earlier than Jan 31 and would drop the month,
+  // while Jan 31 forward correctly reaches Feb 28.
+  const sign = toMs >= fromMs ? 1 : -1;
+  const earlier = new Date(Math.min(fromMs, toMs));
+  const laterMs = Math.max(fromMs, toMs);
+  const later = new Date(laterMs);
+
+  let months =
+    (later.getFullYear() - earlier.getFullYear()) * 12 +
+    (later.getMonth() - earlier.getMonth());
+
+  // The calendar delta above rounds outward — Jan 31 to Feb 1 reads as one
+  // month. Step back toward zero when less than a full month has elapsed.
+  if (months > 0) {
+    const anchor = new Date(earlier.getTime());
+    const wantedMonth = (((anchor.getMonth() + months) % 12) + 12) % 12;
+    anchor.setMonth(anchor.getMonth() + months);
+    // `setMonth` overflows when the day is missing from the target month —
+    // Jan 31 plus one month lands on Mar 3. Clamp back to that month's last
+    // day so Jan 31 → Feb 28 stays the whole month it reads as.
+    if (anchor.getMonth() !== wantedMonth) {
+      anchor.setDate(0);
+    }
+    if (anchor.getTime() > laterMs) {
+      months -= 1;
+    }
+  }
+  return months * sign;
+}
+
+/**
+ * Locales the app translates but CLDR has no relative-time data for, mapped to
+ * the nearest locale it does cover. Left alone, `Intl` falls back to English,
+ * which strands an English "3 days ago" in an otherwise translated UI. Guaraní
+ * is co-official with Spanish in Paraguay, where nearly all of its speakers
+ * are, so Spanish reads far less foreign to them than English.
+ */
+const RELATIVE_TIME_LOCALE_FALLBACKS: Record<string, string> = { gn: "es" };
+
+function resolveRelativeTimeLocale(locale: string): string {
+  const fallback = RELATIVE_TIME_LOCALE_FALLBACKS[locale];
+  // The mapping only applies when the platform genuinely lacks the locale, so
+  // this corrects itself if CLDR gains data later.
+  if (
+    fallback &&
+    Intl.RelativeTimeFormat.supportedLocalesOf([locale]).length === 0
+  ) {
+    return fallback;
+  }
+  return locale;
+}
+
+/**
+ * Formatters are immutable and comparatively expensive to build — around 35x
+ * the cost of a format call — and the reader rebuilds every visible timestamp
+ * on a 15-second timer, so they are kept per locale. Keyed by the requested
+ * locale rather than the resolved one, so the fallback lookup above is paid
+ * once too. Bounded by the number of UI languages, the same as the time-zone
+ * cache in `managers/civilDate.ts`.
+ */
+const relativeTimeFormatters = new Map<string, Intl.RelativeTimeFormat>();
+
+function getRelativeTimeFormatter(locale: string): Intl.RelativeTimeFormat {
+  let formatter = relativeTimeFormatters.get(locale);
+  if (!formatter) {
+    formatter = new Intl.RelativeTimeFormat(resolveRelativeTimeLocale(locale), {
+      numeric: "always",
+    });
+    relativeTimeFormatters.set(locale, formatter);
+  }
+  return formatter;
+}
+
+/** Fixed-length units, largest first, used below the one-month threshold. */
+const RELATIVE_TIME_UNITS: [Intl.RelativeTimeFormatUnit, number][] = [
+  ["day", 86_400_000],
+  ["hour", 3_600_000],
+  ["minute", 60_000],
+  ["second", 1_000],
+];
+
+/**
+ * Renders an instant relative to now — "3 minutes ago", "in 2 days".
+ *
+ * Picks the largest unit that the gap fills at least once and truncates toward
+ * zero, so 90 minutes reads as "1 hour ago" rather than "2 hours ago". Years
+ * and months are counted on the calendar; everything below them uses
+ * fixed-length units.
+ *
+ * @param timeMs The instant to describe.
+ * @param locale The BCP 47 locale to render in.
+ * @param nowMs The instant to compare against. Defaults to now; pass a value
+ *              to keep tests deterministic.
+ */
+export const formatRelativeTime = (
+  timeMs: number,
+  locale: string,
+  nowMs: number = Date.now()
+): string => {
+  const format = getRelativeTimeFormatter(locale);
+
+  const months = wholeMonthsBetween(nowMs, timeMs);
+  const years = Math.trunc(months / 12);
+  if (years !== 0) {
+    return format.format(years, "year");
+  }
+  if (months !== 0) {
+    return format.format(months, "month");
+  }
+
+  const deltaMs = timeMs - nowMs;
+  for (const [unit, unitMs] of RELATIVE_TIME_UNITS) {
+    const value = Math.trunc(deltaMs / unitMs);
+    if (value !== 0) {
+      return format.format(value, unit);
+    }
+  }
+  return format.format(0, "second");
+};
+
 export const download = (blob: Blob, filename: string) => {
   const url = URL.createObjectURL(blob);
   const a = document.createElement("a");

--- a/packages/seed-bible/seed-bible/components/ChatView/ChatView.tsx
+++ b/packages/seed-bible/seed-bible/components/ChatView/ChatView.tsx
@@ -12,13 +12,12 @@ import {
   type ConnectionSessionUserVisual,
 } from "../../managers/SessionsManager";
 import { Avatar } from "../Avatar/Avatar";
-import { translateTitle } from "../../app/utils";
+import { formatRelativeTime, translateTitle } from "../../app/utils";
 import { AskIcon } from "../icons";
 import { VerseReferenceLink } from "../../app/verseReferenceLink";
 import type { SeedBibleState } from "../../managers/SeedBibleStateManager";
 import type { VerseRef } from "../../managers/BibleDataManager";
 import { useEffect, useRef, useState } from "preact/hooks";
-import { DateTime } from "luxon";
 
 interface ChatViewProps {
   chat: ChatSession;
@@ -244,9 +243,12 @@ function RelativeDateTime({ timeMs }: { timeMs: number }) {
   }, []);
 
   void refreshTick.value;
-  const date = DateTime.fromMillis(timeMs).setLocale(language);
 
-  return <span className="relative-date-time">{date.toRelative()}</span>;
+  return (
+    <span className="relative-date-time">
+      {formatRelativeTime(timeMs, language)}
+    </span>
+  );
 }
 
 export function getMessageAvatar(

--- a/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.tsx
+++ b/packages/seed-bible/seed-bible/components/FloatingReaderPanels/FloatingReaderPanels.tsx
@@ -25,9 +25,8 @@ import type {
 import type { SeedBibleState } from "../../managers/SeedBibleStateManager";
 import type { ReaderTab } from "../../managers/TabsManager";
 import { useEffect, useRef } from "preact/hooks";
-import { translateTitle } from "../../app/utils";
+import { formatRelativeTime, translateTitle } from "../../app/utils";
 import { Avatar } from "../Avatar/Avatar";
-import { DateTime } from "luxon";
 import { ChatParticipantsIcon } from "../icons";
 
 interface SearchResult {
@@ -124,8 +123,7 @@ function ChatListRelativeDateTime({ timeMs }: { timeMs: number }) {
   }, []);
 
   void refreshTick.value;
-  const date = DateTime.fromMillis(timeMs).setLocale(language);
-  return <span>{date.toRelative()}</span>;
+  return <span>{formatRelativeTime(timeMs, language)}</span>;
 }
 
 function getOrCreateSearchTargetTab(state: SeedBibleState): ReaderTab {

--- a/packages/seed-bible/seed-bible/components/SettingsPage/SettingsPage.tsx
+++ b/packages/seed-bible/seed-bible/components/SettingsPage/SettingsPage.tsx
@@ -21,7 +21,14 @@ import {
   type ThemeColorKey,
 } from "../../managers/ThemeManager";
 import { download, translateTitle } from "../../app/utils";
-import { ProfilePictureModalContent } from "../../components/ProfilePictureModal/ProfilePictureModal";
+// The picture editor pulls in `react-avatar-editor`, and it is only reachable
+// through the "Update picture" button — so it is fetched on that click rather
+// than at boot, the same way TextItemInput defers TipTap.
+const ProfilePictureModalContent = lazy(() =>
+  import("../../components/ProfilePictureModal/ProfilePictureModal").then(
+    (m) => ({ default: m.ProfilePictureModalContent })
+  )
+);
 import {
   Skeleton,
   SkeletonContainer,
@@ -41,6 +48,7 @@ import {
   handleVerticalListKeyNav,
 } from "../../app/keyboardNav";
 import { useRef } from "preact/hooks";
+import { lazy, Suspense } from "preact/compat";
 import type { RequestedSettingsView } from "../../managers/SidebarManager";
 
 const TEXT_SECTION_ORDER: TextSectionId[] = ["bookTitle", "heading", "verse"];
@@ -260,20 +268,32 @@ function AccountSettingsView(props: { state: SeedBibleState }) {
     const modalId = state.modals.openModal({
       title: { key: "update-picture", defaultValue: "Update picture" },
       content: () => (
-        <ProfilePictureModalContent
-          onClose={() => state.modals.closeModal(modalId)}
-          onUpload={async (file) => {
-            isUploadingPicture.value = true;
-            try {
-              await login.uploadProfilePicture(file);
-            } catch (error) {
-              console.error("Failed to upload profile picture.", error);
-              throw error;
-            } finally {
-              isUploadingPicture.value = false;
-            }
-          }}
-        />
+        <Suspense
+          fallback={
+            <SkeletonContainer
+              label={t("loading-picture-editor", {
+                defaultValue: "Loading the picture editor…",
+              })}
+            >
+              <Skeleton width="100%" height="16rem" radius="0.625rem" />
+            </SkeletonContainer>
+          }
+        >
+          <ProfilePictureModalContent
+            onClose={() => state.modals.closeModal(modalId)}
+            onUpload={async (file) => {
+              isUploadingPicture.value = true;
+              try {
+                await login.uploadProfilePicture(file);
+              } catch (error) {
+                console.error("Failed to upload profile picture.", error);
+                throw error;
+              } finally {
+                isUploadingPicture.value = false;
+              }
+            }}
+          />
+        </Suspense>
       ),
     });
   };

--- a/packages/seed-bible/seed-bible/i18n/en.json
+++ b/packages/seed-bible/seed-bible/i18n/en.json
@@ -394,6 +394,7 @@
   "languageUnavailable.noGoBack": "No, Go back",
   "ui-size": "UI size",
   "loading-profile": "Loading your profile…",
+  "loading-picture-editor": "Loading the picture editor…",
   "saving": "Saving…",
   "app-version": "v{{version}} · {{commit}}",
   "move-bookmark": "Move to folder",

--- a/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
@@ -910,8 +910,21 @@ export function createExtensionManager(
     extensionsSignal.value = computeExtensions();
   };
 
+  // Fetching list strings is a client-only concern, for two reasons. The
+  // Settings extensions list is never server-rendered and English is already
+  // inline as the fallback, so there is nothing for the server to gain. More
+  // importantly `i18n` is the process-wide i18next singleton while this factory
+  // runs once per SSR request (`entry-ssr.tsx` → `createSeedBibleState` →
+  // here), so on the server both the listener below and the fetch would be
+  // per-request writes to state shared by every request — the listener in
+  // particular would accumulate for the life of the process.
+  const fetchesListTranslations = !import.meta.env.SSR;
+
   // Sets whose list strings are fetched per language, kept so a later language
-  // change can re-fetch for the new one.
+  // change can re-fetch for the new one. Nothing removes from this today
+  // because there is no path that untracks a set; if one is added, it should
+  // delete from here too, or the handler below will keep re-fetching for sets
+  // that no longer matter.
   const setsWithListTranslations = new Set<ExtensionSet>();
 
   /**
@@ -947,17 +960,19 @@ export function createExtensionManager(
     }
   };
 
-  i18n.on("languageChanged", (language: string) => {
-    for (const set of setsWithListTranslations) {
-      void loadListTranslationsForLanguage(set, language);
-    }
-  });
+  if (fetchesListTranslations) {
+    i18n.on("languageChanged", (language: string) => {
+      for (const set of setsWithListTranslations) {
+        void loadListTranslationsForLanguage(set, language);
+      }
+    });
+  }
 
   const trackExtensionSet = (set: ExtensionSet) => {
     for (const extension of set.extensions) {
       knownExtensionsById.set(extension.meta.id, extension);
     }
-    if (set.loadListTranslations) {
+    if (fetchesListTranslations && set.loadListTranslations) {
       setsWithListTranslations.add(set);
       void loadListTranslationsForLanguage(set, i18n.language);
     }

--- a/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ExtensionManager.tsx
@@ -2,7 +2,7 @@ import { effect, signal } from "@preact/signals";
 import { orderBy, union } from "es-toolkit";
 import type { SeedBibleState } from "../managers/SeedBibleStateManager";
 import type { LoginManager } from "../managers/LoginManager";
-import { addTranslations } from "../i18n/I18nManager";
+import { addTranslations, i18n } from "../i18n/I18nManager";
 import { safeLocalStorage } from "../app/ssrEnv";
 import {
   getProfileConfigValue,
@@ -137,6 +137,15 @@ export interface ExtensionModule {
   default: ExtensionEntryPoint;
 }
 
+/**
+ * The `title`/`description` every extension in a set offers in one language,
+ * keyed by extension id. Extensions with nothing for that language are absent.
+ */
+export type ExtensionListTranslations = Record<
+  string,
+  { title: string; description: string }
+>;
+
 export interface ExtensionSet {
   /**
    * The ID of this extension set.
@@ -147,6 +156,19 @@ export interface ExtensionSet {
    * The extensions included in this set.
    */
   extensions: Extension[];
+
+  /**
+   * Loads the extensions list's `title`/`description` for one language, keyed
+   * by language code. Bundled sets (see `vite-plugin-extensions.ts`) supply
+   * this so only the reader's own language is downloaded — inlining all 77 in
+   * `meta.translations` cost 138 KB in the entry chunk. Optional: sets whose
+   * `meta.translations` is already populated (uploaded extensions fetched over
+   * the network) don't need it.
+   */
+  loadListTranslations?: Record<
+    string,
+    () => Promise<ExtensionListTranslations>
+  >;
 }
 
 export interface ExtensionListEntry {
@@ -888,9 +910,56 @@ export function createExtensionManager(
     extensionsSignal.value = computeExtensions();
   };
 
+  // Sets whose list strings are fetched per language, kept so a later language
+  // change can re-fetch for the new one.
+  const setsWithListTranslations = new Set<ExtensionSet>();
+
+  /**
+   * Registers the extensions list's `title`/`description` for one language.
+   *
+   * Sets that ship their strings inline (uploaded extensions) already had them
+   * registered by the caller; this only covers sets that defer them to a
+   * per-language chunk. A set with nothing for `language` is skipped, leaving
+   * the list to fall back to each extension's id, which is what
+   * `SettingsPage` already renders via `defaultValue`.
+   */
+  const loadListTranslationsForLanguage = async (
+    set: ExtensionSet,
+    language: string
+  ): Promise<void> => {
+    const load = set.loadListTranslations?.[language];
+    if (!load) {
+      return;
+    }
+    try {
+      const translations = await load();
+      for (const [extensionId, translation] of Object.entries(translations)) {
+        addTranslations(extensionId, { [language]: translation });
+      }
+      refreshExtensionsSignal();
+    } catch (err) {
+      // A missing chunk must not take the Settings page down with it — the
+      // list still renders, just with ids instead of titles.
+      console.error(
+        `Failed to load extension list translations for '${language}'.`,
+        err
+      );
+    }
+  };
+
+  i18n.on("languageChanged", (language: string) => {
+    for (const set of setsWithListTranslations) {
+      void loadListTranslationsForLanguage(set, language);
+    }
+  });
+
   const trackExtensionSet = (set: ExtensionSet) => {
     for (const extension of set.extensions) {
       knownExtensionsById.set(extension.meta.id, extension);
+    }
+    if (set.loadListTranslations) {
+      setsWithListTranslations.add(set);
+      void loadListTranslationsForLanguage(set, i18n.language);
     }
     refreshExtensionsSignal();
   };

--- a/packages/seed-bible/seed-bible/managers/OsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/OsManager.tsx
@@ -1,10 +1,8 @@
-import { RemoteYjsSharedDocument } from "@casual-simulation/aux-common/documents/RemoteYjsSharedDocument";
 import type { SharedDocument } from "@casual-simulation/aux-common/documents/SharedDocument";
 import { createRecordsClient } from "@casual-simulation/aux-records/RecordsClient";
 import { SocketManager as WebsocketManager } from "@casual-simulation/websocket";
 import { WebsocketConnectionClient } from "@casual-simulation/aux-websocket";
 import stringify from "@casual-simulation/fast-json-stable-stringify";
-import axios from "axios";
 import { isArrayBuffer } from "es-toolkit";
 import { v4 as uuid } from "uuid";
 import type { RecordFileFailure } from "@casual-simulation/aux-records";
@@ -223,6 +221,12 @@ export function CasualOSManager(endpoint: string = "https://auth.ao.bot") {
   ): Promise<SharedDocument> {
     const client = getInstClient();
     const authSource = getAuthSource();
+    // Shared documents are the only thing in the app that needs Yjs (~77 KB
+    // with lib0), and they only come into play for multiplayer sessions — so
+    // the module is fetched here rather than at boot. This function is already
+    // async and already waits on a network sync, so the extra await is free.
+    const { RemoteYjsSharedDocument } =
+      await import("@casual-simulation/aux-common/documents/RemoteYjsSharedDocument");
     const doc = new RemoteYjsSharedDocument(client, authSource, {
       recordName,
       inst,
@@ -412,7 +416,10 @@ export async function uploadFile(
   markers: string[] = ["publicRead"],
   providedMimeType?: string
 ) {
-  let encodedData: Uint8Array;
+  // Pinned to `ArrayBuffer` (rather than the default `ArrayBufferLike`) so it
+  // satisfies `fetch`'s `BodyInit` when uploaded below. All three branches
+  // already produce a plain-ArrayBuffer-backed view.
+  let encodedData: Uint8Array<ArrayBuffer>;
   let mimeType: string;
   if (isArrayBuffer(data)) {
     encodedData = new Uint8Array(data);
@@ -457,15 +464,16 @@ export async function uploadFile(
       delete headers[header];
     }
 
-    const uploadResult = await axios.request({
-      method: method.toLowerCase(),
-      url: url,
-      headers: headers,
-      data: encodedData,
+    const uploadResult = await fetch(url, {
+      method,
+      headers,
+      body: encodedData,
     });
 
-    if (uploadResult.status < 200 || uploadResult.status >= 300) {
-      throw new Error("Failed to upload file.");
+    if (!uploadResult.ok) {
+      throw new Error(
+        `Failed to upload file. (${uploadResult.status} ${uploadResult.statusText})`
+      );
     } else {
       console.log("Successfully uploaded AUX file.");
     }

--- a/packages/seed-bible/seed-bible/managers/ReadingPlansManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ReadingPlansManager.tsx
@@ -3,7 +3,12 @@ import { PlaylistItem } from "./PlaylistManager";
 import { z } from "zod";
 import type { LoginManager } from "./LoginManager";
 import { omit } from "es-toolkit";
-import { DateTime } from "luxon";
+import {
+  addCivilDays,
+  civilDateInZone,
+  civilDaysBetween,
+  type CivilDate,
+} from "./civilDate";
 import { CasualOSManager } from "./OsManager";
 import { v4 as uuid } from "uuid";
 
@@ -352,7 +357,7 @@ export function dateForSession(
   startedAtMs: number,
   sessionIndex: number,
   timeZone?: string | null
-): ReturnType<typeof DateTime.fromMillis> | null {
+): CivilDate | null {
   if (sessionIndex < 0) {
     return null;
   }
@@ -361,16 +366,14 @@ export function dateForSession(
   if (period === 0) {
     return null;
   }
-  const start = DateTime.fromMillis(startedAtMs, {
-    zone: timeZone ?? undefined,
-  }).startOf("day");
+  const start = civilDateInZone(startedAtMs, timeZone);
   const fullCycles = Math.floor(sessionIndex / period);
   let remaining = sessionIndex % period;
   let dayOffset = fullCycles * pattern.length;
   for (let i = 0; i < pattern.length; i++) {
     const sessions = pattern[i]!;
     if (remaining < sessions) {
-      return start.plus({ days: dayOffset });
+      return addCivilDays(start, dayOffset);
     }
     remaining -= sessions;
     dayOffset++;
@@ -394,13 +397,9 @@ export function sessionsForDate(
   if (period === 0) {
     return [];
   }
-  const start = DateTime.fromMillis(startedAtMs, {
-    zone: timeZone ?? undefined,
-  }).startOf("day");
-  const target = DateTime.fromMillis(dateMs, {
-    zone: timeZone ?? undefined,
-  }).startOf("day");
-  const dayOffset = Math.round(target.diff(start, "days").days);
+  const start = civilDateInZone(startedAtMs, timeZone);
+  const target = civilDateInZone(dateMs, timeZone);
+  const dayOffset = civilDaysBetween(start, target);
   if (dayOffset < 0) {
     return [];
   }
@@ -623,8 +622,8 @@ export interface CalendarSession {
 /** A single day on which one or more sessions are due. */
 export interface CalendarReadingDay {
   type: "reading";
-  /** Local midnight of the day, in the plan progress's time zone. */
-  date: ReturnType<typeof DateTime.fromMillis>;
+  /** The calendar date, as seen in the plan progress's time zone. */
+  date: CivilDate;
   /** Whole-day offset from the start date. */
   dayOffset: number;
   sessions: CalendarSession[];
@@ -641,10 +640,10 @@ export interface CalendarReadingDay {
 /** A contiguous run of skipped (non-reading) days. */
 export interface CalendarSkipRange {
   type: "skip";
-  /** Local midnight of the first skipped day. */
-  startDate: ReturnType<typeof DateTime.fromMillis>;
-  /** Local midnight of the last (inclusive) skipped day. */
-  endDate: ReturnType<typeof DateTime.fromMillis>;
+  /** The first skipped day, as seen in the plan progress's time zone. */
+  startDate: CivilDate;
+  /** The last (inclusive) skipped day, in the same time zone. */
+  endDate: CivilDate;
   startDayOffset: number;
   days: number;
   /** True when `nowMs` falls within this range (in the plan's time zone). */
@@ -678,12 +677,10 @@ export function getReadingCalendar(
     return entries; // never reads — cannot schedule (avoids an infinite loop)
   }
 
-  const zone = progress.timeZone ?? undefined;
-  const start = DateTime.fromMillis(progress.startedAtMs, { zone }).startOf(
-    "day"
-  );
-  const today = DateTime.fromMillis(nowMs, { zone }).startOf("day");
-  const todayOffset = Math.round(today.diff(start, "days").days);
+  const zone = progress.timeZone;
+  const start = civilDateInZone(progress.startedAtMs, zone);
+  const today = civilDateInZone(nowMs, zone);
+  const todayOffset = civilDaysBetween(start, today);
 
   const progressBySession = new Map(
     progress.sessions.map((s) => [s.sessionId, s])
@@ -699,8 +696,8 @@ export function getReadingCalendar(
     }
     entries.push({
       type: "skip",
-      startDate: start.plus({ days: pendingSkipStart }),
-      endDate: start.plus({ days: endExclusive - 1 }),
+      startDate: addCivilDays(start, pendingSkipStart),
+      endDate: addCivilDays(start, endExclusive - 1),
       startDayOffset: pendingSkipStart,
       days: endExclusive - pendingSkipStart,
       containsNow:
@@ -748,7 +745,7 @@ export function getReadingCalendar(
         : null;
       entries.push({
         type: "reading",
-        date: start.plus({ days: dayOffset }),
+        date: addCivilDays(start, dayOffset),
         dayOffset,
         sessions,
         startSessionIndex,

--- a/packages/seed-bible/seed-bible/managers/SearchManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SearchManager.tsx
@@ -1,4 +1,6 @@
-import * as Typesense from "typesense";
+// Type-only: erased at build time, so it costs nothing in the bundle. The
+// runtime client is loaded on demand in `getClient` below.
+import type * as Typesense from "typesense";
 import * as z from "zod/v4";
 import type { TranslationBook } from "./FreeUseBibleAPI";
 
@@ -215,16 +217,29 @@ export function createSearchManager(): SearchManager {
     };
   }
 
-  const client = new Typesense.Client({
-    apiKey: TYPESENSE_API_KEY,
-    nodes: [
-      {
-        host: TYPESENSE_NODE_URL.hostname,
-        port: Number(TYPESENSE_NODE_URL.port || 443),
-        protocol: TYPESENSE_NODE_URL.protocol.replace(":", ""),
-      },
-    ],
-  });
+  // Typesense (and the copy of axios it brings with it) is ~150 KB, and nobody
+  // needs it until they run their first search — so it is fetched then rather
+  // than at boot. The promise is cached, so the chunk is downloaded once and
+  // every later search reuses the same client.
+  let clientPromise: Promise<Typesense.Client> | null = null;
+  const getClient = (): Promise<Typesense.Client> => {
+    if (!clientPromise) {
+      clientPromise = import("typesense").then(
+        (Typesense) =>
+          new Typesense.Client({
+            apiKey: TYPESENSE_API_KEY,
+            nodes: [
+              {
+                host: TYPESENSE_NODE_URL.hostname,
+                port: Number(TYPESENSE_NODE_URL.port || 443),
+                protocol: TYPESENSE_NODE_URL.protocol.replace(":", ""),
+              },
+            ],
+          })
+      );
+    }
+    return clientPromise;
+  };
 
   const searchVerses = async (
     language: string,
@@ -235,6 +250,7 @@ export function createSearchManager(): SearchManager {
     const filterBy = buildVerseFilterBy(translationId, filters);
 
     const collection = `${VERSE_COLLECTION_PREFIX}.${language}`;
+    const client = await getClient();
     return await client
       .collections<VerseSearchDocument>(collection)
       .documents()

--- a/packages/seed-bible/seed-bible/managers/civilDate.ts
+++ b/packages/seed-bible/seed-bible/managers/civilDate.ts
@@ -1,0 +1,127 @@
+/**
+ * Calendar-date arithmetic that is correct across time zones and daylight
+ * saving, without pulling a date library into the bundle.
+ *
+ * The trick is to never do arithmetic on instants. "Three days after the plan
+ * started" is a question about a wall calendar, and calendars have no DST — the
+ * day after March 8th is March 9th whether or not the clocks moved overnight.
+ * So we resolve an instant to the calendar date a person in some time zone
+ * would see (`civilDateInZone`), do all the adding and subtracting on that
+ * date, and never convert back. Doing the same thing with milliseconds would
+ * drift by an hour twice a year.
+ */
+
+/** A date on the wall calendar, with no time and no time zone attached. */
+export interface CivilDate {
+  /** Full year, e.g. 2026. */
+  year: number;
+  /** Month of the year, 1-12. */
+  month: number;
+  /** Day of the month, 1-31. */
+  day: number;
+}
+
+const MS_PER_DAY = 86_400_000;
+
+/**
+ * `Intl.DateTimeFormat` construction is comparatively expensive and these are
+ * immutable, so one is kept per time zone.
+ */
+const formatterCache = new Map<string, Intl.DateTimeFormat>();
+
+function getFormatter(timeZone: string | undefined): Intl.DateTimeFormat {
+  const key = timeZone ?? "";
+  let formatter = formatterCache.get(key);
+  if (!formatter) {
+    formatter = new Intl.DateTimeFormat("en-US", {
+      // `undefined` means "the machine's zone", matching the previous
+      // behaviour when a reading plan has no time zone recorded.
+      timeZone,
+      year: "numeric",
+      month: "2-digit",
+      day: "2-digit",
+      era: "narrow",
+    });
+    formatterCache.set(key, formatter);
+  }
+  return formatter;
+}
+
+/** The calendar date someone in `timeZone` sees at the instant `ms`. */
+export function civilDateInZone(
+  ms: number,
+  timeZone?: string | null
+): CivilDate {
+  const parts = getFormatter(timeZone ?? undefined).formatToParts(new Date(ms));
+  let year = 0;
+  let month = 1;
+  let day = 1;
+  let isBce = false;
+  for (const part of parts) {
+    if (part.type === "year") {
+      year = Number(part.value);
+    } else if (part.type === "month") {
+      month = Number(part.value);
+    } else if (part.type === "day") {
+      day = Number(part.value);
+    } else if (part.type === "era") {
+      // Intl reports year 1 BCE as "1 B", not 0, so the era is needed to map
+      // back onto the proleptic numbering the rest of this module uses.
+      isBce = part.value.startsWith("B");
+    }
+  }
+  return { year: isBce ? 1 - year : year, month, day };
+}
+
+/**
+ * The UTC instant of midnight on `date`. Only used as a stable integer
+ * representation for day arithmetic — it is deliberately *not* the real
+ * instant that day began in any particular zone.
+ */
+function utcMidnightMs(date: CivilDate): number {
+  const ms = Date.UTC(date.year, date.month - 1, date.day);
+  if (date.year >= 0 && date.year < 100) {
+    // `Date.UTC` maps two-digit years into 1900-1999; undo that.
+    const corrected = new Date(ms);
+    corrected.setUTCFullYear(date.year);
+    return corrected.getTime();
+  }
+  return ms;
+}
+
+/**
+ * A date as a count of days since 1970-01-01. UTC has no daylight saving, so
+ * this is exact integer arithmetic and round-trips through `dayNumberToCivil`.
+ */
+export function civilToDayNumber(date: CivilDate): number {
+  return Math.round(utcMidnightMs(date) / MS_PER_DAY);
+}
+
+/** Inverse of {@link civilToDayNumber}. */
+export function dayNumberToCivil(dayNumber: number): CivilDate {
+  const date = new Date(dayNumber * MS_PER_DAY);
+  return {
+    year: date.getUTCFullYear(),
+    month: date.getUTCMonth() + 1,
+    day: date.getUTCDate(),
+  };
+}
+
+/** `date` moved forward (or back, for a negative `days`) on the calendar. */
+export function addCivilDays(date: CivilDate, days: number): CivilDate {
+  return dayNumberToCivil(civilToDayNumber(date) + days);
+}
+
+/** Whole days from `from` to `to`; negative when `to` is earlier. */
+export function civilDaysBetween(from: CivilDate, to: CivilDate): number {
+  return civilToDayNumber(to) - civilToDayNumber(from);
+}
+
+/** The date as `YYYY-MM-DD`, for display, keys, and test assertions. */
+export function civilDateToISO(date: CivilDate): string {
+  const year =
+    date.year < 0
+      ? `-${String(-date.year).padStart(6, "0")}`
+      : String(date.year).padStart(4, "0");
+  return `${year}-${String(date.month).padStart(2, "0")}-${String(date.day).padStart(2, "0")}`;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,12 +102,13 @@ catalogs:
     uuid:
       specifier: ^13.0.0
       version: 13.0.0
-    zod:
-      specifier: 4.4.3
-      version: 4.4.3
 
 overrides:
   prosemirror-model: 1.25.9
+  prosemirror-transform: 1.12.0
+  prosemirror-view: 1.42.0
+  zod: 4.4.3
+  chromium-bidi>zod: 3.25.76
 
 patchedDependencies:
   '@casual-simulation/aux-records': b5692a44748c9e7178367491286fa1eec21fb9786bd18d1369173e6ef587011e
@@ -142,9 +143,6 @@ importers:
       imagetracerjs:
         specifier: ^1.2.6
         version: 1.2.6
-      luxon:
-        specifier: 'catalog:'
-        version: 3.7.2
       opentype.js:
         specifier: ^1.3.4
         version: 1.3.4
@@ -164,7 +162,7 @@ importers:
         specifier: 'catalog:'
         version: 3.0.5(@babel/runtime@7.29.2)
       zod:
-        specifier: 'catalog:'
+        specifier: 4.4.3
         version: 4.4.3
     devDependencies:
       '@babel/core':
@@ -485,9 +483,6 @@ importers:
       i18next:
         specifier: 'catalog:'
         version: 26.2.0(typescript@6.0.3)
-      luxon:
-        specifier: 'catalog:'
-        version: 3.7.2
       preact:
         specifier: 'catalog:'
         version: 10.29.2
@@ -510,7 +505,7 @@ importers:
         specifier: 'catalog:'
         version: 3.0.5(@babel/runtime@7.29.2)
       zod:
-        specifier: 'catalog:'
+        specifier: 4.4.3
         version: 4.4.3
 
   packages/seed-bible-refresh-example-extension:
@@ -612,7 +607,7 @@ packages:
     resolution: {integrity: sha512-l653JFC83wCglH8H83t1xpgDurCyPyslYW1maPRdCsfuNuGbLvQjQ81sWd3Go3LWRm0jNspzAhuqAYV8r9joSw==}
     hasBin: true
     peerDependencies:
-      zod: ^3.25.0 || ^4.0.0
+      zod: 4.4.3
     peerDependenciesMeta:
       zod:
         optional: true
@@ -5786,7 +5781,7 @@ packages:
     hasBin: true
     peerDependencies:
       ws: ^8.18.0
-      zod: ^3.23.8
+      zod: 4.4.3
     peerDependenciesMeta:
       ws:
         optional: true
@@ -6037,14 +6032,8 @@ packages:
   prosemirror-tables@1.8.5:
     resolution: {integrity: sha512-V/0cDCsHKHe/tfWkeCmthNUcEp1IVO3p6vwN8XtwE9PZQLAZJigbw3QoraAdfJPir4NKJtNvOB8oYGKRl+t0Dw==}
 
-  prosemirror-transform@1.11.0:
-    resolution: {integrity: sha512-4I7Ce4KpygXb9bkiPS3hTEk4dSHorfRw8uI0pE8IhxlK2GXsqv5tIA7JUSxtSu7u8APVOTtbUBxTmnHIxVkIJw==}
-
   prosemirror-transform@1.12.0:
     resolution: {integrity: sha512-GxboyN4AMIsoHNtz5uf2r2Ru551i5hWeCMD6E2Ib4Eogqoub0NflniaBPVQ4MrGE5yZ8JV9tUHg9qcZTTrcN4w==}
-
-  prosemirror-view@1.41.5:
-    resolution: {integrity: sha512-UDQbIPnDrjE8tqUBbPmCOZgtd75htE6W3r0JCmY9bL6W1iemDM37MZEKC49d+tdQ0v/CKx4gjxLoLsfkD2NiZA==}
 
   prosemirror-view@1.42.0:
     resolution: {integrity: sha512-N54DF3OXNWDuP81G1kbfCys8ZzIjuL1VnvJ2mk5STSu/fNxWIcX/EutQLA3s9KR/2wVhgDi4hzBB/1fINVxk0A==}
@@ -7221,19 +7210,16 @@ packages:
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
-  zod@4.1.12:
-    resolution: {integrity: sha512-JInaHOamG8pt5+Ey8kGmdcAcg3OL9reK8ltczgHTAwNhMys/6ThXHityHxVV2p3fkw/c+MAvBHFVYHFZDmjMCQ==}
-
   zod@4.4.3:
     resolution: {integrity: sha512-ytENFjIJFl2UwYglde2jchW2Hwm4GJFLDiSXWdTrJQBIN9Fcyp7n4DhxJEiWNAJMV1/BqWfW/kkg71UDcHJyTQ==}
 
 snapshots:
 
-  '@anthropic-ai/sdk@0.92.0(zod@4.1.12)':
+  '@anthropic-ai/sdk@0.92.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
     optionalDependencies:
-      zod: 4.1.12
+      zod: 4.4.3
 
   '@apideck/better-ajv-errors@0.3.7(ajv@8.17.1)':
     dependencies:
@@ -8355,11 +8341,11 @@ snapshots:
       three: 0.182.0
       uuid: 10.0.0
       yjs: 13.6.8
-      zod: 4.1.12
+      zod: 4.4.3
 
   '@casual-simulation/aux-records@4.2.4(patch_hash=b5692a44748c9e7178367491286fa1eec21fb9786bd18d1369173e6ef587011e)(@babel/runtime@7.29.2)(ws@8.19.0)':
     dependencies:
-      '@anthropic-ai/sdk': 0.92.0(zod@4.1.12)
+      '@anthropic-ai/sdk': 0.92.0(zod@4.4.3)
       '@casual-simulation/aux-common': 4.2.3
       '@casual-simulation/crypto': 4.0.5
       '@casual-simulation/fast-json-stable-stringify': 4.0.5(patch_hash=a37823e251d7d3ba40f212da3583baff724ac2bdaa83c3412dff9e0e5ec113ef)
@@ -8381,7 +8367,7 @@ snapshots:
       livekit-server-sdk: 2.7.2
       luxon: 3.4.4
       mime: 2.4.6
-      openai: 4.89.0(ws@8.19.0)(zod@4.1.12)
+      openai: 4.89.0(ws@8.19.0)(zod@4.4.3)
       openid-client: 5.6.1
       preact: 10.28.4
       preact-render-to-string: 6.6.3(preact@10.28.4)
@@ -8390,7 +8376,7 @@ snapshots:
       typesense: 3.0.5(@babel/runtime@7.29.2)
       uuid: 10.0.0
       yjs: 13.6.8
-      zod: 4.1.12
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@babel/runtime'
       - bufferutil
@@ -10975,7 +10961,7 @@ snapshots:
       simple-git: 3.30.0
       tweetnacl: 1.0.3
       uuid: 10.0.0
-      zod: 4.1.12
+      zod: 4.4.3
     transitivePeerDependencies:
       - '@babel/runtime'
       - bufferutil
@@ -13199,7 +13185,7 @@ snapshots:
       is-inside-container: 1.0.0
       is-wsl: 3.1.0
 
-  openai@4.89.0(ws@8.19.0)(zod@4.1.12):
+  openai@4.89.0(ws@8.19.0)(zod@4.4.3):
     dependencies:
       '@types/node': 18.19.130
       '@types/node-fetch': 2.6.13
@@ -13210,7 +13196,7 @@ snapshots:
       node-fetch: 2.7.0
     optionalDependencies:
       ws: 8.19.0
-      zod: 4.1.12
+      zod: 4.4.3
     transitivePeerDependencies:
       - encoding
 
@@ -13419,38 +13405,38 @@ snapshots:
 
   prosemirror-changeset@2.3.1:
     dependencies:
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
 
   prosemirror-commands@1.7.1:
     dependencies:
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
 
   prosemirror-dropcursor@1.8.2:
     dependencies:
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
-      prosemirror-view: 1.41.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.0
 
   prosemirror-gapcursor@1.4.0:
     dependencies:
       prosemirror-keymap: 1.2.3
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
-      prosemirror-view: 1.41.5
+      prosemirror-view: 1.42.0
 
   prosemirror-history@1.5.0:
     dependencies:
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
-      prosemirror-view: 1.41.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.0
       rope-sequence: 1.3.4
 
   prosemirror-inputrules@1.5.1:
     dependencies:
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
 
   prosemirror-keymap@1.2.3:
     dependencies:
@@ -13465,41 +13451,31 @@ snapshots:
     dependencies:
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
 
   prosemirror-state@1.4.4:
     dependencies:
       prosemirror-model: 1.25.9
-      prosemirror-transform: 1.11.0
-      prosemirror-view: 1.41.5
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.0
 
   prosemirror-tables@1.8.5:
     dependencies:
       prosemirror-keymap: 1.2.3
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
-      prosemirror-view: 1.41.5
-
-  prosemirror-transform@1.11.0:
-    dependencies:
-      prosemirror-model: 1.25.9
+      prosemirror-transform: 1.12.0
+      prosemirror-view: 1.42.0
 
   prosemirror-transform@1.12.0:
     dependencies:
       prosemirror-model: 1.25.9
 
-  prosemirror-view@1.41.5:
-    dependencies:
-      prosemirror-model: 1.25.9
-      prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
-
   prosemirror-view@1.42.0:
     dependencies:
       prosemirror-model: 1.25.9
       prosemirror-state: 1.4.4
-      prosemirror-transform: 1.11.0
+      prosemirror-transform: 1.12.0
 
   proto3-json-serializer@3.0.4:
     dependencies:
@@ -14863,7 +14839,5 @@ snapshots:
   zimmerframe@1.1.4: {}
 
   zod@3.25.76: {}
-
-  zod@4.1.12: {}
 
   zod@4.4.3: {}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -63,5 +63,22 @@ catalog:
   "@tiptap/extension-underline": "3.27.1"
   "@tiptap/starter-kit": "3.27.1"
   "prosemirror-model": "1.25.9"
+  "prosemirror-transform": "1.12.0"
+  "prosemirror-view": "1.42.0"
+# The prosemirror packages and zod each resolved to two versions, so the bundle
+# carried both copies (prosemirror-view alone cost 94 KB twice over). Vite's
+# `resolve.dedupe` cannot fix this: it resolves to the copy in the project root
+# `node_modules`, and pnpm does not hoist transitive dependencies there. Pinning
+# via `overrides` is what actually collapses them.
 overrides:
   "prosemirror-model": "catalog:"
+  "prosemirror-transform": "catalog:"
+  "prosemirror-view": "catalog:"
+  # @casual-simulation/aux-common's @anthropic-ai/sdk pulled zod 4.1.12 next to
+  # the app's 4.4.3. Both are zod 4.x, so one copy serves both.
+  "zod": "catalog:"
+  # ...but chromium-bidi (via puppeteer, which `script/dev.ts` drives) is built
+  # against zod 3 and its internals are not compatible with zod 4. This more
+  # specific selector wins over the blanket override above and keeps the dev
+  # tooling on the version it expects. It never reaches the client bundle.
+  "chromium-bidi>zod": "3.25.76"

--- a/script/lib/extensionsModule.ts
+++ b/script/lib/extensionsModule.ts
@@ -1,0 +1,179 @@
+/**
+ * Source generation for the `virtual:@extensions` module family.
+ *
+ * Kept separate from the Vite plugin so it can be unit tested without running
+ * a build, the same split `precacheManifest.ts` uses.
+ */
+
+export interface ExtensionTranslationFile {
+  title: string;
+  description: string;
+  [key: string]: string;
+}
+
+export interface ExtensionMetaFile {
+  id: string;
+  translations: Record<string, ExtensionTranslationFile>;
+  dependencies?: string[];
+  autoinstall?: boolean;
+}
+
+/** An extension package discovered under `packages/`, with its parsed meta. */
+export interface DiscoveredExtension {
+  /** The directory name under `packages/`, used to build import specifiers. */
+  folder: string;
+  meta: ExtensionMetaFile;
+}
+
+export const VIRTUAL_ID = "virtual:@extensions";
+export const RESOLVED_ID = "\0" + VIRTUAL_ID;
+
+/** `virtual:@extensions/locale/es` → one chunk of list strings for Spanish. */
+export const LOCALE_VIRTUAL_PREFIX = "virtual:@extensions/locale/";
+export const RESOLVED_LOCALE_PREFIX = "\0" + LOCALE_VIRTUAL_PREFIX;
+
+/**
+ * The language of a resolved locale-module id, or null if the id is not one.
+ * Only well-formed language subtags are accepted, so a stray id cannot make
+ * the plugin emit a module for it.
+ */
+export function parseLocaleModuleId(resolvedId: string): string | null {
+  if (!resolvedId.startsWith(RESOLVED_LOCALE_PREFIX)) {
+    return null;
+  }
+  const lang = resolvedId.slice(RESOLVED_LOCALE_PREFIX.length);
+  return /^[A-Za-z]{2,3}(-[A-Za-z0-9]+)*$/.test(lang) ? lang : null;
+}
+
+// U+2028/U+2029 are valid JSON string characters but, unescaped, are illegal
+// in JS string literals in some contexts — escape them before inlining.
+function toJsLiteral(value: unknown): string {
+  return JSON.stringify(value)
+    .replace(/\u2028/g, "\\u2028")
+    .replace(/\u2029/g, "\\u2029");
+}
+
+/**
+ * Every language any extension has strings for, sorted. Extensions do not all
+ * carry the same set, so this is a union rather than the first one's keys.
+ */
+export function listExtensionLanguages(
+  extensions: DiscoveredExtension[]
+): string[] {
+  const languages = new Set<string>();
+  for (const { meta } of extensions) {
+    for (const lang of Object.keys(meta.translations ?? {})) {
+      languages.add(lang);
+    }
+  }
+  return [...languages].sort();
+}
+
+/**
+ * The `title`/`description` every extension offers in one language — the only
+ * strings the Settings extensions list needs before anything is installed.
+ *
+ * This is its own module per language so a reader downloads one language's
+ * worth of list strings on demand instead of all of them at boot. Inlining
+ * every language cost 138 KB (72.5 KB gzipped) in the entry chunk.
+ *
+ * Extensions with no entry for the language are omitted rather than emitted as
+ * `undefined`, so the caller can register the result as-is.
+ */
+export function generateLocaleModuleSource(
+  extensions: DiscoveredExtension[],
+  language: string
+): string {
+  const entries: Record<string, { title: string; description: string }> = {};
+  for (const { meta } of extensions) {
+    const translation = meta.translations?.[language];
+    if (!translation) {
+      continue;
+    }
+    entries[meta.id] = {
+      title: translation.title,
+      description: translation.description,
+    };
+  }
+  return `export default ${toJsLiteral(entries)};\n`;
+}
+
+/** The English fallback baked into the entry chunk. */
+export const FALLBACK_LANGUAGE = "en";
+
+/**
+ * Reduces an extension's meta to what the boot path actually needs:
+ * `id`/`dependencies`/`autoinstall`, which resolve install order and
+ * auto-install eligibility, plus English `title`/`description`.
+ *
+ * English stays inline for two reasons: `ExtensionMeta` requires it (it is
+ * i18next's `fallbackLng`, so it is what renders when a language has no string
+ * of its own), and it means the extensions list shows real titles rather than
+ * raw ids in the moment before a locale chunk arrives. One language costs
+ * about 1.8 KB; it was all 77 of them that cost 138 KB.
+ *
+ * Every other language lives in the per-language modules above, and every key
+ * beyond `title`/`description` is behind `loadFullTranslations`.
+ */
+export function trimMeta(meta: ExtensionMetaFile): ExtensionMetaFile {
+  const english = meta.translations?.[FALLBACK_LANGUAGE];
+  return {
+    id: meta.id,
+    translations: {
+      // An extension.json with no English block is malformed, but failing the
+      // whole build over it helps nobody — degrade to the id.
+      [FALLBACK_LANGUAGE]: {
+        title: english?.title ?? meta.id,
+        description: english?.description ?? "",
+      },
+    },
+    ...(meta.dependencies ? { dependencies: meta.dependencies } : {}),
+    ...(meta.autoinstall !== undefined
+      ? { autoinstall: meta.autoinstall }
+      : {}),
+  };
+}
+
+/**
+ * The `virtual:@extensions` entry module: the `ExtensionSet` for the app.
+ *
+ * Each extension's code and full translations are `() => import(...)` thunks so
+ * Vite code-splits them, and `loadListTranslations` does the same per language.
+ */
+export function generateEntryModuleSource(
+  extensions: DiscoveredExtension[],
+  setId: string
+): string {
+  const entries = extensions
+    .map(
+      ({ folder, meta }) => `  {
+    meta: ${toJsLiteral(trimMeta(meta))},
+    loadFullTranslations: () => import("@packages/${folder}/extension.json").then((m) => m.default.translations),
+    import: () => import("@packages/${folder}/index"),
+  },`
+    )
+    .join("\n");
+
+  const localeEntries = listExtensionLanguages(extensions)
+    // English is already inline via `trimMeta`, so there is nothing to fetch
+    // for it — which is also the common case.
+    .filter((lang) => lang !== FALLBACK_LANGUAGE)
+    .map(
+      (lang) =>
+        `  ${toJsLiteral(lang)}: () => import(${toJsLiteral(
+          LOCALE_VIRTUAL_PREFIX + lang
+        )}).then((m) => m.default),`
+    )
+    .join("\n");
+
+  return `const extensions = [
+${entries}
+];
+
+const loadListTranslations = {
+${localeEntries}
+};
+
+export default { id: ${JSON.stringify(setId)}, extensions, loadListTranslations };
+`;
+}

--- a/script/lib/vite-plugin-extensions.ts
+++ b/script/lib/vite-plugin-extensions.ts
@@ -2,6 +2,16 @@ import type { Plugin, ViteDevServer } from "vite";
 import { readdir, readFile } from "node:fs/promises";
 import { existsSync } from "node:fs";
 import path from "node:path";
+import {
+  generateEntryModuleSource,
+  generateLocaleModuleSource,
+  parseLocaleModuleId,
+  LOCALE_VIRTUAL_PREFIX,
+  RESOLVED_ID,
+  VIRTUAL_ID,
+  type DiscoveredExtension,
+  type ExtensionMetaFile,
+} from "./extensionsModule";
 
 // Virtual module convention: `virtual:@extensions` resolves to a module whose
 // default export is the `ExtensionSet` for the app — auto-discovered from every
@@ -11,18 +21,21 @@ import path from "node:path";
 // `extension.json` at its root (the extension's `meta`). This matches every
 // extension and excludes the main `packages/seed-bible` app, which has none.
 //
-// The module is generated as source: the `meta` for each extension is inlined
-// as a JS literal, but trimmed down to just `title`/`description` per locale —
-// the only translations needed before an extension is installed (to render it
-// in the Settings extensions list). The full per-locale translations (every
-// other UI string the extension uses) and the extension's code are each
-// exposed as `() => import(...)` thunks, so Vite code-splits both into chunks
-// that are only fetched once the extension is actually installed.
+// The module is generated as source: each extension's `meta` is inlined as a JS
+// literal, trimmed to `id`/`dependencies`/`autoinstall` — what the boot path
+// needs to resolve install order. Its code and its full per-locale translations
+// are `() => import(...)` thunks, so Vite code-splits both into chunks fetched
+// only once the extension is installed.
 //
-// The `\0` prefix on the resolved id is the Rollup convention that tells other
-// plugins to leave the id alone.
-const VIRTUAL_ID = "virtual:@extensions";
-const RESOLVED_ID = "\0" + VIRTUAL_ID;
+// The `title`/`description` shown in the Settings extensions list live in a
+// second virtual module family, `virtual:@extensions/locale/<lang>`, one chunk
+// per language, reached through the set's `loadListTranslations` map. They used
+// to be inlined for all 77 languages, which cost 138 KB (72.5 KB gzipped) in
+// the entry chunk for strings a reader sees in one language, in one screen.
+//
+// The generation itself lives in `./extensionsModule` so it can be unit tested
+// without running a build. The `\0` prefix on resolved ids is the Rollup
+// convention that tells other plugins to leave the id alone.
 
 // Must match the `id` of the hand-written set this replaces.
 const EXTENSION_SET_ID = "seed-bible";
@@ -44,78 +57,20 @@ async function discoverExtensionFolders(): Promise<string[]> {
     .sort();
 }
 
-interface ExtensionTranslationFile {
-  title: string;
-  description: string;
-  [key: string]: string;
-}
-
-interface ExtensionMetaFile {
-  id: string;
-  translations: Record<string, ExtensionTranslationFile>;
-  dependencies?: string[];
-  autoinstall?: boolean;
-}
-
 async function readExtensionMeta(folder: string): Promise<ExtensionMetaFile> {
   const raw = await readFile(extensionJsonPath(folder), "utf-8");
   return JSON.parse(raw);
 }
 
-/**
- * Reduces an extension's meta to just what's needed before it's installed:
- * `title`/`description` per locale (for the Settings extensions list), plus
- * `id`/`dependencies`/`autoinstall` (needed to resolve install order and
- * auto-install eligibility). Every other translation key is dropped — it's
- * only available via the extension's `loadFullTranslations()` thunk.
- */
-function trimMeta(meta: ExtensionMetaFile): ExtensionMetaFile {
-  const translations: Record<string, ExtensionTranslationFile> = {};
-  for (const [lang, translation] of Object.entries(meta.translations)) {
-    translations[lang] = {
-      title: translation.title,
-      description: translation.description,
-    };
-  }
-
-  return {
-    id: meta.id,
-    translations,
-    ...(meta.dependencies ? { dependencies: meta.dependencies } : {}),
-    ...(meta.autoinstall !== undefined
-      ? { autoinstall: meta.autoinstall }
-      : {}),
-  };
-}
-
-// U+2028/U+2029 are valid JSON string characters but, unescaped, are illegal
-// in JS string literals in some contexts — escape them before inlining.
-function toJsLiteral(value: unknown): string {
-  return JSON.stringify(value)
-    .replace(/\u2028/g, "\\u2028")
-    .replace(/\u2029/g, "\\u2029");
-}
-
-async function generateModuleSource(folders: string[]): Promise<string> {
-  const metas = await Promise.all(folders.map(readExtensionMeta));
-
-  const entries = folders
-    .map((folder, i) => {
-      const trimmed = trimMeta(metas[i]!);
-      return `  {
-    meta: ${toJsLiteral(trimmed)},
-    loadFullTranslations: () => import("@packages/${folder}/extension.json").then((m) => m.default.translations),
-    import: () => import("@packages/${folder}/index"),
-  },`;
-    })
-    .join("\n");
-
-  return `const extensions = [
-${entries}
-];
-
-export default { id: ${JSON.stringify(EXTENSION_SET_ID)}, extensions };
-`;
+/** Every extension package under `packages/`, with its meta parsed. */
+async function discoverExtensions(): Promise<DiscoveredExtension[]> {
+  const folders = await discoverExtensionFolders();
+  return Promise.all(
+    folders.map(async (folder) => ({
+      folder,
+      meta: await readExtensionMeta(folder),
+    }))
+  );
 }
 
 /**
@@ -131,22 +86,29 @@ export function extensionsPlugin(): Plugin {
       if (id === VIRTUAL_ID) {
         return RESOLVED_ID;
       }
+      if (id.startsWith(LOCALE_VIRTUAL_PREFIX)) {
+        return "\0" + id;
+      }
       return null;
     },
 
     async load(id) {
-      if (id !== RESOLVED_ID) {
+      const isEntry = id === RESOLVED_ID;
+      const language = parseLocaleModuleId(id);
+      if (!isEntry && language === null) {
         return null;
       }
 
-      const folders = await discoverExtensionFolders();
+      const extensions = await discoverExtensions();
 
       // Reload the module if any extension's meta changes.
-      for (const folder of folders) {
+      for (const { folder } of extensions) {
         this.addWatchFile(extensionJsonPath(folder));
       }
 
-      return await generateModuleSource(folders);
+      return isEntry
+        ? generateEntryModuleSource(extensions, EXTENSION_SET_ID)
+        : generateLocaleModuleSource(extensions, language!);
     },
 
     configureServer(server: ViteDevServer) {
@@ -173,9 +135,15 @@ export function extensionsPlugin(): Plugin {
         }
         pending = setTimeout(() => {
           pending = undefined;
-          const mod = server.moduleGraph.getModuleById(RESOLVED_ID);
-          if (mod) {
-            server.moduleGraph.invalidateModule(mod);
+          // The per-locale modules are generated from the same metas, so
+          // invalidate them alongside the entry module.
+          for (const [moduleId, mod] of server.moduleGraph.idToModuleMap) {
+            if (
+              moduleId === RESOLVED_ID ||
+              parseLocaleModuleId(moduleId) !== null
+            ) {
+              server.moduleGraph.invalidateModule(mod);
+            }
           }
           server.config.logger.info("[extensions] extension set changed");
           server.ws.send({ type: "full-reload" });

--- a/script/lib/vite-plugin-extensions.ts
+++ b/script/lib/vite-plugin-extensions.ts
@@ -63,7 +63,7 @@ async function readExtensionMeta(folder: string): Promise<ExtensionMetaFile> {
 }
 
 /** Every extension package under `packages/`, with its meta parsed. */
-async function discoverExtensions(): Promise<DiscoveredExtension[]> {
+async function readExtensions(): Promise<DiscoveredExtension[]> {
   const folders = await discoverExtensionFolders();
   return Promise.all(
     folders.map(async (folder) => ({
@@ -71,6 +71,27 @@ async function discoverExtensions(): Promise<DiscoveredExtension[]> {
       meta: await readExtensionMeta(folder),
     }))
   );
+}
+
+// `load()` runs once for the entry module and once per language module, and
+// the entry module names one import per language — so a build asks for ~77
+// modules, each of which would otherwise re-`readdir` `packages/` and re-parse
+// every `extension.json`. The metas are identical across all of them, so the
+// first read is shared. Cleared by the dev-server watcher below when an
+// `extension.json` is added or removed.
+let cachedExtensions: Promise<DiscoveredExtension[]> | null = null;
+
+function discoverExtensions(): Promise<DiscoveredExtension[]> {
+  if (!cachedExtensions) {
+    // Cache the promise rather than the result so concurrent `load()` calls —
+    // which is how Rollup drives this — share one read instead of racing.
+    cachedExtensions = readExtensions().catch((err) => {
+      // Don't poison the cache with a failed read; let the next call retry.
+      cachedExtensions = null;
+      throw err;
+    });
+  }
+  return cachedExtensions;
 }
 
 /**
@@ -119,16 +140,31 @@ export function extensionsPlugin(): Plugin {
 
       let pending: NodeJS.Timeout | undefined;
 
-      const handle = (file: string) => {
+      /** True for a top-level `packages/<folder>/extension.json`. */
+      const isExtensionManifest = (file: string) => {
         if (path.basename(file) !== "extension.json") {
-          return;
+          return false;
         }
         const rel = path.relative(packagesDir, path.resolve(file));
-        // Only top-level `packages/<folder>/extension.json` (not nested ones).
         const segments = rel.split(/[\\/]/);
-        if (rel.startsWith("..") || segments.length !== 2) {
+        return !rel.startsWith("..") && segments.length === 2;
+      };
+
+      // A file's *contents* changing is already handled by the `addWatchFile`
+      // calls in `load()`, which make Vite re-run it — but that would now be
+      // served the cached metas, so the cache has to be dropped here too.
+      server.watcher.on("change", (file) => {
+        if (isExtensionManifest(file)) {
+          cachedExtensions = null;
+        }
+      });
+
+      const handle = (file: string) => {
+        if (!isExtensionManifest(file)) {
           return;
         }
+        // An added or removed package changes the discovered set itself.
+        cachedExtensions = null;
 
         if (pending) {
           clearTimeout(pending);

--- a/test/unit/script/lib/extensionsModule.test.ts
+++ b/test/unit/script/lib/extensionsModule.test.ts
@@ -1,0 +1,187 @@
+import { describe, expect, it } from "vitest";
+import {
+  generateEntryModuleSource,
+  generateLocaleModuleSource,
+  listExtensionLanguages,
+  parseLocaleModuleId,
+  trimMeta,
+  RESOLVED_LOCALE_PREFIX,
+  type DiscoveredExtension,
+} from "../../../../script/lib/extensionsModule";
+
+const apologist: DiscoveredExtension = {
+  folder: "apologist-extension",
+  meta: {
+    id: "ext_Apologist",
+    autoinstall: true,
+    translations: {
+      en: { title: "Apologist", description: "AI for seekers" },
+      es: { title: "Apologista", description: "IA para buscadores" },
+      // A key beyond title/description, to prove it is not inlined anywhere.
+      de: { title: "Apologet", description: "KI", "some-other-key": "nope" },
+    },
+  },
+};
+
+const bonfire: DiscoveredExtension = {
+  folder: "bonfire-extension",
+  meta: {
+    id: "ext_Bonfire",
+    dependencies: ["ext_Apologist"],
+    translations: {
+      en: { title: "Bonfire", description: "Gather round" },
+      // No Spanish, and a language no other extension has.
+      gn: { title: "Tata", description: "Ñembyaty" },
+    },
+  },
+};
+
+const extensions = [apologist, bonfire];
+
+describe("trimMeta", () => {
+  it("keeps only what the boot path needs", () => {
+    expect(trimMeta(apologist.meta)).toEqual({
+      id: "ext_Apologist",
+      // English stays inline as i18next's fallback; every other language is
+      // fetched per chunk.
+      translations: {
+        en: { title: "Apologist", description: "AI for seekers" },
+      },
+      autoinstall: true,
+    });
+    expect(trimMeta(bonfire.meta)).toEqual({
+      id: "ext_Bonfire",
+      translations: {
+        en: { title: "Bonfire", description: "Gather round" },
+      },
+      dependencies: ["ext_Apologist"],
+    });
+  });
+
+  it("omits dependencies and autoinstall when absent rather than emitting undefined", () => {
+    const trimmed = trimMeta({ id: "ext_X", translations: {} });
+    expect(Object.keys(trimmed).sort()).toEqual(["id", "translations"]);
+  });
+
+  it("degrades to the id when an extension has no English block", () => {
+    // Malformed extension.json, but failing the build over it helps nobody.
+    expect(trimMeta({ id: "ext_X", translations: {} }).translations).toEqual({
+      en: { title: "ext_X", description: "" },
+    });
+  });
+});
+
+describe("listExtensionLanguages", () => {
+  it("returns the union across extensions, sorted", () => {
+    // Extensions do not all carry the same languages: es is Apologist-only,
+    // gn is Bonfire-only.
+    expect(listExtensionLanguages(extensions)).toEqual([
+      "de",
+      "en",
+      "es",
+      "gn",
+    ]);
+  });
+
+  it("handles an extension with no translations", () => {
+    expect(
+      listExtensionLanguages([
+        { folder: "x", meta: { id: "ext_X", translations: {} } },
+      ])
+    ).toEqual([]);
+  });
+});
+
+describe("generateLocaleModuleSource", () => {
+  it("emits every extension's title and description for that language", () => {
+    const source = generateLocaleModuleSource(extensions, "en");
+    expect(source).toContain('"ext_Apologist"');
+    expect(source).toContain('"Apologist"');
+    expect(source).toContain('"ext_Bonfire"');
+    expect(source).toContain('"Gather round"');
+  });
+
+  it("omits extensions that have nothing for the language", () => {
+    // Bonfire has no Spanish; it must be absent, not present as undefined.
+    const source = generateLocaleModuleSource(extensions, "es");
+    expect(source).toContain('"ext_Apologist"');
+    expect(source).not.toContain("ext_Bonfire");
+    expect(source).not.toContain("undefined");
+  });
+
+  it("carries only title and description, not other translation keys", () => {
+    const source = generateLocaleModuleSource(extensions, "de");
+    expect(source).toContain('"Apologet"');
+    expect(source).not.toContain("some-other-key");
+  });
+
+  it("emits a valid empty module for an unknown language", () => {
+    expect(generateLocaleModuleSource(extensions, "zz")).toBe(
+      "export default {};\n"
+    );
+  });
+});
+
+describe("generateEntryModuleSource", () => {
+  const source = generateEntryModuleSource(extensions, "seed-bible");
+
+  it("inlines English only, not the other languages", () => {
+    // This is the regression that mattered: all 77 languages used to ship in
+    // the entry chunk, at 138 KB (72.5 KB gzipped). English alone is ~1.8 KB
+    // and earns its place as the i18next fallback.
+    expect(source).toContain("AI for seekers");
+    expect(source).toContain("Gather round");
+    expect(source).not.toContain("Apologista");
+    expect(source).not.toContain("Apologet");
+    expect(source).not.toContain("Tata");
+  });
+
+  it("keeps the ids, dependencies and autoinstall flags the boot path needs", () => {
+    expect(source).toContain('"id":"ext_Apologist"');
+    expect(source).toContain('"autoinstall":true');
+    expect(source).toContain('"dependencies":["ext_Apologist"]');
+  });
+
+  it("exposes one lazy loader per language except the inlined English", () => {
+    for (const lang of ["de", "es", "gn"]) {
+      expect(source).toContain(
+        `"${lang}": () => import("virtual:@extensions/locale/${lang}")`
+      );
+    }
+    // Nothing to fetch for English — it is already in this chunk.
+    expect(source).not.toContain('"en": () => import(');
+  });
+
+  it("defers each extension's code and full translations to dynamic imports", () => {
+    expect(source).toContain(
+      'import("@packages/apologist-extension/extension.json")'
+    );
+    expect(source).toContain('import("@packages/bonfire-extension/index")');
+  });
+
+  it("names the set", () => {
+    expect(source).toContain('id: "seed-bible"');
+  });
+});
+
+describe("parseLocaleModuleId", () => {
+  it("extracts the language from a resolved locale id", () => {
+    expect(parseLocaleModuleId(`${RESOLVED_LOCALE_PREFIX}es`)).toBe("es");
+    expect(parseLocaleModuleId(`${RESOLVED_LOCALE_PREFIX}fil`)).toBe("fil");
+    expect(parseLocaleModuleId(`${RESOLVED_LOCALE_PREFIX}pt-BR`)).toBe("pt-BR");
+  });
+
+  it("ignores ids belonging to other modules", () => {
+    expect(parseLocaleModuleId("\0virtual:@extensions")).toBeNull();
+    expect(parseLocaleModuleId("/src/main.tsx")).toBeNull();
+  });
+
+  it("rejects malformed language subtags", () => {
+    // Guards against a stray id making the plugin emit a module for it.
+    expect(
+      parseLocaleModuleId(`${RESOLVED_LOCALE_PREFIX}../secret`)
+    ).toBeNull();
+    expect(parseLocaleModuleId(`${RESOLVED_LOCALE_PREFIX}`)).toBeNull();
+    expect(parseLocaleModuleId(`${RESOLVED_LOCALE_PREFIX}toolong`)).toBeNull();
+  });
+});

--- a/test/unit/seed-bible/app/utils.test.ts
+++ b/test/unit/seed-bible/app/utils.test.ts
@@ -1,0 +1,144 @@
+import { describe, expect, it } from "vitest";
+import { formatRelativeTime } from "@packages/seed-bible/seed-bible/app/utils";
+
+const NOW = Date.UTC(2026, 5, 17, 12, 0, 0); // 2026-06-17 12:00 UTC
+const SECOND = 1_000;
+const MINUTE = 60 * SECOND;
+const HOUR = 60 * MINUTE;
+const DAY = 24 * HOUR;
+
+describe("formatRelativeTime", () => {
+  it("picks the largest unit the gap fills at least once", () => {
+    expect(formatRelativeTime(NOW - 30 * SECOND, "en", NOW)).toBe(
+      "30 seconds ago"
+    );
+    expect(formatRelativeTime(NOW - 5 * MINUTE, "en", NOW)).toBe(
+      "5 minutes ago"
+    );
+    expect(formatRelativeTime(NOW - 3 * HOUR, "en", NOW)).toBe("3 hours ago");
+    expect(formatRelativeTime(NOW - 4 * DAY, "en", NOW)).toBe("4 days ago");
+  });
+
+  it("truncates toward zero rather than rounding up", () => {
+    // 90 minutes is an hour and a half, and reads as one hour — not two.
+    expect(formatRelativeTime(NOW - 90 * MINUTE, "en", NOW)).toBe("1 hour ago");
+    expect(formatRelativeTime(NOW - 59 * SECOND, "en", NOW)).toBe(
+      "59 seconds ago"
+    );
+  });
+
+  it("handles future instants", () => {
+    expect(formatRelativeTime(NOW + 2 * HOUR, "en", NOW)).toBe("in 2 hours");
+    expect(formatRelativeTime(NOW + 10 * DAY, "en", NOW)).toBe("in 10 days");
+  });
+
+  it("counts months and years on the calendar", () => {
+    // 2026-05-17 is exactly one month back; a day later is not yet a month.
+    expect(formatRelativeTime(Date.UTC(2026, 4, 17, 12), "en", NOW)).toBe(
+      "1 month ago"
+    );
+    expect(formatRelativeTime(Date.UTC(2026, 4, 18, 12), "en", NOW)).toBe(
+      "30 days ago"
+    );
+    expect(formatRelativeTime(Date.UTC(2025, 5, 17, 12), "en", NOW)).toBe(
+      "1 year ago"
+    );
+    expect(formatRelativeTime(Date.UTC(2024, 0, 1, 12), "en", NOW)).toBe(
+      "2 years ago"
+    );
+  });
+
+  it("clamps to the month end when the start day is missing from it", () => {
+    // February has no 31st, so "a month after Jan 31" is Feb 28 — the gap
+    // reads as a whole month even though it is only 28 days.
+    expect(
+      formatRelativeTime(
+        Date.UTC(2026, 0, 31, 12),
+        "en",
+        Date.UTC(2026, 1, 28, 12)
+      )
+    ).toBe("1 month ago");
+    expect(
+      formatRelativeTime(
+        Date.UTC(2026, 2, 31, 12),
+        "en",
+        Date.UTC(2026, 3, 30, 12)
+      )
+    ).toBe("1 month ago");
+    expect(
+      formatRelativeTime(
+        Date.UTC(2026, 0, 31, 12),
+        "en",
+        Date.UTC(2026, 3, 30, 12)
+      )
+    ).toBe("3 months ago");
+  });
+
+  it("clamps the same way for future instants", () => {
+    // The month count is measured from the earlier instant forward, so the
+    // direction must not change the answer — only its sign.
+    expect(
+      formatRelativeTime(
+        Date.UTC(2026, 1, 28, 12),
+        "en",
+        Date.UTC(2026, 0, 31, 12)
+      )
+    ).toBe("in 1 month");
+    expect(
+      formatRelativeTime(
+        Date.UTC(2026, 3, 30, 12),
+        "en",
+        Date.UTC(2026, 2, 31, 12)
+      )
+    ).toBe("in 1 month");
+  });
+
+  it("does not over-apply the clamp within a single month", () => {
+    // Jan 1 to Jan 31 is 30 days, not a month — the clamp must not turn a
+    // same-month gap into one.
+    expect(
+      formatRelativeTime(
+        Date.UTC(2026, 0, 1, 12),
+        "en",
+        Date.UTC(2026, 0, 31, 12)
+      )
+    ).toBe("30 days ago");
+    // One day short of a full month still reads in days.
+    expect(
+      formatRelativeTime(
+        Date.UTC(2026, 0, 15, 12),
+        "en",
+        Date.UTC(2026, 1, 14, 12)
+      )
+    ).toBe("30 days ago");
+  });
+
+  it("reports no elapsed time as zero seconds", () => {
+    expect(formatRelativeTime(NOW, "en", NOW)).toBe("in 0 seconds");
+  });
+
+  it("renders in the requested locale", () => {
+    expect(formatRelativeTime(NOW - 3 * DAY, "es", NOW)).toBe("hace 3 días");
+    expect(formatRelativeTime(NOW + 3 * DAY, "de", NOW)).toBe("in 3 Tagen");
+  });
+
+  it("falls back to a related locale where CLDR has no data", () => {
+    // The app translates Guaraní, but CLDR carries no relative-time data for
+    // it, so Intl would silently render English inside an otherwise Guaraní
+    // UI. Spanish is co-official with Guaraní in Paraguay.
+    expect(formatRelativeTime(NOW - 3 * DAY, "gn", NOW)).toBe("hace 3 días");
+    expect(formatRelativeTime(NOW + 2 * HOUR, "gn", NOW)).toBe(
+      "dentro de 2 horas"
+    );
+  });
+
+  it("leaves supported locales untouched by the fallback table", () => {
+    expect(formatRelativeTime(NOW - 3 * DAY, "en", NOW)).toBe("3 days ago");
+    expect(formatRelativeTime(NOW - 3 * DAY, "es", NOW)).toBe("hace 3 días");
+    // A locale with no data and no mapping still degrades to English rather
+    // than throwing.
+    expect(formatRelativeTime(NOW - 3 * DAY, "zu", NOW)).toEqual(
+      expect.any(String)
+    );
+  });
+});

--- a/test/unit/seed-bible/managers/ExtensionManager.test.ts
+++ b/test/unit/seed-bible/managers/ExtensionManager.test.ts
@@ -708,6 +708,47 @@ describe("createExtensionManager", () => {
     });
   });
 
+  it("fetches nothing and registers no listener during SSR", async () => {
+    // `createExtensionManager` runs once per SSR request, while `i18n` is the
+    // process-wide i18next singleton — so a listener registered here would
+    // accumulate for the life of the server process. The Settings list is
+    // never server-rendered and English is inline, so there is nothing to lose
+    // by sitting this out on the server.
+    const loadEn = vi.fn().mockResolvedValue({
+      "ext.listed": { title: "Listed", description: "A listed extension" },
+    });
+    const set: ExtensionSet = {
+      id: "set.ssr",
+      extensions: [
+        {
+          url: "pkg://listed",
+          meta: {
+            id: "ext.listed",
+            translations: { en: { title: "Listed", description: "" } },
+          },
+        },
+      ],
+      loadListTranslations: { en: loadEn },
+    };
+
+    try {
+      import.meta.env.SSR = true;
+      const manager = createExtensionManager(login);
+      await manager.loadExtensionSet(set, () => false);
+
+      expect(loadEn).not.toHaveBeenCalled();
+      expect(i18nListeners.get("languageChanged") ?? []).toHaveLength(0);
+    } finally {
+      delete import.meta.env.SSR;
+    }
+  });
+
+  it("registers exactly one listener per manager on the client", () => {
+    // Guards the other side of the SSR check: the client still needs it.
+    createExtensionManager(login);
+    expect(i18nListeners.get("languageChanged") ?? []).toHaveLength(1);
+  });
+
   it("still uses meta.translations for sets without loadListTranslations", async () => {
     const manager = createExtensionManager(login);
     const translations = {

--- a/test/unit/seed-bible/managers/ExtensionManager.test.ts
+++ b/test/unit/seed-bible/managers/ExtensionManager.test.ts
@@ -5,8 +5,31 @@ import type {
 } from "@packages/seed-bible/seed-bible/managers/LoginManager";
 import { signal } from "@preact/signals";
 
+// A minimal stand-in for the i18next instance: the manager only reads the
+// active language and subscribes to changes. `emitLanguageChanged` lets a test
+// drive a language switch without booting real i18next.
+const i18nListeners = new Map<string, ((lng: string) => void)[]>();
+const i18nStub = {
+  language: "en",
+  on(event: string, handler: (lng: string) => void) {
+    const handlers = i18nListeners.get(event) ?? [];
+    handlers.push(handler);
+    i18nListeners.set(event, handlers);
+  },
+};
+
+function emitLanguageChanged(language: string) {
+  i18nStub.language = language;
+  for (const handler of i18nListeners.get("languageChanged") ?? []) {
+    handler(language);
+  }
+}
+
 vi.mock("@packages/seed-bible/seed-bible/i18n/I18nManager", () => ({
   addTranslations: vi.fn(),
+  get i18n() {
+    return i18nStub;
+  },
 }));
 
 import {
@@ -399,6 +422,10 @@ describe("createExtensionManager", () => {
     >("@packages/seed-bible/seed-bible/i18n/I18nManager");
     addTranslationsMock = addTranslations as Mock;
     addTranslationsMock.mockReset();
+    // The i18n stub is module-level, so a test that switches language would
+    // otherwise leak that language into the next one.
+    i18nStub.language = "en";
+    i18nListeners.clear();
   });
 
   it("loadExtensionSet() installs dependencies before dependents", async () => {
@@ -609,6 +636,125 @@ describe("createExtensionManager", () => {
       "ext.translation-b",
       translationsB
     );
+  });
+
+  it("loadExtensionSet() fetches only the active language's list translations", async () => {
+    const manager = createExtensionManager(login);
+    const loadEn = vi.fn().mockResolvedValue({
+      "ext.listed": { title: "Listed", description: "A listed extension" },
+    });
+    const loadEs = vi.fn().mockResolvedValue({
+      "ext.listed": { title: "Listada", description: "Una extensión" },
+    });
+
+    // The bundled set ships empty meta.translations and defers the list
+    // strings to one chunk per language.
+    const set: ExtensionSet = {
+      id: "set.list-translations",
+      extensions: [
+        {
+          url: "pkg://listed",
+          meta: {
+            id: "ext.listed",
+            // The bundled set inlines English and defers the rest.
+            translations: { en: { title: "Listed", description: "" } },
+          },
+        },
+      ],
+      loadListTranslations: { en: loadEn, es: loadEs },
+    };
+
+    await manager.loadExtensionSet(set, () => false);
+    await vi.waitFor(() => expect(loadEn).toHaveBeenCalled());
+
+    // Only English is fetched — this is the whole point of the split.
+    expect(loadEs).not.toHaveBeenCalled();
+    expect(addTranslationsMock).toHaveBeenCalledWith("ext.listed", {
+      en: { title: "Listed", description: "A listed extension" },
+    });
+  });
+
+  it("fetches the new language's list translations when the language changes", async () => {
+    const manager = createExtensionManager(login);
+    const loadEs = vi.fn().mockResolvedValue({
+      "ext.listed": { title: "Listada", description: "Una extensión" },
+    });
+    const set: ExtensionSet = {
+      id: "set.language-change",
+      extensions: [
+        {
+          url: "pkg://listed",
+          meta: {
+            id: "ext.listed",
+            // The bundled set inlines English and defers the rest.
+            translations: { en: { title: "Listed", description: "" } },
+          },
+        },
+      ],
+      loadListTranslations: {
+        en: vi.fn().mockResolvedValue({}),
+        es: loadEs,
+      },
+    };
+
+    await manager.loadExtensionSet(set, () => false);
+    addTranslationsMock.mockClear();
+
+    emitLanguageChanged("es");
+    await vi.waitFor(() => expect(loadEs).toHaveBeenCalled());
+
+    expect(addTranslationsMock).toHaveBeenCalledWith("ext.listed", {
+      es: { title: "Listada", description: "Una extensión" },
+    });
+  });
+
+  it("still uses meta.translations for sets without loadListTranslations", async () => {
+    const manager = createExtensionManager(login);
+    const translations = {
+      en: { title: "Inline", description: "Ships its own strings" },
+    };
+    const set: ExtensionSet = {
+      id: "set.inline",
+      extensions: [
+        { url: "pkg://inline", meta: { id: "ext.inline", translations } },
+      ],
+    };
+
+    await manager.loadExtensionSet(set, () => false);
+
+    expect(addTranslationsMock).toHaveBeenCalledWith(
+      "ext.inline",
+      translations
+    );
+  });
+
+  it("survives a list-translation chunk that fails to load", async () => {
+    const manager = createExtensionManager(login);
+    const consoleError = vi
+      .spyOn(console, "error")
+      .mockImplementation(() => {});
+    const loadEn = vi.fn().mockRejectedValue(new Error("chunk 404"));
+    const set: ExtensionSet = {
+      id: "set.broken-chunk",
+      extensions: [
+        {
+          url: "pkg://listed",
+          meta: {
+            id: "ext.listed",
+            // The bundled set inlines English and defers the rest.
+            translations: { en: { title: "Listed", description: "" } },
+          },
+        },
+      ],
+      loadListTranslations: { en: loadEn },
+    };
+
+    // The Settings list falls back to rendering ids; nothing should throw.
+    await expect(
+      manager.loadExtensionSet(set, () => false)
+    ).resolves.toBeDefined();
+    await vi.waitFor(() => expect(consoleError).toHaveBeenCalled());
+    consoleError.mockRestore();
   });
 
   it("loadExtension() adds the extension's full translations from loadFullTranslations(), not the (trimmed) meta.translations", async () => {

--- a/test/unit/seed-bible/managers/ReadingPlansManager.test.ts
+++ b/test/unit/seed-bible/managers/ReadingPlansManager.test.ts
@@ -25,7 +25,13 @@ import {
   type CalendarSkipRange,
 } from "@packages/seed-bible/seed-bible/managers/ReadingPlansManager";
 import { signal } from "@preact/signals";
-import { DateTime } from "luxon";
+import {
+  addCivilDays,
+  civilDateInZone,
+  civilDateToISO,
+  civilDaysBetween,
+  type CivilDate,
+} from "@packages/seed-bible/seed-bible/managers/civilDate";
 import type { Mock } from "vitest";
 
 // An arbitrary mid-week start instant to exercise "start any time".
@@ -98,9 +104,12 @@ function makeProgress(
 // Resolve day boundaries in a fixed zone so the schedule math is deterministic
 // regardless of the machine's local time zone.
 const ZONE = "utc";
-const START_DAY = DateTime.fromMillis(START_MS, { zone: ZONE }).startOf("day");
-const dayOffsetOf = (date: ReturnType<typeof DateTime.fromMillis>) =>
-  Math.round(date.diff(START_DAY, "days").days);
+const START_DAY = civilDateInZone(START_MS, ZONE);
+const dayOffsetOf = (date: CivilDate) => civilDaysBetween(START_DAY, date);
+// The instant `hours` into `date`. Valid because ZONE above is UTC, so a
+// calendar date and a UTC timestamp line up exactly.
+const msAt = (date: CivilDate, hours = 0) =>
+  Date.UTC(date.year, date.month - 1, date.day, hours);
 
 describe("ReadingPlansManager schemas", () => {
   it("parses a large plan with multiple cadence options", () => {
@@ -238,7 +247,7 @@ describe("schedule math", () => {
         expect(date).not.toBeNull();
         expect(dayOffsetOf(date!)).toBe(slot.dayOffset);
         expect(
-          sessionsForDate(c.cadence, START_MS, date!.toMillis(), ZONE)
+          sessionsForDate(c.cadence, START_MS, msAt(date!), ZONE)
         ).toContain(sessionIndex);
       });
     });
@@ -310,7 +319,7 @@ describe("getReadingCalendar", () => {
   ) => makeProgress({ customCadence: cadence, timeZone: ZONE, ...overrides });
 
   const nowAtOffset = (days: number, hours = 5) =>
-    START_DAY.plus({ days, hours }).toMillis();
+    msAt(addCivilDays(START_DAY, days), hours);
 
   const asReading = (e: ReadingCalendarEntry): CalendarReadingDay => {
     expect(e.type).toBe("reading");
@@ -1434,5 +1443,98 @@ describe("createReadingPlan", () => {
     expect(plan.description).toBe("A custom plan");
     expect(plan.cadenceOptions).toEqual(cadenceOptions);
     expect(plan.defaultCadenceId).toBe("weekly"); // first provided option
+  });
+});
+
+describe("time-zone-aware day boundaries", () => {
+  const DAILY: Cadence = { segments: [{ type: "read", days: 1 }] };
+
+  // Plans schedule by calendar day, not by elapsed milliseconds, so a run of
+  // days that crosses a clock change must still be one day apart. Doing this
+  // arithmetic on timestamps would drift by an hour each way.
+  it("counts a spring-forward day as one day (America/New_York)", () => {
+    // 2026-03-08 is when US clocks jump forward, making the local day 23h long.
+    const startMs = Date.UTC(2026, 2, 6, 17, 0, 0); // 2026-03-06 12:00 EST
+    const zone = "America/New_York";
+
+    const dates = [0, 1, 2, 3, 4].map(
+      (i) => dateForSession(DAILY, startMs, i, zone)!
+    );
+
+    expect(dates.map((d) => civilDateToISO(d))).toEqual([
+      "2026-03-06",
+      "2026-03-07",
+      "2026-03-08",
+      "2026-03-09",
+      "2026-03-10",
+    ]);
+  });
+
+  it("counts a fall-back day as one day (America/New_York)", () => {
+    // 2026-11-01 is when US clocks go back, making the local day 25h long.
+    const startMs = Date.UTC(2026, 9, 30, 16, 0, 0); // 2026-10-30 12:00 EDT
+    const zone = "America/New_York";
+
+    const dates = [0, 1, 2, 3, 4].map(
+      (i) => dateForSession(DAILY, startMs, i, zone)!
+    );
+
+    expect(dates.map((d) => civilDateToISO(d))).toEqual([
+      "2026-10-30",
+      "2026-10-31",
+      "2026-11-01",
+      "2026-11-02",
+      "2026-11-03",
+    ]);
+  });
+
+  it("resolves the day in the plan's zone, not the machine's", () => {
+    // 2026-06-17 03:30 UTC is still the 16th in New York and already the 17th
+    // in Kolkata (UTC+05:30) — a zone whose offset is not a whole hour.
+    const ms = Date.UTC(2026, 5, 17, 3, 30, 0);
+
+    expect(civilDateToISO(civilDateInZone(ms, "America/New_York"))).toBe(
+      "2026-06-16"
+    );
+    expect(civilDateToISO(civilDateInZone(ms, "Asia/Kolkata"))).toBe(
+      "2026-06-17"
+    );
+    expect(civilDateToISO(civilDateInZone(ms, "utc"))).toBe("2026-06-17");
+  });
+
+  it("keeps sessionsForDate the inverse of dateForSession across a DST change", () => {
+    const startMs = Date.UTC(2026, 2, 6, 17, 0, 0);
+    const zone = "America/New_York";
+
+    for (let i = 0; i < 6; i++) {
+      const date = dateForSession(DAILY, startMs, i, zone)!;
+      // Midday local time on that date, in both offsets the week spans.
+      const middayMs = Date.UTC(date.year, date.month - 1, date.day, 16, 0, 0);
+      expect(sessionsForDate(DAILY, startMs, middayMs, zone)).toContain(i);
+    }
+  });
+
+  it("advances the calendar correctly across a month and a leap day", () => {
+    expect(
+      civilDateToISO(addCivilDays({ year: 2028, month: 2, day: 28 }, 1))
+    ).toBe("2028-02-29");
+    expect(
+      civilDateToISO(addCivilDays({ year: 2026, month: 2, day: 28 }, 1))
+    ).toBe("2026-03-01");
+    expect(
+      civilDateToISO(addCivilDays({ year: 2026, month: 12, day: 31 }, 1))
+    ).toBe("2027-01-01");
+    expect(
+      civilDaysBetween(
+        { year: 2026, month: 1, day: 1 },
+        { year: 2027, month: 1, day: 1 }
+      )
+    ).toBe(365);
+    expect(
+      civilDaysBetween(
+        { year: 2028, month: 1, day: 1 },
+        { year: 2029, month: 1, day: 1 }
+      )
+    ).toBe(366);
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -301,12 +301,47 @@ export default defineConfig(({ isSsrBuild }) => ({
         manifest: true,
         sourcemap: true,
         rolldownOptions: {
+          // `@casual-simulation/aux-common` ships no `sideEffects` field, so
+          // every module in it is assumed to have import-time side effects and
+          // cannot be tree-shaken away. That matters because `aux-websocket`'s
+          // `WebsocketConnectionClient` — which the boot path needs — imports
+          // the aux-common package root, and that barrel re-exports
+          // `./partitions`, which reaches the Yjs document classes. The result
+          // was Yjs + lib0 (~97 KB) sitting in the eager vendor chunk even
+          // though the app only touches shared documents behind a dynamic
+          // import. Declaring these two directories side-effect-free lets the
+          // barrel shake out; anything genuinely imported from them (we use
+          // `PartitionAuthSource` at boot and `RemoteYjsSharedDocument`
+          // on demand) is still kept, and the one real side effect in the
+          // subtree — `import '../BlobPolyfill'` — also reaches the bundle via
+          // the package root, which is untouched by this rule.
+          treeshake: {
+            moduleSideEffects: [
+              {
+                test: /aux-common[\\/](documents|partitions)[\\/]/,
+                sideEffects: false,
+              },
+            ],
+          },
           output: {
             codeSplitting: {
               groups: [
                 {
                   test: /(node_modules|\.pnpm)/,
                   name: "vendor",
+                  // `$initial` restricts the group to modules a user-defined
+                  // entry imports statically (or reaches through a static
+                  // import chain). Without it, rolldown reads the `test` above
+                  // literally and puts *every* node_modules module in `vendor`
+                  // — including ones only reachable via `import()`. Because the
+                  // entry statically needs some of `vendor`, the chunk loads
+                  // eagerly, so that hoisting silently undid every lazy import
+                  // in the app: TipTap/ProseMirror (~500 KB), the transcript
+                  // extension's reference parser (~120 KB), and dompurify all
+                  // shipped on first paint. Tagging keeps one long-cacheable
+                  // vendor chunk for boot-path libraries and lets everything
+                  // else land in the lazy chunk that actually needs it.
+                  tags: ["$initial"],
                 },
               ],
             },
@@ -331,6 +366,12 @@ export default defineConfig(({ isSsrBuild }) => ({
     // extensions. Two copies (the CasualOS SDK pulls in preact 10.28.4 while the
     // app uses the catalog's 10.29.2) break hooks with
     // "Cannot read properties of undefined (reading '__H')".
+    // Only packages this project depends on directly belong here: `dedupe`
+    // resolves to the copy in the project root `node_modules`, which under
+    // pnpm's strict layout only exists for direct dependencies. The
+    // prosemirror packages used to be listed and had no effect for exactly
+    // that reason — they are pinned in `pnpm-workspace.yaml`'s `overrides`
+    // instead, which is the mechanism that reaches transitive dependencies.
     dedupe: [
       "preact",
       "preact/hooks",
@@ -338,10 +379,6 @@ export default defineConfig(({ isSsrBuild }) => ({
       "preact/jsx-runtime",
       "@preact/signals",
       "@preact/signals-core",
-      "prosemirror-model",
-      "prosemirror-state",
-      "prosemirror-transform",
-      "prosemirror-view",
     ],
   },
 


### PR DESCRIPTION
## Summary

The Settings extensions list shows each extension's `title` and `description`. Those strings were inlined into the `virtual:@extensions` module for **all 77 UI languages**, and that module is a static import on the boot path — so every reader downloaded 77 languages to render one, on a screen most never open.

Measured by deleting the literal from the built chunk and re-gzipping: **138 KB raw / 72.5 KB gzipped, 34.6% of the gzipped entry chunk.**

| | before | after |
|---|---|---|
| `assets/index.js` | 630.4 KB raw / 209.4 KB gz | **500.7 KB / 138.9 KB gz** |
| Total initial download | 1123.6 KB / 312.0 KB gz | **935.7 KB / 242.2 KB gz** |

`vendor.js` is byte-identical. Nothing is deferred and no loading state is added.

> **Scope:** the vendor-chunk work this branch was cut from has since merged as #1560, so the diff here is now only the two commits below. An earlier version of this description documented #1560's changes as well — apologies to anyone who went looking for `civilDate.ts`.

## How it works

- **`script/lib/extensionsModule.ts` (new)** — source generation for the `virtual:@extensions` module family, split out of the plugin so it is unit-testable without running a build, matching how `precacheManifest.ts` is separated from its own plugin.
- **`virtual:@extensions/locale/<lang>`** — a new virtual module per language, ~2.2 KB each, holding every extension's `title`/`description` for that language. Reached through a new optional `loadListTranslations` map on `ExtensionSet`.
- **`ExtensionManager`** fetches only the active language, and re-fetches when the UI language changes. Sets that ship strings inline (uploaded extensions) are unaffected and still use `meta.translations`.

**English stays inline.** `ExtensionMeta` requires it, it is i18next's `fallbackLng` so it renders wherever a language has no string of its own, and it means the list shows real titles rather than raw ids in the moment before a locale chunk lands. Measured cost: 1.6 KB raw / 0.6 KB gz. It was all 77 languages that cost 138 KB, not one.

The existing trimming is kept — the full `extension.json` files total 1.1 MB, so inlining `title`/`description` was the right call. The defect was only shipping every language of it.

## Review fixes (`e1ccd8d`)

- **SSR listener leak.** `createExtensionManager` runs once per SSR request while `i18n` is the process-wide i18next singleton, so the `languageChanged` listener accumulated for the life of the server process. The whole list-translation path is now skipped under SSR — the list is never server-rendered and English is inline, so nothing is lost, and the initial fetch was likewise a per-request write to shared state. Two tests cover it; both fail if the guard is removed.
- **Redundant build-time reads.** `load()` re-ran `readdir` and re-parsed every manifest for each of the 78 modules it emits. Instrumenting `readExtensionMeta` across a real build: **936 reads before, 12 after.** The promise is cached so Rollup's concurrent calls share one read, a failed read clears rather than poisons the cache, and the dev watcher now also drops it on content change — `addWatchFile` re-runs `load()` on an edit, which would otherwise be served stale metas.
- **`setsWithListTranslations` growth** — noted in the code for whoever adds a set-untracking path; there is none today.

The pre-existing unguarded listener in `I18nManager.tsx` is deliberately left alone: it updates a signal the SSR render reads, so guarding it is not the same one-line change and doesn't belong in this PR.

## Testing

3,456 tests pass. New: `test/unit/script/lib/extensionsModule.test.ts` for the generator, plus `ExtensionManager` coverage for active-language-only fetching, language switching, the SSR guard, sets without the new loader, and a locale chunk that fails to load (the list degrades to ids rather than throwing). `check:ts` and `lint` clean; client and SSR builds succeed.

**Not yet verified by hand:** Settings → Extensions in a browser. The language-switch path is covered by unit tests but not by eye.