### PR TITLE
Remove references to ao.bot in favor of auth.seedbible.org

### DIFF
--- a/packages/seed-bible/seed-bible/app/initPostHog.tsx
+++ b/packages/seed-bible/seed-bible/app/initPostHog.tsx
@@ -85,7 +85,7 @@ if (
 
   const seedBibleApiKey = "phc_rEUogfrnXkdTitOTrfWK2laEINF1QwNtGNQizzuMW0";
   posthog.init(seedBibleApiKey, {
-    api_host: "https://i.ao.bot",
+    api_host: "https://i.seedbible.org",
     ui_host: "https://us.posthog.com",
     defaults: "2026-05-30",
   });

--- a/packages/seed-bible/seed-bible/managers/OsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/OsManager.tsx
@@ -64,7 +64,9 @@ const UNSAFE_HEADERS = new Set([
   "host",
 ]);
 
-export function CasualOSManager(endpoint: string = "https://auth.ao.bot") {
+export function CasualOSManager(
+  endpoint: string = "https://auth.seedbible.org"
+) {
   const rawClient = createRecordsClient(endpoint);
   const connectionId = uuid();
   let currentWakeLock: WakeLockSentinel | null = null;
@@ -127,7 +129,7 @@ export function CasualOSManager(endpoint: string = "https://auth.ao.bot") {
 
   function getInstClient(): InstRecordsClient {
     if (!instRecordsClient) {
-      const url = new URL("wss://auth.ao.bot");
+      const url = new URL("wss://auth.seedbible.org");
       const manager = new WebsocketManager(url);
       manager.init();
       const client = new WebsocketConnectionClient(manager.socket);

--- a/packages/seed-bible/seed-bible/managers/SearchManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SearchManager.tsx
@@ -2,7 +2,7 @@ import * as Typesense from "typesense";
 import * as z from "zod/v4";
 import type { TranslationBook } from "./FreeUseBibleAPI";
 
-const TYPESENSE_NODE_URL = new URL("https://search.ao.bot");
+const TYPESENSE_NODE_URL = new URL("https://search.seedbible.org");
 const TYPESENSE_API_KEY = "5A496vKeCWhVxntITkcrZ6i7Fehh9lCB";
 const VERSE_COLLECTION_PREFIX = "bibleVerses";
 

--- a/script/lib/extension.ts
+++ b/script/lib/extension.ts
@@ -13,7 +13,7 @@ import * as z from "zod/v4";
 // const downloadRecordName = "testingPublickKey";
 const uploadRecordName = "seedBibleExtensions";
 const headers = {
-  Origin: "https://auth.ao.bot",
+  Origin: "https://auth.seedbible.org",
 };
 
 /**
@@ -372,7 +372,7 @@ export async function upload(
 
   const programOptions: string[] = [
     `--endpoint "https://api.ao.bot"`,
-    `--origin "https://auth.ao.bot"`,
+    `--origin "https://auth.seedbible.org"`,
   ];
   if (options.sessionKey) {
     programOptions.push(`--session-key "${options.sessionKey}"`);

--- a/script/lib/extension.ts
+++ b/script/lib/extension.ts
@@ -371,7 +371,7 @@ export async function upload(
   execSync(`casualos minify-aux "${filePath}"`, { stdio: "ignore" });
 
   const programOptions: string[] = [
-    `--endpoint "https://api.ao.bot"`,
+    `--endpoint "https://auth.seedbible.org"`,
     `--origin "https://auth.seedbible.org"`,
   ];
   if (options.sessionKey) {
@@ -428,7 +428,7 @@ export async function uploadAll(options: {
 
   const { createRecordsClient } =
     await import("@casual-simulation/aux-records/RecordsClient.js");
-  const client = createRecordsClient("https://api.ao.bot");
+  const client = createRecordsClient("https://auth.seedbible.org");
 
   if (options.sessionKey) {
     client.sessionKey = options.sessionKey;

--- a/script/lib/pattern.ts
+++ b/script/lib/pattern.ts
@@ -19,7 +19,7 @@ const { createRecordsClient } = createRequire(import.meta.url)(
 
 const recordName = "aoBot";
 const headers = {
-  Origin: "https://auth.ao.bot",
+  Origin: "https://auth.seedbible.org",
 };
 
 /**

--- a/script/lib/pattern.ts
+++ b/script/lib/pattern.ts
@@ -31,7 +31,7 @@ export async function downloadPattern(
   name: string,
   version?: number
 ): Promise<StoredAux | null> {
-  const client = createRecordsClient("https://api.ao.bot");
+  const client = createRecordsClient("https://auth.seedbible.org");
 
   const result: any = await client.getData(
     {
@@ -137,7 +137,7 @@ export async function uploadPattern(
   telegramBotToken?: string,
   telegramChatId?: string
 ) {
-  const client = createRecordsClient("https://api.ao.bot");
+  const client = createRecordsClient("https://auth.seedbible.org");
 
   client.sessionKey = sessionKey;
 

--- a/script/lib/records.ts
+++ b/script/lib/records.ts
@@ -14,7 +14,7 @@ const { createRecordsClient } = createRequire(import.meta.url)(
 ) as typeof import("@casual-simulation/aux-records/RecordsClient.js");
 
 const headers = {
-  Origin: "https://auth.ao.bot",
+  Origin: "https://auth.seedbible.org",
 };
 
 const UNSAFE_HEADERS = new Set([

--- a/script/lib/records.ts
+++ b/script/lib/records.ts
@@ -58,7 +58,7 @@ export async function uploadFile(
   sessionKey: string,
   markers: string[] = ["publicRead"]
 ) {
-  const client = createRecordsClient("https://api.ao.bot");
+  const client = createRecordsClient("https://auth.seedbible.org");
 
   client.sessionKey = sessionKey;
 

--- a/test/unit/seed-bible/components/BibleSelector.test.tsx
+++ b/test/unit/seed-bible/components/BibleSelector.test.tsx
@@ -91,7 +91,7 @@ describe("BibleSelector", () => {
   beforeEach(() => {
     // The mocked Bible API responses are keyed to the free-use endpoint, so
     // opt into it via the URL (the app otherwise defaults to the private one).
-    jsdom.reconfigure({ url: "https://ao.bot/?useFreeBibleAPI" });
+    jsdom.reconfigure({ url: "https://seedbible.org/?useFreeBibleAPI" });
 
     // The data manager persists per-translation endpoints to localStorage;
     // clear it so state does not leak between tests.
@@ -738,7 +738,7 @@ describe("BibleSelector translation selector", () => {
   beforeEach(() => {
     // The mocked Bible API responses are keyed to the free-use endpoint, so
     // opt into it via the URL (the app otherwise defaults to the private one).
-    jsdom.reconfigure({ url: "https://ao.bot/?useFreeBibleAPI" });
+    jsdom.reconfigure({ url: "https://seedbible.org/?useFreeBibleAPI" });
 
     // The data manager persists per-translation endpoints to localStorage;
     // clear it so state does not leak between tests.
@@ -1620,7 +1620,7 @@ describe("BibleSelector sharing translations", () => {
   let setClipboard: Mock;
 
   beforeEach(() => {
-    jsdom.reconfigure({ url: "https://ao.bot/somepage" });
+    jsdom.reconfigure({ url: "https://seedbible.org/somepage" });
 
     // Clear persisted per-translation endpoints so state does not leak in
     // from earlier tests (which would mark default-endpoint translations as
@@ -1709,7 +1709,7 @@ describe("BibleSelector sharing translations", () => {
     await waitFor(() => setClipboard.mock.calls.length > 0);
 
     const copiedUrl = new URL(setClipboard.mock.calls[0]![0] as string);
-    expect(copiedUrl.hostname).toBe("ao.bot");
+    expect(copiedUrl.hostname).toBe("seedbible.org");
     expect(copiedUrl.searchParams.get("translation")).toBe("AAB");
   });
 
@@ -1729,7 +1729,7 @@ describe("BibleSelector sharing translations", () => {
     await waitFor(() => setClipboard.mock.calls.length > 0);
 
     const copiedUrl = new URL(setClipboard.mock.calls[0]![0] as string);
-    expect(copiedUrl.hostname).toBe("ao.bot");
+    expect(copiedUrl.hostname).toBe("seedbible.org");
     const translationParam = copiedUrl.searchParams.get("translation")!;
     expect(translationParam).toContain("example.test");
     expect(translationParam).toContain("CST");
@@ -1741,7 +1741,7 @@ describe("BibleSelector offline downloads", () => {
   let container: HTMLDivElement;
 
   beforeEach(() => {
-    jsdom.reconfigure({ url: "https://ao.bot/?useFreeBibleAPI" });
+    jsdom.reconfigure({ url: "https://seedbible.org/?useFreeBibleAPI" });
     localStorage.clear();
     container = document.createElement("div");
     document.body.appendChild(container);

--- a/test/unit/seed-bible/managers/SearchManager.test.ts
+++ b/test/unit/seed-bible/managers/SearchManager.test.ts
@@ -77,7 +77,7 @@ describe("createSearchManager", () => {
       apiKey: expect.any(String),
       nodes: [
         {
-          host: "search.ao.bot",
+          host: "search.seedbible.org",
           port: 443,
           protocol: "https",
         },


### PR DESCRIPTION
We've had issues with ao.bot domains getting blocked by network filters, so we're switching as much as possible over to auth.seedbible.org