### PR TITLE
fix: correct broken dynamic import path in policy modals

### DIFF
--- a/packages/seed-bible/seed-bible/components/CodeOfConductModal/CodeOfConductModal.tsx
+++ b/packages/seed-bible/seed-bible/components/CodeOfConductModal/CodeOfConductModal.tsx
@@ -25,12 +25,14 @@ function loadCodeOfConduct(
 ): Promise<void> {
   let promise = loadingPromises.get(language);
   if (!promise) {
-    promise = import(`../i18n/policies/code-of-conduct/${language}.json`).then(
-      (resources) => {
+    promise = import(`../../i18n/policies/code-of-conduct/${language}.json`)
+      .then((resources) => {
         i18n.addResourceBundle(language, "code-of-conduct", resources.default);
         loadedLanguages.value = new Set(loadedLanguages.value).add(language);
-      }
-    );
+      })
+      .catch((error) => {
+        console.error("Failed to load code of conduct policy bundle", error);
+      });
     loadingPromises.set(language, promise);
   }
   return promise;

--- a/packages/seed-bible/seed-bible/components/CodeOfConductModal/CodeOfConductModal.tsx
+++ b/packages/seed-bible/seed-bible/components/CodeOfConductModal/CodeOfConductModal.tsx
@@ -19,6 +19,11 @@ const loadingPromises = new Map<string, Promise<void>>();
  * the bundle is available — callers can await it (during SSR) to block rendering
  * until the policy text is present.
  */
+// Resolves — never rejects, even on failure (logged below). A rejected
+// promise thrown during `renderToStringAsync` surfaces as a render exception
+// and takes down the whole SSR document (see BibleReadingManager's
+// `chapterDataPromise`); resolving lets the modal render with an empty body
+// instead.
 function loadCodeOfConduct(
   i18n: I18nInstance,
   language: string
@@ -32,6 +37,8 @@ function loadCodeOfConduct(
       })
       .catch((error) => {
         console.error("Failed to load code of conduct policy bundle", error);
+        // Don't cache the failure — let the next modal open retry the import.
+        loadingPromises.delete(language);
       });
     loadingPromises.set(language, promise);
   }

--- a/packages/seed-bible/seed-bible/components/PrivacyPolicyModal/PrivacyPolicyModal.tsx
+++ b/packages/seed-bible/seed-bible/components/PrivacyPolicyModal/PrivacyPolicyModal.tsx
@@ -19,6 +19,11 @@ const loadingPromises = new Map<string, Promise<void>>();
  * the bundle is available — callers can await it (during SSR) to block rendering
  * until the policy text is present.
  */
+// Resolves — never rejects, even on failure (logged below). A rejected
+// promise thrown during `renderToStringAsync` surfaces as a render exception
+// and takes down the whole SSR document (see BibleReadingManager's
+// `chapterDataPromise`); resolving lets the modal render with an empty body
+// instead.
 function loadPrivacyPolicy(
   i18n: I18nInstance,
   language: string
@@ -32,6 +37,8 @@ function loadPrivacyPolicy(
       })
       .catch((error) => {
         console.error("Failed to load privacy policy bundle", error);
+        // Don't cache the failure — let the next modal open retry the import.
+        loadingPromises.delete(language);
       });
     loadingPromises.set(language, promise);
   }

--- a/packages/seed-bible/seed-bible/components/PrivacyPolicyModal/PrivacyPolicyModal.tsx
+++ b/packages/seed-bible/seed-bible/components/PrivacyPolicyModal/PrivacyPolicyModal.tsx
@@ -25,12 +25,14 @@ function loadPrivacyPolicy(
 ): Promise<void> {
   let promise = loadingPromises.get(language);
   if (!promise) {
-    promise = import(`../i18n/policies/privacy-policy/${language}.json`).then(
-      (resources) => {
+    promise = import(`../../i18n/policies/privacy-policy/${language}.json`)
+      .then((resources) => {
         i18n.addResourceBundle(language, "privacy-policy", resources.default);
         loadedLanguages.value = new Set(loadedLanguages.value).add(language);
-      }
-    );
+      })
+      .catch((error) => {
+        console.error("Failed to load privacy policy bundle", error);
+      });
     loadingPromises.set(language, promise);
   }
   return promise;

--- a/packages/seed-bible/seed-bible/components/TermsOfServiceModal/TermsOfServiceModal.tsx
+++ b/packages/seed-bible/seed-bible/components/TermsOfServiceModal/TermsOfServiceModal.tsx
@@ -20,6 +20,11 @@ const loadingPromises = new Map<string, Promise<void>>();
  * resolves once the bundle is available — callers can await it (during SSR) to
  * block rendering until the policy text is present.
  */
+// Resolves — never rejects, even on failure (logged below). A rejected
+// promise thrown during `renderToStringAsync` surfaces as a render exception
+// and takes down the whole SSR document (see BibleReadingManager's
+// `chapterDataPromise`); resolving lets the modal render with an empty body
+// instead.
 function loadTermsOfService(
   i18n: I18nInstance,
   language: string
@@ -33,6 +38,8 @@ function loadTermsOfService(
       })
       .catch((error) => {
         console.error("Failed to load terms of service policy bundle", error);
+        // Don't cache the failure — let the next modal open retry the import.
+        loadingPromises.delete(language);
       });
     loadingPromises.set(language, promise);
   }

--- a/packages/seed-bible/seed-bible/components/TermsOfServiceModal/TermsOfServiceModal.tsx
+++ b/packages/seed-bible/seed-bible/components/TermsOfServiceModal/TermsOfServiceModal.tsx
@@ -26,12 +26,14 @@ function loadTermsOfService(
 ): Promise<void> {
   let promise = loadingPromises.get(language);
   if (!promise) {
-    promise = import(`../i18n/policies/terms-of-service/${language}.json`).then(
-      (resources) => {
+    promise = import(`../../i18n/policies/terms-of-service/${language}.json`)
+      .then((resources) => {
         i18n.addResourceBundle(language, "terms-of-service", resources.default);
         loadedLanguages.value = new Set(loadedLanguages.value).add(language);
-      }
-    );
+      })
+      .catch((error) => {
+        console.error("Failed to load terms of service policy bundle", error);
+      });
     loadingPromises.set(language, promise);
   }
   return promise;

--- a/test/unit/seed-bible/components/CodeOfConductModal.test.tsx
+++ b/test/unit/seed-bible/components/CodeOfConductModal.test.tsx
@@ -1,0 +1,65 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { CodeOfConductModal } from "@packages/seed-bible/seed-bible/components/CodeOfConductModal/CodeOfConductModal";
+import {
+  createTestSeedBibleState,
+  waitFor,
+} from "../testUtils/createTestSeedBibleState";
+import { TestHost } from "./TestHost";
+
+describe("CodeOfConductModal", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it("renders nothing when closed", async () => {
+    const state = await createTestSeedBibleState();
+
+    act(() => {
+      render(
+        <TestHost state={state}>
+          <CodeOfConductModal isOpen={false} onClose={vi.fn()} />
+        </TestHost>,
+        container
+      );
+    });
+
+    expect(container.querySelector(".sb-tos-modal")).toBeNull();
+  });
+
+  it("loads and renders the real code of conduct text when opened", async () => {
+    const state = await createTestSeedBibleState();
+
+    act(() => {
+      render(
+        <TestHost state={state}>
+          <CodeOfConductModal isOpen={true} onClose={vi.fn()} />
+        </TestHost>,
+        container
+      );
+    });
+
+    // Regression guard: the modal lazily imports its policy bundle relative
+    // to its own folder. An off-by-one path once made that import reject
+    // silently, leaving this content area permanently empty with no error.
+    await waitFor(() =>
+      Boolean(container.querySelector(".sb-tos-content")?.innerHTML)
+    );
+
+    const content = container.querySelector(".sb-tos-content");
+    expect(content?.innerHTML).toContain(
+      "ao-lab-web-services-acceptable-use-policy"
+    );
+    expect(content?.textContent).toContain(
+      "AO Lab Web Services Acceptable Use Policy"
+    );
+  });
+});

--- a/test/unit/seed-bible/components/PrivacyPolicyModal.test.tsx
+++ b/test/unit/seed-bible/components/PrivacyPolicyModal.test.tsx
@@ -1,0 +1,63 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { PrivacyPolicyModal } from "@packages/seed-bible/seed-bible/components/PrivacyPolicyModal/PrivacyPolicyModal";
+import {
+  createTestSeedBibleState,
+  waitFor,
+} from "../testUtils/createTestSeedBibleState";
+import { TestHost } from "./TestHost";
+
+describe("PrivacyPolicyModal", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it("renders nothing when closed", async () => {
+    const state = await createTestSeedBibleState();
+
+    act(() => {
+      render(
+        <TestHost state={state}>
+          <PrivacyPolicyModal isOpen={false} onClose={vi.fn()} />
+        </TestHost>,
+        container
+      );
+    });
+
+    expect(container.querySelector(".sb-tos-modal")).toBeNull();
+  });
+
+  it("loads and renders the real privacy policy text when opened", async () => {
+    const state = await createTestSeedBibleState();
+
+    act(() => {
+      render(
+        <TestHost state={state}>
+          <PrivacyPolicyModal isOpen={true} onClose={vi.fn()} />
+        </TestHost>,
+        container
+      );
+    });
+
+    // Regression guard: the modal lazily imports its policy bundle relative
+    // to its own folder. An off-by-one path once made that import reject
+    // silently, leaving this content area permanently empty with no error.
+    await waitFor(() =>
+      Boolean(container.querySelector(".sb-tos-content")?.innerHTML)
+    );
+
+    const content = container.querySelector(".sb-tos-content");
+    expect(content?.innerHTML).toContain("ao-lab-web-services-privacy-policy");
+    expect(content?.textContent).toContain(
+      "AO Lab Web Services Privacy Policy"
+    );
+  });
+});

--- a/test/unit/seed-bible/components/TermsOfServiceModal.test.tsx
+++ b/test/unit/seed-bible/components/TermsOfServiceModal.test.tsx
@@ -1,0 +1,65 @@
+import { render } from "preact";
+import { act } from "preact/test-utils";
+import { TermsOfServiceModal } from "@packages/seed-bible/seed-bible/components/TermsOfServiceModal/TermsOfServiceModal";
+import {
+  createTestSeedBibleState,
+  waitFor,
+} from "../testUtils/createTestSeedBibleState";
+import { TestHost } from "./TestHost";
+
+describe("TermsOfServiceModal", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it("renders nothing when closed", async () => {
+    const state = await createTestSeedBibleState();
+
+    act(() => {
+      render(
+        <TestHost state={state}>
+          <TermsOfServiceModal isOpen={false} onClose={vi.fn()} />
+        </TestHost>,
+        container
+      );
+    });
+
+    expect(container.querySelector(".sb-tos-modal")).toBeNull();
+  });
+
+  it("loads and renders the real terms of service text when opened", async () => {
+    const state = await createTestSeedBibleState();
+
+    act(() => {
+      render(
+        <TestHost state={state}>
+          <TermsOfServiceModal isOpen={true} onClose={vi.fn()} />
+        </TestHost>,
+        container
+      );
+    });
+
+    // Regression guard: the modal lazily imports its policy bundle relative
+    // to its own folder. An off-by-one path once made that import reject
+    // silently, leaving this content area permanently empty with no error.
+    await waitFor(() =>
+      Boolean(container.querySelector(".sb-tos-content")?.innerHTML)
+    );
+
+    const content = container.querySelector(".sb-tos-content");
+    expect(content?.innerHTML).toContain(
+      "ao-lab-web-services-terms-of-service"
+    );
+    expect(content?.textContent).toContain(
+      "AO Lab Web Services Terms of Service"
+    );
+  });
+});


### PR DESCRIPTION
TermsOfServiceModal, PrivacyPolicyModal, and CodeOfConductModal each
lazily import their policy HTML from an i18n JSON bundle, but the
import path was left at one directory level up after a refactor moved
these components into their own subfolders. The path resolved to a
nonexistent location, so the import silently rejected and the modals
always rendered with an empty body.

Fix the path to go up two levels, matching the correct static
useI18n import already in each file, and log a console error if the
import ever fails again instead of failing silently.

Add regression tests for all three modals that render with a real
i18n instance and assert the actual policy text loads.