### PR TITLE
Repair highlighting in shared sessions.

### DIFF
--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.css
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.css
@@ -455,6 +455,22 @@
   }
 }
 
+/* A highlight arriving from a shared session (or an extension) is outlined
+   rather than solid, so it reads as somebody else's mark laid over the page
+   instead of one of the reader's own. The reader's highlight is still there
+   underneath and returns to solid when the broadcast goes away. Same colour on
+   the stroke — only the amount of fill differs — so the colour still says who
+   picked what. One opacity serves both themes; the presets are light enough in
+   light mode and dark enough in dark mode to read at the same strength. */
+.sb-highlight-ribbon-broadcast {
+  fill-opacity: 0.5;
+  stroke-width: 2;
+  transition:
+    opacity 0.25s ease,
+    fill 0.25s ease,
+    stroke 0.25s ease;
+}
+
 @media (prefers-reduced-motion: reduce) {
   .sb-highlight-ribbon {
     transition: none;

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
@@ -181,6 +181,16 @@ function getVersePlainText(content: ChapterVerse["content"]): string {
   return content.map((part) => getInlineText(part)).join("");
 }
 
+/**
+ * A highlight resolved for one verse, plus where it came from. `broadcast` is
+ * true for a highlight carried by a decoration — a session peer's, or an
+ * extension's — as opposed to one the reader saved themselves.
+ */
+interface ResolvedHighlight {
+  highlight: ChapterHighlight;
+  broadcast: boolean;
+}
+
 function hasContentTargeting(decoration: VerseDecoration): boolean {
   const hasTargetContent =
     typeof decoration.targetContent === "string" &&
@@ -566,10 +576,15 @@ function renderChapterContent(
   // `showHighlights` hides the reader's *saved* highlights. Decoration
   // highlights are a live signal from a session peer or an extension, so they
   // stay visible either way — as they did when they were plain CSS.
-  const getVerseHighlight = (verseNumber: number): ChapterHighlight | null => {
+  //
+  // `broadcast` distinguishes the two for rendering: a decoration highlight is
+  // drawn as an outline, a saved one as a solid ribbon. A broadcast covers the
+  // reader's own highlight rather than replacing it, so the outline is what
+  // says "this isn't yours, and yours is still underneath".
+  const getVerseHighlight = (verseNumber: number): ResolvedHighlight | null => {
     const decorated = decorationHighlights.get(verseNumber);
     if (decorated) {
-      return decorated;
+      return { highlight: decorated, broadcast: true };
     }
 
     if (!scriptureElements.showHighlights) {
@@ -579,14 +594,14 @@ function renderChapterContent(
     for (const highlight of highlights) {
       if (typeof highlight.verse === "number") {
         if (highlight.verse === verseNumber) {
-          return highlight;
+          return { highlight, broadcast: false };
         }
         continue;
       }
 
       const [start, end] = highlight.verse;
       if (verseNumber >= start && verseNumber <= end) {
-        return highlight;
+        return { highlight, broadcast: false };
       }
     }
 
@@ -597,20 +612,24 @@ function renderChapterContent(
   // ChapterContent), so a highlighted run's wrapper paints no background itself.
   // It only carries the readable font color and a `fill` (a CSS-var reference for
   // preset colors, or the custom hex) that the layer reads back off the DOM.
-  const getHighlightPresentation = (highlight: ChapterHighlight | null) => {
-    if (!highlight) {
+  const getHighlightPresentation = (resolved: ResolvedHighlight | null) => {
+    if (!resolved) {
       return {
         className: "",
         style: undefined as JSX.CSSProperties | undefined,
         fill: null as string | null,
+        broadcast: false,
       };
     }
+
+    const { highlight, broadcast } = resolved;
 
     if (highlight.customColor && highlight.customFontColor) {
       return {
         className: "sb-highlight",
         style: { color: highlight.customFontColor } as JSX.CSSProperties,
         fill: highlight.customColor,
+        broadcast,
       };
     }
 
@@ -618,6 +637,7 @@ function renderChapterContent(
       className: `sb-highlight sb-highlight-${highlight.colorId}`,
       style: undefined as JSX.CSSProperties | undefined,
       fill: `var(--sb-highlight-${highlight.colorId}-color)`,
+      broadcast,
     };
   };
 
@@ -645,14 +665,18 @@ function renderChapterContent(
     );
   };
 
-  const getHighlightColorKey = (highlight: ChapterHighlight | null) => {
-    if (!highlight) {
+  // Also keys on `broadcast`, so a broadcast highlight never merges into one run
+  // with a saved highlight of the same colour — they draw differently.
+  const getHighlightColorKey = (resolved: ResolvedHighlight | null) => {
+    if (!resolved) {
       return null;
     }
+    const { highlight, broadcast } = resolved;
+    const prefix = broadcast ? "broadcast:" : "";
     if (highlight.customColor && highlight.customFontColor) {
-      return `custom:${highlight.customColor}:${highlight.customFontColor}`;
+      return `${prefix}custom:${highlight.customColor}:${highlight.customFontColor}`;
     }
-    return highlight.colorId;
+    return `${prefix}${highlight.colorId}`;
   };
 
   // Renders a single verse's `<span class="sb-verse">`. The highlight background
@@ -939,6 +963,7 @@ function renderChapterContent(
           style={presentation.style}
           data-highlight-fill={presentation.fill ?? undefined}
           data-highlight-key={runKey}
+          data-highlight-broadcast={presentation.broadcast ? "true" : undefined}
         >
           {runIndices.map((idx) =>
             renderVerseNode(entries[idx] as ChapterVerse, idx)
@@ -1007,6 +1032,8 @@ interface Ribbon {
   key: string;
   d: string;
   fill: string;
+  /** Drawn as an outline rather than a solid fill — see `ResolvedHighlight`. */
+  broadcast: boolean;
   first: number;
   last: number;
   enter: boolean;
@@ -1161,6 +1188,7 @@ function ChapterContent(props: ChapterContentProps) {
         el,
         key: el.getAttribute("data-highlight-key") || `i${index}`,
         fill: el.getAttribute("data-highlight-fill") ?? "",
+        broadcast: el.getAttribute("data-highlight-broadcast") === "true",
         lines: collectLineRects(el, box.left, box.top),
         leadPad: padX,
         trailPad: padX,
@@ -1192,6 +1220,7 @@ function ChapterContent(props: ChapterContentProps) {
       key: string;
       d: string;
       fill: string;
+      broadcast: boolean;
       first: number;
       last: number;
     }> = [];
@@ -1211,6 +1240,7 @@ function ChapterContent(props: ChapterContentProps) {
         key: `${chapterId}:${run.key}`,
         d,
         fill: run.fill,
+        broadcast: run.broadcast,
         first,
         last,
       });
@@ -1255,6 +1285,7 @@ function ChapterContent(props: ChapterContentProps) {
         key: r.key,
         d: r.d,
         fill: r.fill,
+        broadcast: r.broadcast,
         first: r.first,
         last: r.last,
         enter,
@@ -1348,14 +1379,19 @@ function ChapterContent(props: ChapterContentProps) {
         {ribbons.map((ribbon) => (
           <path
             key={ribbon.key}
-            className={
-              ribbon.enter
-                ? "sb-highlight-ribbon sb-highlight-ribbon-enter"
-                : "sb-highlight-ribbon"
-            }
+            className={[
+              "sb-highlight-ribbon",
+              ribbon.enter ? "sb-highlight-ribbon-enter" : "",
+              ribbon.broadcast ? "sb-highlight-ribbon-broadcast" : "",
+            ]
+              .filter(Boolean)
+              .join(" ")}
             d={ribbon.d}
             style={{
               fill: ribbon.fill,
+              // Same colour on the stroke; the class decides how much of the
+              // fill shows through.
+              stroke: ribbon.broadcast ? ribbon.fill : undefined,
               opacity: ribbon.exiting ? 0 : undefined,
             }}
           />

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
@@ -624,10 +624,15 @@ function renderChapterContent(
 
     const { highlight, broadcast } = resolved;
 
-    if (highlight.customColor && highlight.customFontColor) {
+    // A custom colour stands on its own — the font colour is optional and the
+    // text inherits when it's absent. Requiring both meant a highlight with
+    // only a custom colour silently rendered as its preset instead.
+    if (highlight.customColor) {
       return {
         className: "sb-highlight",
-        style: { color: highlight.customFontColor } as JSX.CSSProperties,
+        style: highlight.customFontColor
+          ? ({ color: highlight.customFontColor } as JSX.CSSProperties)
+          : undefined,
         fill: highlight.customColor,
         broadcast,
       };
@@ -673,8 +678,8 @@ function renderChapterContent(
     }
     const { highlight, broadcast } = resolved;
     const prefix = broadcast ? "broadcast:" : "";
-    if (highlight.customColor && highlight.customFontColor) {
-      return `${prefix}custom:${highlight.customColor}:${highlight.customFontColor}`;
+    if (highlight.customColor) {
+      return `${prefix}custom:${highlight.customColor}:${highlight.customFontColor ?? ""}`;
     }
     return `${prefix}${highlight.colorId}`;
   };
@@ -1032,7 +1037,6 @@ interface Ribbon {
   key: string;
   d: string;
   fill: string;
-  /** Drawn as an outline rather than a solid fill — see `ResolvedHighlight`. */
   broadcast: boolean;
   first: number;
   last: number;

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
@@ -527,7 +527,55 @@ function renderChapterContent(
     return null;
   }
 
+  const getVerseDecorations = (verseNumber: number) => {
+    return decorations.filter(
+      (decoration) =>
+        (!decoration.translationId ||
+          decoration.translationId === chapterData.translation.id) &&
+        decoration.bookId === chapterData.book.id &&
+        decoration.chapterNumber === chapterData.chapter.number &&
+        decoration.verses.includes(verseNumber)
+    );
+  };
+
+  // Decorations asking to be drawn as highlights (`decoration.highlight`),
+  // flattened to one entry per verse. Content-targeted decorations are skipped:
+  // the ribbon layer works per verse-run and can't paint a text fragment.
+  // Later decorations win, matching how their CSS is layered below.
+  const decorationHighlights = new Map<number, ChapterHighlight>();
+  for (const decoration of decorations) {
+    if (!decoration.highlight || hasContentTargeting(decoration)) {
+      continue;
+    }
+    if (
+      (decoration.translationId &&
+        decoration.translationId !== chapterData.translation.id) ||
+      decoration.bookId !== chapterData.book.id ||
+      decoration.chapterNumber !== chapterData.chapter.number
+    ) {
+      continue;
+    }
+    for (const verseNumber of decoration.verses) {
+      decorationHighlights.set(verseNumber, {
+        ...decoration.highlight,
+        verse: verseNumber,
+      });
+    }
+  }
+
+  // `showHighlights` hides the reader's *saved* highlights. Decoration
+  // highlights are a live signal from a session peer or an extension, so they
+  // stay visible either way — as they did when they were plain CSS.
   const getVerseHighlight = (verseNumber: number): ChapterHighlight | null => {
+    const decorated = decorationHighlights.get(verseNumber);
+    if (decorated) {
+      return decorated;
+    }
+
+    if (!scriptureElements.showHighlights) {
+      return null;
+    }
+
     for (const highlight of highlights) {
       if (typeof highlight.verse === "number") {
         if (highlight.verse === verseNumber) {
@@ -594,17 +642,6 @@ function renderChapterContent(
         className: "",
         style: undefined as JSX.CSSProperties | undefined,
       }
-    );
-  };
-
-  const getVerseDecorations = (verseNumber: number) => {
-    return decorations.filter(
-      (decoration) =>
-        (!decoration.translationId ||
-          decoration.translationId === chapterData.translation.id) &&
-        decoration.bookId === chapterData.book.id &&
-        decoration.chapterNumber === chapterData.chapter.number &&
-        decoration.verses.includes(verseNumber)
     );
   };
 
@@ -847,9 +884,7 @@ function renderChapterContent(
     }
 
     if (isVerseEntry(entry)) {
-      const highlight = scriptureElements.showHighlights
-        ? getVerseHighlight(entry.number)
-        : null;
+      const highlight = getVerseHighlight(entry.number);
       const colorKey = getHighlightColorKey(highlight);
 
       if (colorKey === null) {
@@ -876,11 +911,7 @@ function renderChapterContent(
           if (!isVerseEntry(next)) {
             break;
           }
-          const nextKey = getHighlightColorKey(
-            scriptureElements.showHighlights
-              ? getVerseHighlight(next.number)
-              : null
-          );
+          const nextKey = getHighlightColorKey(getVerseHighlight(next.number));
           const nextIsPoetry = splitVerseIntoSegments(next.content).some(
             (s) => s.type === "poetry"
           );

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
@@ -638,10 +638,16 @@ function renderChapterContent(
       };
     }
 
+    // The `transparent` fallback matters: a colorId with no matching theme
+    // variable would otherwise make `fill` invalid at computed-value time, and
+    // `fill` inherits down to its initial value of black — a solid black bar
+    // behind the verse. Colour ids don't all come from our own picker (an
+    // extension can pass one through from a chat message), so an unrecognised
+    // one has to fail invisible.
     return {
       className: `sb-highlight sb-highlight-${highlight.colorId}`,
       style: undefined as JSX.CSSProperties | undefined,
-      fill: `var(--sb-highlight-${highlight.colorId}-color)`,
+      fill: `var(--sb-highlight-${highlight.colorId}-color, transparent)`,
       broadcast,
     };
   };

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
@@ -355,7 +355,10 @@ function removeSharedHighlightsFromSelection(
  * - Broadcasting with `highlightDurationSeconds` = null (∞) → save permanently
  *   AND broadcast a decoration so other clients see it. The saved copy is the
  *   author's alone: participants get the broadcast, not a highlight of their
- *   own, and the author still has theirs once the session ends.
+ *   own, and the author still has theirs once the session ends. Skipped when
+ *   the user is signed out: there is nowhere to save it, and attempting to
+ *   would interrupt them with a login modal for a highlight the session is
+ *   already carrying. Broadcasting itself only needs a connection id.
  * - Broadcasting with a finite duration → broadcast a decoration only, and
  *   leave any existing personal highlight on those verses alone. The broadcast
  *   covers it for as long as it lives (the reader draws a decoration highlight
@@ -368,11 +371,13 @@ function applyHighlightWithSession(
     colorId: string;
     customColor?: string;
     customFontColor?: string;
-  }
+  },
+  isSignedIn: boolean
 ): void {
   if (!session || !session.userCanDecorate(session.localSessionId.value)) {
     // A participant who can't broadcast used to match neither branch here, so
-    // highlighting silently did nothing for them.
+    // highlighting silently did nothing for them. Saving is the only thing this
+    // can mean, so a signed-out user is asked to sign in before it applies.
     void rs.highlightSelectedVerses(details);
     return;
   }
@@ -380,7 +385,7 @@ function applyHighlightWithSession(
   const duration = session.options.value.highlightDurationSeconds;
   const isTransient = duration !== null && duration > 0;
 
-  if (!isTransient) {
+  if (!isTransient && isSignedIn) {
     void rs.highlightSelectedVerses(details);
   }
 
@@ -403,6 +408,7 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
     settings,
     bookmarks,
     extensions,
+    login,
   } = props.state;
   const selectedTab = useComputed(
     () =>
@@ -739,11 +745,16 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
       settings.addCustomHighlightColor(color);
       const rs = readingState.value;
       if (rs) {
-        applyHighlightWithSession(rs, sessionState.value, {
-          colorId: "yellow",
-          customColor: color,
-          customFontColor: getContrastTextColor(color),
-        });
+        applyHighlightWithSession(
+          rs,
+          sessionState.value,
+          {
+            colorId: "yellow",
+            customColor: color,
+            customFontColor: getContrastTextColor(color),
+          },
+          !!login.userId.value
+        );
       }
       customColorCommitTimeoutRef.current = null;
     }, 300);
@@ -1585,9 +1596,12 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                   onClick={() => {
                     const rs = readingState.value;
                     if (!rs) return;
-                    applyHighlightWithSession(rs, sessionState.value, {
-                      colorId,
-                    });
+                    applyHighlightWithSession(
+                      rs,
+                      sessionState.value,
+                      { colorId },
+                      !!login.userId.value
+                    );
                   }}
                   aria-label={`Highlight ${colorId}`}
                   title={colorId}
@@ -1609,11 +1623,16 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                   onClick={() => {
                     const rs = readingState.value;
                     if (!rs) return;
-                    applyHighlightWithSession(rs, sessionState.value, {
-                      colorId: "yellow",
-                      customColor: hex,
-                      customFontColor: getContrastTextColor(hex),
-                    });
+                    applyHighlightWithSession(
+                      rs,
+                      sessionState.value,
+                      {
+                        colorId: "yellow",
+                        customColor: hex,
+                        customFontColor: getContrastTextColor(hex),
+                      },
+                      !!login.userId.value
+                    );
                   }}
                   onContextMenu={(event: MouseEvent) => {
                     event.preventDefault();

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
@@ -271,14 +271,18 @@ function sharedHighlightDecorationId(
  * Broadcasts a decoration to the rest of a shared session by creating one
  * `VerseDecoration` per selected verse. The decoration is synced through
  * `SessionsManager`'s existing decorations CRDT, so other connected clients
- * see the exact same visual styling.
+ * see the same highlight, drawn by the reader's own ribbon layer.
+ *
+ * The decoration carries the highlight's `colorId` rather than a resolved
+ * colour, so a preset lands as each participant's theme renders it — a peer in
+ * dark mode gets their dark-mode yellow, not the sender's.
  *
  * If the session's `highlightDurationSeconds` is set (non-null, non-zero),
  * we schedule a local removal after that many seconds — the removal also
  * propagates through the CRDT so every client clears it at once.
  */
 function broadcastDecorationToSession(
-  session: BibleReadingSession | null,
+  session: BibleReadingSession,
   rs: BibleReadingState,
   details: {
     colorId: string;
@@ -286,21 +290,10 @@ function broadcastDecorationToSession(
     customFontColor?: string;
   }
 ): void {
-  if (!session) return;
   const verses = rs.selectedVerses.value;
   if (verses.length === 0) return;
 
   const duration = session.options.value.highlightDurationSeconds;
-  const style = details.customColor
-    ? {
-        backgroundColor: details.customColor,
-        color:
-          details.customFontColor ?? getContrastTextColor(details.customColor),
-      }
-    : undefined;
-  const className = details.customColor
-    ? ""
-    : `sb-highlight-${details.colorId}`;
 
   for (const verse of verses) {
     const id = sharedHighlightDecorationId(
@@ -313,8 +306,7 @@ function broadcastDecorationToSession(
       verse.chapterNumber,
       verse.verse.number,
       {
-        className,
-        ...(style ? { style } : {}),
+        highlight: details,
         preserveOnChapterChange: false,
         removeAfterMs: duration ? duration * 1000 : undefined,
       },
@@ -343,30 +335,31 @@ function removeSharedHighlightsFromSelection(
   rs: BibleReadingState
 ): void {
   for (const verse of rs.selectedVerses.value) {
-    const id = sharedHighlightDecorationId(
-      verse.bookId,
-      verse.chapterNumber,
-      verse.verse.number
+    session.removeSharedDecoration(
+      sharedHighlightDecorationId(
+        verse.bookId,
+        verse.chapterNumber,
+        verse.verse.number
+      )
     );
-    if (session) {
-      session.removeSharedDecoration(id);
-    } else {
-      rs.removeDecoration(id);
-    }
   }
 }
 
 /**
- * Applies a highlight to the current selection with the right lifetime for
- * the current context:
+ * Applies a highlight to the current selection with the right lifetime for the
+ * current context:
  *
  * - Not in a shared session → save permanently via HighlightsManager.
- * - In a shared session with `highlightDurationSeconds` = null (∞) → save
- *   permanently AND broadcast a decoration so other clients see it.
- * - In a shared session with a finite duration → broadcast a decoration
- *   only. Don't persist to HighlightsManager, and also clear any existing
- *   permanent highlight on the same verses so the originating user's view
- *   stays in sync with the timer.
+ * - In a shared session but not permitted to broadcast → save permanently. This
+ *   highlight reaches nobody else, so it is an ordinary personal one.
+ * - Broadcasting with `highlightDurationSeconds` = null (∞) → save permanently
+ *   AND broadcast a decoration so other clients see it. The saved copy is the
+ *   author's alone: participants get the broadcast, not a highlight of their
+ *   own, and the author still has theirs once the session ends.
+ * - Broadcasting with a finite duration → broadcast a decoration only. Don't
+ *   persist, and clear any existing permanent highlight on the same verses so
+ *   the author's view stays in sync with the timer — otherwise the old
+ *   highlight resurfaces on their screen alone once the broadcast expires.
  */
 function applyHighlightWithSession(
   rs: BibleReadingState,
@@ -377,20 +370,25 @@ function applyHighlightWithSession(
     customFontColor?: string;
   }
 ): void {
-  // const duration = session?.options.value.highlightDurationSeconds ?? null;
-  // const isTransient = session !== null && duration !== null && duration > 0;
-
-  if (!session || session.userCanDecorate(session.localSessionId.value)) {
+  if (!session || !session.userCanDecorate(session.localSessionId.value)) {
+    // A participant who can't broadcast used to match neither branch here, so
+    // highlighting silently did nothing for them.
     void rs.highlightSelectedVerses(details);
+    return;
   }
 
-  // if (isTransient) {
-  //   // Wipe any prior permanent highlight on these verses so the timer is
-  //   // the sole source of truth for how long the highlight shows.
-  //   void rs.unhighlightSelectedVerses();
-  // } else {
-  //   void rs.highlightSelectedVerses(details);
-  // }
+  const duration = session.options.value.highlightDurationSeconds;
+  const isTransient = duration !== null && duration > 0;
+
+  if (isTransient) {
+    // Wipe any prior permanent highlight on these verses so the timer is the
+    // sole source of truth for how long the highlight shows. Scoped to the
+    // verses the user just re-highlighted, so nothing they weren't acting on
+    // is touched.
+    void rs.unhighlightSelectedVerses();
+  } else {
+    void rs.highlightSelectedVerses(details);
+  }
 
   broadcastDecorationToSession(session, rs, details);
 }
@@ -757,36 +755,43 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
     }, 300);
   };
 
+  // Clear removes a saved highlight *and* the session's broadcast copy, so it
+  // stays enabled while either is present. Testing only decorations inside a
+  // session meant the button greyed itself out the moment the session's
+  // highlight timer expired, with the saved highlight still on screen.
   const hasAnyHighlighted = useComputed(() => {
     const rs = readingState.value;
     if (!rs) return false;
 
-    if (
-      sessionState.value &&
-      sessionState.value.userCanDecorate(
-        sessionState.value.localSessionId.value
+    const hasSavedHighlight = rs.selectedVerses.value.some((verse) =>
+      rs.highlights.value.highlights.some((highlight) =>
+        highlightContainsVerse(highlight, verse.verse.number)
       )
-    ) {
-      // Shared sessions use decorations, not highlights
-      const currentBookId = rs.bookId.value;
-      const currentChapterNumber = rs.chapterNumber.value;
-
-      return rs.selectedVerses.value.some((verse) =>
-        rs.decorations.value.some(
-          (d) =>
-            d.bookId === currentBookId &&
-            d.chapterNumber === currentChapterNumber &&
-            d.verses.includes(verse.verse.number)
-        )
-      );
-    } else {
-      return rs.selectedVerses.value.some((verse) => {
-        const existing = rs.highlights.value.highlights.find((h) =>
-          highlightContainsVerse(h, verse.verse.number)
-        );
-        return !!existing;
-      });
+    );
+    if (hasSavedHighlight) {
+      return true;
     }
+
+    const session = sessionState.value;
+    if (!session || !session.userCanDecorate(session.localSessionId.value)) {
+      return false;
+    }
+
+    // Only decorations clear can actually remove — its own shared highlights,
+    // by deterministic id. An unrelated decoration from an extension sitting on
+    // the same verse shouldn't light up a button that won't touch it.
+    const decorationIds = new Set(
+      rs.decorations.value.map((decoration) => decoration.id)
+    );
+    return rs.selectedVerses.value.some((verse) =>
+      decorationIds.has(
+        sharedHighlightDecorationId(
+          verse.bookId,
+          verse.chapterNumber,
+          verse.verse.number
+        )
+      )
+    );
   });
 
   const selectedVersesReference = useComputed(() => {
@@ -1667,21 +1672,24 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                 onClick={() => {
                   const rs = readingState.value;
                   if (!rs) return;
+                  const session = sessionState.value;
                   if (
-                    sessionState.value &&
-                    sessionState.value.userCanDecorate(
-                      sessionState.value.localSessionId.value
-                    )
+                    session &&
+                    session.userCanDecorate(session.localSessionId.value)
                   ) {
                     // Clean up the shared decoration first so the removal
                     // propagates to other clients even if the local
                     // unhighlight is a no-op (e.g. user isn't logged in
                     // with HighlightsManager but the session had a
                     // decoration broadcast earlier).
-                    removeSharedHighlightsFromSelection(sessionState.value, rs);
-                  } else {
-                    rs.unhighlightSelectedVerses();
+                    removeSharedHighlightsFromSelection(session, rs);
                   }
+                  // Clear the saved highlight too. Highlights broadcast to a
+                  // session aren't saved, but a personal one can still be
+                  // sitting on these verses — made before joining, or made
+                  // while the user had no permission to broadcast — and
+                  // "clear" has to mean the verse ends up unhighlighted.
+                  void rs.unhighlightSelectedVerses();
                 }}
                 aria-label={t("clear-highlight", {
                   defaultValue: "Clear highlight",

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
@@ -356,10 +356,10 @@ function removeSharedHighlightsFromSelection(
  *   AND broadcast a decoration so other clients see it. The saved copy is the
  *   author's alone: participants get the broadcast, not a highlight of their
  *   own, and the author still has theirs once the session ends.
- * - Broadcasting with a finite duration → broadcast a decoration only. Don't
- *   persist, and clear any existing permanent highlight on the same verses so
- *   the author's view stays in sync with the timer — otherwise the old
- *   highlight resurfaces on their screen alone once the broadcast expires.
+ * - Broadcasting with a finite duration → broadcast a decoration only, and
+ *   leave any existing personal highlight on those verses alone. The broadcast
+ *   covers it for as long as it lives (the reader draws a decoration highlight
+ *   over a saved one) and it reappears when the broadcast expires.
  */
 function applyHighlightWithSession(
   rs: BibleReadingState,
@@ -380,13 +380,7 @@ function applyHighlightWithSession(
   const duration = session.options.value.highlightDurationSeconds;
   const isTransient = duration !== null && duration > 0;
 
-  if (isTransient) {
-    // Wipe any prior permanent highlight on these verses so the timer is the
-    // sole source of truth for how long the highlight shows. Scoped to the
-    // verses the user just re-highlighted, so nothing they weren't acting on
-    // is touched.
-    void rs.unhighlightSelectedVerses();
-  } else {
+  if (!isTransient) {
     void rs.highlightSelectedVerses(details);
   }
 

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
@@ -1834,7 +1834,6 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                   ? t("remove-bookmark", { defaultValue: "Remove bookmark" })
                   : t("bookmark-verses", { defaultValue: "Bookmark" });
 
-                // const canHighlight = !sessionState.value || sessionState.value.userCanDecorate(sessionState.value.localSessionId.value);
                 const highlightCard = selectionUI.value.showHighlightColors ? (
                   <div key="highlight" className="sb-verse-toolbar-action-item">
                     <button

--- a/packages/seed-bible/seed-bible/managers/BibleReadingManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/BibleReadingManager.tsx
@@ -126,6 +126,8 @@ export interface VerseDecoration {
   containerClassName?: string;
   /** Optional inline style to apply to the decorated verse/range. */
   style?: JSX.CSSProperties;
+  /** Renders the decorated verses as a highlight. See `VerseDecorationInput`. */
+  highlight?: Omit<ChapterHighlight, "verse">;
   /** Optional delay in milliseconds before this decoration auto-removes itself. */
   removeAfterMs?: number;
 
@@ -149,6 +151,20 @@ export interface VerseDecorationInput {
 
   /** Optional inline style to apply to the decorated verse/range. */
   style?: JSX.CSSProperties;
+
+  /**
+   * Renders the decorated verses as a highlight, drawn by the same SVG ribbon
+   * layer as the reader's own highlights — so a preset `colorId` resolves
+   * against each viewer's active theme rather than a colour baked in here.
+   *
+   * Prefer this over hand-writing `className`/`style`: the reader paints
+   * highlight backgrounds in the ribbon layer, not in CSS, so a
+   * `sb-highlight-<id>` class alone sets only the font colour.
+   *
+   * Takes precedence over a saved highlight on the same verse.
+   */
+  highlight?: Omit<ChapterHighlight, "verse">;
+
   /** Optional delay in milliseconds before this decoration auto-removes itself. */
   removeAfterMs?: number;
 

--- a/packages/seed-bible/seed-bible/managers/HighlightsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/HighlightsManager.tsx
@@ -450,12 +450,9 @@ export function createHighlightsManager(
     const chapterHighlightsSignal = getOrCreateChapterHighlightsSignal(address);
     const normalized = normalizeHighlights(highlights);
 
-    // Optimistically update local state before waiting for persistence.
-    chapterHighlightsSignal.value = {
-      highlights: normalized,
-    };
-    loadedAddresses.add(address);
-
+    // Settle who the user is before showing anything. `login()` opens a modal,
+    // and applying first left the highlight sitting behind it looking saved —
+    // then quietly not saving when the prompt was dismissed.
     if (!login.userId.value) {
       await login.login();
     }
@@ -465,6 +462,13 @@ export function createHighlightsManager(
       console.warn("Unable to save highlights: user is not authenticated.");
       return;
     }
+
+    // Show it before waiting on the write, which is the point of doing this
+    // optimistically; for an already-signed-in user nothing above suspends.
+    chapterHighlightsSignal.value = {
+      highlights: normalized,
+    };
+    loadedAddresses.add(address);
 
     const payload = chapterHighlightsSchema.parse({
       highlights: normalized,
@@ -576,6 +580,18 @@ export function createHighlightsManager(
       chapterNumber
     );
     await awaitChapterLoad(address);
+
+    // Nothing saved on these verses — no write to make, and no reason to ask an
+    // anonymous user to sign in just to clear a highlight that was never theirs
+    // to save (a session's broadcast highlight, say).
+    const coversAnyVerse = deduplicatedVerseNumbers.some((verseNumber) =>
+      current.value.highlights.some((highlight) =>
+        highlightContainsVerse(highlight, verseNumber)
+      )
+    );
+    if (!coversAnyVerse) {
+      return;
+    }
 
     const targetRanges = rangesFromVerseNumbers(deduplicatedVerseNumbers);
     let updated = current.value.highlights.map(toRangeHighlight);

--- a/packages/seed-bible/seed-bible/managers/SessionsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SessionsManager.tsx
@@ -357,6 +357,7 @@ function toSessionDecorationInput(
     endIndex: decoration.endIndex,
     className: decoration.className,
     style: decoration.style,
+    highlight: decoration.highlight,
     removeAfterMs: decoration.removeAfterMs,
     preserveOnChapterChange: decoration.preserveOnChapterChange,
     translationId: decoration.translationId,

--- a/packages/twitchSub-extension/ext_twitchSub/client/twitchSubManager.tsx
+++ b/packages/twitchSub-extension/ext_twitchSub/client/twitchSubManager.tsx
@@ -281,11 +281,21 @@ export function CreateTwitchSubState(
                     ])
                   : Number(highlight.verse),
                 {
-                  style: {
-                    color: highlight.customFontColor || "inherit",
-                    backgroundColor: highlight.customColor || null,
+                  // `sb-highlight-<id>` only sets a font colour — the reader
+                  // paints highlight backgrounds in its SVG ribbon layer, so
+                  // hand-rolling the CSS here stopped showing anything. Handing
+                  // over the colour lets the reader draw it, as an outline
+                  // (it isn't the reader's own highlight) resolved against
+                  // whichever theme they're using.
+                  highlight: {
+                    colorId: highlight.color,
+                    ...(highlight.customColor
+                      ? { customColor: highlight.customColor }
+                      : {}),
+                    ...(highlight.customFontColor
+                      ? { customFontColor: highlight.customFontColor }
+                      : {}),
                   },
-                  className: `sb-highlight-${highlight.color}`,
                   preserveOnChapterChange: true,
                 }
               );

--- a/test/unit/seed-bible/components/BibleReader.test.tsx
+++ b/test/unit/seed-bible/components/BibleReader.test.tsx
@@ -1056,6 +1056,244 @@ describe("BibleReader", () => {
     expect(wrapper?.getAttribute("data-highlight-fill")).toBe("#123456");
   });
 
+  it("draws a decoration carrying a preset highlight through the ribbon layer", () => {
+    const { slot, selectorState, readingState, decorations } = createFixture();
+
+    decorations.value = [
+      {
+        id: "shared-highlight:GEN:1:1",
+        translationId: "BSB",
+        bookId: "GEN",
+        chapterNumber: 1,
+        verses: [1],
+        highlight: { colorId: "yellow" },
+      },
+    ];
+
+    act(() => {
+      render(
+        <BibleReader
+          currentSlot={slot}
+          selectorState={selectorState}
+          readingState={readingState}
+        />,
+        container
+      );
+    });
+
+    // The fill stays a CSS-var reference so each viewer resolves it against
+    // their own theme, rather than a color baked in by whoever broadcast it.
+    const wrapper = container.querySelector(
+      ".sb-highlight-yellow"
+    ) as HTMLElement | null;
+    expect(wrapper).not.toBeNull();
+    expect(wrapper?.getAttribute("data-highlight-fill")).toBe(
+      "var(--sb-highlight-yellow-color)"
+    );
+  });
+
+  it("draws a decoration carrying a custom highlight color through the ribbon layer", () => {
+    const { slot, selectorState, readingState, decorations } = createFixture();
+
+    decorations.value = [
+      {
+        id: "shared-highlight:GEN:1:1",
+        translationId: "BSB",
+        bookId: "GEN",
+        chapterNumber: 1,
+        verses: [1],
+        highlight: {
+          colorId: "yellow",
+          customColor: "#123456",
+          customFontColor: "#abcdef",
+        },
+      },
+    ];
+
+    act(() => {
+      render(
+        <BibleReader
+          currentSlot={slot}
+          selectorState={selectorState}
+          readingState={readingState}
+        />,
+        container
+      );
+    });
+
+    const wrapper = container.querySelector(
+      "[data-highlight-fill]"
+    ) as HTMLElement | null;
+    expect(wrapper?.getAttribute("data-highlight-fill")).toBe("#123456");
+    expect(wrapper?.style.color).toBe("rgb(171, 205, 239)");
+  });
+
+  it("merges contiguous verses sharing a decoration highlight into one ribbon", () => {
+    const { slot, selectorState, readingState, decorations, chapterData } =
+      createFixture();
+
+    chapterData.value = {
+      ...chapterData.value!,
+      chapter: {
+        ...chapterData.value!.chapter,
+        content: [
+          { type: "verse", number: 1, content: ["First verse. "] },
+          { type: "verse", number: 2, content: ["Second verse."] },
+        ],
+      },
+    };
+    decorations.value = [
+      {
+        id: "shared-highlight:GEN:1:1",
+        translationId: "BSB",
+        bookId: "GEN",
+        chapterNumber: 1,
+        verses: [1],
+        highlight: { colorId: "green" },
+      },
+      {
+        id: "shared-highlight:GEN:1:2",
+        translationId: "BSB",
+        bookId: "GEN",
+        chapterNumber: 1,
+        verses: [2],
+        highlight: { colorId: "green" },
+      },
+    ];
+
+    act(() => {
+      render(
+        <BibleReader
+          currentSlot={slot}
+          selectorState={selectorState}
+          readingState={readingState}
+        />,
+        container
+      );
+    });
+
+    // One wrapper spanning both verses, so the layer draws a single continuous
+    // ribbon rather than two abutting shapes.
+    const wrappers = container.querySelectorAll("[data-highlight-fill]");
+    expect(wrappers.length).toBe(1);
+    expect(wrappers[0]?.getAttribute("data-highlight-key")).toBe("1-2");
+  });
+
+  it("lets a decoration highlight win over a saved highlight on the same verse", () => {
+    const { slot, selectorState, readingState, highlights, decorations } =
+      createFixture();
+
+    highlights.value = {
+      highlights: [{ verse: 1, colorId: "yellow" }],
+    };
+    decorations.value = [
+      {
+        id: "shared-highlight:GEN:1:1",
+        translationId: "BSB",
+        bookId: "GEN",
+        chapterNumber: 1,
+        verses: [1],
+        highlight: { colorId: "green" },
+      },
+    ];
+
+    act(() => {
+      render(
+        <BibleReader
+          currentSlot={slot}
+          selectorState={selectorState}
+          readingState={readingState}
+        />,
+        container
+      );
+    });
+
+    const wrapper = container.querySelector(
+      "[data-highlight-fill]"
+    ) as HTMLElement | null;
+    expect(wrapper?.getAttribute("data-highlight-fill")).toBe(
+      "var(--sb-highlight-green-color)"
+    );
+    expect(wrapper?.classList.contains("sb-highlight-yellow")).toBe(false);
+  });
+
+  it("keeps decoration highlights visible when showHighlights is off", () => {
+    const { slot, selectorState, readingState, highlights, decorations } =
+      createFixture();
+
+    // The setting hides the reader's own saved highlights; a session peer's
+    // broadcast is a live signal and stays on screen.
+    highlights.value = {
+      highlights: [{ verse: 1, colorId: "yellow" }],
+    };
+    decorations.value = [
+      {
+        id: "shared-highlight:GEN:1:2",
+        translationId: "BSB",
+        bookId: "GEN",
+        chapterNumber: 1,
+        verses: [2],
+        highlight: { colorId: "green" },
+      },
+    ];
+
+    act(() => {
+      render(
+        <BibleReader
+          currentSlot={slot}
+          selectorState={selectorState}
+          readingState={readingState}
+          scriptureElements={{
+            showHeadings: true,
+            showVerseNumbers: true,
+            showFootnotes: true,
+            showHighlights: false,
+            showRedLettering: true,
+          }}
+        />,
+        container
+      );
+    });
+
+    const wrappers = Array.from(
+      container.querySelectorAll("[data-highlight-fill]")
+    );
+    expect(wrappers.map((w) => w.getAttribute("data-highlight-fill"))).toEqual([
+      "var(--sb-highlight-green-color)",
+    ]);
+  });
+
+  it("ignores a decoration highlight that targets text inside a verse", () => {
+    const { slot, selectorState, readingState, decorations } = createFixture();
+
+    // The ribbon layer works per verse-run, so a fragment-targeted highlight
+    // can't be drawn as one — it must not swallow the whole verse instead.
+    decorations.value = [
+      {
+        id: "decoration-1",
+        translationId: "BSB",
+        bookId: "GEN",
+        chapterNumber: 1,
+        verses: [1],
+        targetContent: "beginning",
+        highlight: { colorId: "yellow" },
+      },
+    ];
+
+    act(() => {
+      render(
+        <BibleReader
+          currentSlot={slot}
+          selectorState={selectorState}
+          readingState={readingState}
+        />,
+        container
+      );
+    });
+
+    expect(container.querySelector("[data-highlight-fill]")).toBeNull();
+  });
+
   it("displays decorations for any translation when decoration translationId is null", () => {
     const { slot, selectorState, readingState, decorations } = createFixture();
 

--- a/test/unit/seed-bible/components/BibleReader.test.tsx
+++ b/test/unit/seed-bible/components/BibleReader.test.tsx
@@ -1179,6 +1179,106 @@ describe("BibleReader", () => {
     expect(wrappers[0]?.getAttribute("data-highlight-key")).toBe("1-2");
   });
 
+  it("marks a decoration highlight as a broadcast and leaves a saved one unmarked", () => {
+    const { slot, selectorState, readingState, highlights, decorations } =
+      createFixture();
+
+    highlights.value = {
+      highlights: [{ verse: 1, colorId: "yellow" }],
+    };
+    decorations.value = [
+      {
+        id: "shared-highlight:GEN:1:2",
+        translationId: "BSB",
+        bookId: "GEN",
+        chapterNumber: 1,
+        verses: [2],
+        highlight: { colorId: "green" },
+      },
+    ];
+
+    act(() => {
+      render(
+        <BibleReader
+          currentSlot={slot}
+          selectorState={selectorState}
+          readingState={readingState}
+        />,
+        container
+      );
+    });
+
+    // The ribbon layer reads this off the DOM to decide outline vs solid.
+    const wrappers = Array.from(
+      container.querySelectorAll("[data-highlight-fill]")
+    );
+    const marks = wrappers.map((w) => [
+      w.getAttribute("data-highlight-fill"),
+      w.getAttribute("data-highlight-broadcast"),
+    ]);
+    expect(marks).toEqual([
+      ["var(--sb-highlight-yellow-color)", null],
+      ["var(--sb-highlight-green-color)", "true"],
+    ]);
+  });
+
+  it("does not merge a broadcast and a saved highlight of the same color into one run", () => {
+    const {
+      slot,
+      selectorState,
+      readingState,
+      highlights,
+      decorations,
+      chapterData,
+    } = createFixture();
+
+    chapterData.value = {
+      ...chapterData.value!,
+      chapter: {
+        ...chapterData.value!.chapter,
+        content: [
+          { type: "verse", number: 1, content: ["First verse. "] },
+          { type: "verse", number: 2, content: ["Second verse."] },
+        ],
+      },
+    };
+
+    highlights.value = {
+      highlights: [{ verse: 1, colorId: "green" }],
+    };
+    decorations.value = [
+      {
+        id: "shared-highlight:GEN:1:2",
+        translationId: "BSB",
+        bookId: "GEN",
+        chapterNumber: 1,
+        verses: [2],
+        highlight: { colorId: "green" },
+      },
+    ];
+
+    act(() => {
+      render(
+        <BibleReader
+          currentSlot={slot}
+          selectorState={selectorState}
+          readingState={readingState}
+        />,
+        container
+      );
+    });
+
+    // Same color, but one draws solid and the other outlined — merging them into
+    // a single continuous ribbon would paint both the same way.
+    const wrappers = Array.from(
+      container.querySelectorAll("[data-highlight-fill]")
+    );
+    expect(wrappers.length).toBe(2);
+    expect(
+      wrappers.map((w) => w.getAttribute("data-highlight-broadcast"))
+    ).toEqual([null, "true"]);
+  });
+
   it("lets a decoration highlight win over a saved highlight on the same verse", () => {
     const { slot, selectorState, readingState, highlights, decorations } =
       createFixture();

--- a/test/unit/seed-bible/components/BibleReader.test.tsx
+++ b/test/unit/seed-bible/components/BibleReader.test.tsx
@@ -816,7 +816,7 @@ describe("BibleReader", () => {
     ) as HTMLElement | null;
     expect(wrapper).not.toBeNull();
     expect(wrapper?.getAttribute("data-highlight-fill")).toBe(
-      "var(--sb-highlight-yellow-color)"
+      "var(--sb-highlight-yellow-color, transparent)"
     );
     const firstDecorator = container.querySelector(
       ".sb-verse-decorator"
@@ -866,7 +866,7 @@ describe("BibleReader", () => {
     const wrapper = highlightEls[0] as HTMLElement;
     expect(wrapper.classList.contains("sb-verse-decorator")).toBe(false);
     expect(wrapper.getAttribute("data-highlight-fill")).toBe(
-      "var(--sb-highlight-yellow-color)"
+      "var(--sb-highlight-yellow-color, transparent)"
     );
     expect(wrapper.querySelectorAll(".sb-verse").length).toBe(2);
     // The verses' own decorators stay transparent (no highlight of their own).
@@ -1088,7 +1088,7 @@ describe("BibleReader", () => {
     ) as HTMLElement | null;
     expect(wrapper).not.toBeNull();
     expect(wrapper?.getAttribute("data-highlight-fill")).toBe(
-      "var(--sb-highlight-yellow-color)"
+      "var(--sb-highlight-yellow-color, transparent)"
     );
   });
 
@@ -1244,8 +1244,8 @@ describe("BibleReader", () => {
       w.getAttribute("data-highlight-broadcast"),
     ]);
     expect(marks).toEqual([
-      ["var(--sb-highlight-yellow-color)", null],
-      ["var(--sb-highlight-green-color)", "true"],
+      ["var(--sb-highlight-yellow-color, transparent)", null],
+      ["var(--sb-highlight-green-color, transparent)", "true"],
     ]);
   });
 
@@ -1339,7 +1339,7 @@ describe("BibleReader", () => {
       "[data-highlight-fill]"
     ) as HTMLElement | null;
     expect(wrapper?.getAttribute("data-highlight-fill")).toBe(
-      "var(--sb-highlight-green-color)"
+      "var(--sb-highlight-green-color, transparent)"
     );
     expect(wrapper?.classList.contains("sb-highlight-yellow")).toBe(false);
   });
@@ -1386,7 +1386,7 @@ describe("BibleReader", () => {
       container.querySelectorAll("[data-highlight-fill]")
     );
     expect(wrappers.map((w) => w.getAttribute("data-highlight-fill"))).toEqual([
-      "var(--sb-highlight-green-color)",
+      "var(--sb-highlight-green-color, transparent)",
     ]);
   });
 

--- a/test/unit/seed-bible/components/BibleReader.test.tsx
+++ b/test/unit/seed-bible/components/BibleReader.test.tsx
@@ -1179,6 +1179,33 @@ describe("BibleReader", () => {
     expect(wrappers[0]?.getAttribute("data-highlight-key")).toBe("1-2");
   });
 
+  it("uses a custom highlight color even when no font color comes with it", () => {
+    const { slot, selectorState, readingState, highlights } = createFixture();
+
+    // The font color is optional in the schema; requiring it meant a highlight
+    // like this silently fell back to rendering as its preset color.
+    highlights.value = {
+      highlights: [{ verse: 1, colorId: "yellow", customColor: "#123456" }],
+    };
+
+    act(() => {
+      render(
+        <BibleReader
+          currentSlot={slot}
+          selectorState={selectorState}
+          readingState={readingState}
+        />,
+        container
+      );
+    });
+
+    const wrapper = container.querySelector(
+      "[data-highlight-fill]"
+    ) as HTMLElement | null;
+    expect(wrapper?.getAttribute("data-highlight-fill")).toBe("#123456");
+    expect(wrapper?.style.color).toBe("");
+  });
+
   it("marks a decoration highlight as a broadcast and leaves a saved one unmarked", () => {
     const { slot, selectorState, readingState, highlights, decorations } =
       createFixture();

--- a/test/unit/seed-bible/components/BibleReaderToolbar.test.tsx
+++ b/test/unit/seed-bible/components/BibleReaderToolbar.test.tsx
@@ -189,6 +189,8 @@ describe("BibleReaderToolbar — clearing highlights", () => {
     state = await createTestSeedBibleState({
       responses: createPrivateEndpointResponses(),
     });
+    stubRecords();
+    signIn();
 
     await act(async () => {
       window.dispatchEvent(new Event("resize"));
@@ -199,6 +201,50 @@ describe("BibleReaderToolbar — clearing highlights", () => {
     render(null, container);
     container.remove();
   });
+
+  /**
+   * Highlights are stored per user, so a signed-in fixture starts reading and
+   * writing records. Nothing here is about the wire format — stub both ends so
+   * a chapter loads empty and a save reports success.
+   */
+  function stubRecords() {
+    Object.defineProperty(state.os, "getData", {
+      value: vi.fn(async () => null),
+      configurable: true,
+      writable: true,
+    });
+    Object.defineProperty(state.os, "recordData", {
+      value: vi.fn(async () => ({ success: true })),
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  /**
+   * Gives the state a signed-in user. `userId` is a computed off the session
+   * key, so it can't be assigned — but the managers read `login.userId` off the
+   * same object at call time, so swapping the property reaches all of them.
+   * Signed in is the default here because it's the case these tests are about;
+   * the signed-out ones say so explicitly.
+   */
+  function signIn(userId: string | null = "user-1") {
+    Object.defineProperty(state.login, "userId", {
+      value: signal(userId),
+      configurable: true,
+      writable: true,
+    });
+  }
+
+  /** Spy on the login prompt so a test can assert it never opens. */
+  function watchLoginPrompt() {
+    const prompt = vi.fn(async () => null);
+    Object.defineProperty(state.login, "login", {
+      value: prompt,
+      configurable: true,
+      writable: true,
+    });
+    return prompt;
+  }
 
   /**
    * Minimal stand-in for a joined session. The toolbar only reaches for
@@ -290,6 +336,9 @@ describe("BibleReaderToolbar — clearing highlights", () => {
     }
     await act(async () => {
       element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      // Highlighting is fire-and-forget from the handler and a signed-in save
+      // waits on a record read first, so let that chain settle before asserting.
+      await new Promise((resolve) => setTimeout(resolve, 0));
     });
   }
 
@@ -369,6 +418,51 @@ describe("BibleReaderToolbar — clearing highlights", () => {
     // highlighted destroyed your own colour once the timer ran out.
     expect(readingState.highlights.value.highlights).toHaveLength(1);
     expect(broadcastHighlights()).toHaveLength(1);
+  });
+
+  it("broadcasts without prompting a signed-out user to log in, even with no expiry", async () => {
+    signIn(null);
+    const prompt = watchLoginPrompt();
+    attachFakeSession({ highlightDurationSeconds: null });
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+
+    // Broadcasting only needs a connection id. Reaching for the save path would
+    // open the login modal over a highlight the session is already carrying.
+    expect(broadcastHighlights()).toHaveLength(1);
+    expect(readingState.highlights.value.highlights).toHaveLength(0);
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it("does not prompt a signed-out user to log in when clearing a broadcast-only highlight", async () => {
+    signIn(null);
+    attachFakeSession({ highlightDurationSeconds: 16 });
+    await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+
+    // Nothing was ever saved, so clearing has no write to make — and asking for
+    // an account to undo something that never persisted is pure interruption.
+    const prompt = watchLoginPrompt();
+    await click(".sb-verse-toolbar-clear");
+
+    expect(broadcastHighlights()).toHaveLength(0);
+    expect(prompt).not.toHaveBeenCalled();
+  });
+
+  it("does not apply a highlight a signed-out user declines to log in for", async () => {
+    signIn(null);
+    const prompt = watchLoginPrompt();
+    // Restricted participant: saving is the only thing highlighting can mean.
+    attachFakeSession({ canDecorate: false });
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+
+    expect(prompt).toHaveBeenCalled();
+    // The highlight used to appear behind the modal and then never save.
+    expect(readingState.highlights.value.highlights).toHaveLength(0);
   });
 
   it("saves a personal highlight instead, when not allowed to broadcast", async () => {

--- a/test/unit/seed-bible/components/BibleReaderToolbar.test.tsx
+++ b/test/unit/seed-bible/components/BibleReaderToolbar.test.tsx
@@ -350,7 +350,7 @@ describe("BibleReaderToolbar — clearing highlights", () => {
     expect(readingState.highlights.value.highlights).toHaveLength(1);
   });
 
-  it("drops a personal highlight the author already had when broadcasting with a timer", async () => {
+  it("keeps a personal highlight the author already had when broadcasting with a timer", async () => {
     // Highlight under ∞ (saved), then switch the session to a finite duration
     // and re-highlight the same verse.
     const { options } = attachFakeSession({ highlightDurationSeconds: null });
@@ -364,9 +364,10 @@ describe("BibleReaderToolbar — clearing highlights", () => {
     });
     await openPickerAndHighlight();
 
-    // Without this the saved copy resurfaces on the author's screen alone once
-    // the broadcast expires.
-    expect(readingState.highlights.value.highlights).toHaveLength(0);
+    // The broadcast covers the saved highlight while it lives and uncovers it
+    // on expiry. Deleting it here meant highlighting a verse you had already
+    // highlighted destroyed your own colour once the timer ran out.
+    expect(readingState.highlights.value.highlights).toHaveLength(1);
     expect(broadcastHighlights()).toHaveLength(1);
   });
 

--- a/test/unit/seed-bible/components/BibleReaderToolbar.test.tsx
+++ b/test/unit/seed-bible/components/BibleReaderToolbar.test.tsx
@@ -1,5 +1,6 @@
 import { render } from "preact";
 import { act } from "preact/test-utils";
+import { signal } from "@preact/signals";
 import { BibleReaderToolbar } from "@packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar";
 import type { SeedBibleState } from "@packages/seed-bible/seed-bible/managers/SeedBibleStateManager";
 import type { ChapterVerse } from "@packages/seed-bible/seed-bible/managers/FreeUseBibleAPI";
@@ -171,6 +172,283 @@ describe("BibleReaderToolbar — verse toolbar vs. fullscreen panes", () => {
     });
 
     expect(readingState.selectedVerses.value).toHaveLength(1);
+  });
+});
+
+describe("BibleReaderToolbar — clearing highlights", () => {
+  let container: HTMLDivElement;
+  let state: SeedBibleState;
+
+  beforeEach(async () => {
+    window.innerWidth = MOBILE_VIEWPORT_WIDTH;
+    window.innerHeight = 800;
+
+    container = document.createElement("div");
+    document.body.appendChild(container);
+
+    state = await createTestSeedBibleState({
+      responses: createPrivateEndpointResponses(),
+    });
+
+    await act(async () => {
+      window.dispatchEvent(new Event("resize"));
+    });
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  /**
+   * Minimal stand-in for a joined session. The toolbar only reaches for
+   * permissions, the highlight duration, and the shared-decoration removal
+   * during this flow; `sharedSession` is otherwise handed to lazily-opened
+   * modals.
+   */
+  function attachFakeSession({
+    canDecorate = true,
+    highlightDurationSeconds = 16 as number | null,
+  } = {}) {
+    const removeSharedDecoration = vi.fn((decorationId: string) => {
+      readingStateOf().removeDecoration(decorationId);
+    });
+    const options = signal({
+      allowedNavigators: null,
+      allowedDecorators: canDecorate ? null : ["someone-else"],
+      hostUserId: "host-user",
+      coHostUserIds: null,
+      highlightDurationSeconds,
+      shareTranslation: true,
+      endedAt: null,
+    });
+    const tab = state.app.currentReadingState.value!.tab;
+    tab.sharedSession = {
+      id: "group-abc",
+      options,
+      localSessionId: signal("user-1"),
+      userCanDecorate: () => canDecorate,
+      userCanNavigate: () => true,
+      isHost: () => canDecorate,
+      removeSharedDecoration,
+      readingState: tab.readingState,
+      allUsers: signal([]),
+      connectedUsers: signal([]),
+      currentUser: signal(null),
+      document: {} as never,
+      updateOptions: vi.fn(),
+      dispose: vi.fn(),
+    } as unknown as NonNullable<typeof tab.sharedSession>;
+    return { removeSharedDecoration, options };
+  }
+
+  function readingStateOf() {
+    return state.app.currentReadingState.value!.tab.readingState;
+  }
+
+  async function selectFirstVerse() {
+    const readingState = readingStateOf();
+    const chapter = readingState.chapterData.value!;
+    const firstVerse = chapter.chapter.content.find(
+      (entry): entry is ChapterVerse =>
+        !!entry &&
+        typeof entry === "object" &&
+        (entry as { type?: string }).type === "verse"
+    )!;
+
+    await act(async () => {
+      readingState.selectVerse(
+        {
+          bookId: chapter.book.id,
+          chapterNumber: chapter.chapter.number,
+          verse: firstVerse,
+          translationId: chapter.translation.id,
+        },
+        10,
+        10
+      );
+    });
+
+    return { readingState, verseNumber: firstVerse.number };
+  }
+
+  async function renderToolbar() {
+    await act(async () => {
+      render(
+        <TestHost state={state}>
+          <BibleReaderToolbar state={state} />
+        </TestHost>,
+        container
+      );
+    });
+  }
+
+  async function click(selector: string) {
+    const element = container.querySelector<HTMLButtonElement>(selector);
+    if (!element) {
+      throw new Error(`No element matched ${selector}`);
+    }
+    await act(async () => {
+      element.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+  }
+
+  /** Clicks the first preset colour, opening the picker first if it is closed. */
+  async function openPickerAndHighlight() {
+    if (!container.querySelector(".sb-verse-toolbar-color-button")) {
+      await click(".sb-verse-toolbar-highlight-trigger");
+    }
+    await click(".sb-verse-toolbar-color-button");
+  }
+
+  const clearButton = () =>
+    container.querySelector<HTMLButtonElement>(".sb-verse-toolbar-clear");
+
+  /**
+   * The session's broadcast copies only. Other decorations sit on these verses
+   * too (the reader diminishes deep-linked verses, for one), and clear neither
+   * removes them nor should be enabled by them.
+   */
+  const broadcastHighlights = () =>
+    readingStateOf().decorations.value.filter((decoration) =>
+      decoration.id.startsWith("shared-highlight:")
+    );
+
+  it("removes the saved highlight when clearing outside a session", async () => {
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+
+    expect(readingState.highlights.value.highlights).toHaveLength(1);
+
+    await click(".sb-verse-toolbar-clear");
+
+    expect(readingState.highlights.value.highlights).toHaveLength(0);
+  });
+
+  it("broadcasts without saving when the session expires highlights", async () => {
+    attachFakeSession({ highlightDurationSeconds: 16 });
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+
+    // The timer owns the lifetime. Saving too would outlive the broadcast and
+    // leave the author alone in seeing it.
+    expect(broadcastHighlights()).toHaveLength(1);
+    expect(readingState.highlights.value.highlights).toHaveLength(0);
+  });
+
+  it("saves as well as broadcasts when the session keeps highlights forever", async () => {
+    attachFakeSession({ highlightDurationSeconds: null });
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+
+    // Nothing expires it, so the author keeps a personal copy for after the
+    // session. Participants get the broadcast, not a highlight of their own.
+    expect(broadcastHighlights()).toHaveLength(1);
+    expect(readingState.highlights.value.highlights).toHaveLength(1);
+  });
+
+  it("drops a personal highlight the author already had when broadcasting with a timer", async () => {
+    // Highlight under ∞ (saved), then switch the session to a finite duration
+    // and re-highlight the same verse.
+    const { options } = attachFakeSession({ highlightDurationSeconds: null });
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+    expect(readingState.highlights.value.highlights).toHaveLength(1);
+
+    await act(async () => {
+      options.value = { ...options.value, highlightDurationSeconds: 16 };
+    });
+    await openPickerAndHighlight();
+
+    // Without this the saved copy resurfaces on the author's screen alone once
+    // the broadcast expires.
+    expect(readingState.highlights.value.highlights).toHaveLength(0);
+    expect(broadcastHighlights()).toHaveLength(1);
+  });
+
+  it("saves a personal highlight instead, when not allowed to broadcast", async () => {
+    attachFakeSession({ canDecorate: false });
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+
+    // Nobody else sees this one, so it behaves like any highlight made outside
+    // a session. Previously a restricted participant got neither branch and
+    // highlighting silently did nothing.
+    expect(readingState.highlights.value.highlights).toHaveLength(1);
+    expect(broadcastHighlights()).toHaveLength(0);
+  });
+
+  it("removes the broadcast copy when clearing in a session", async () => {
+    const { removeSharedDecoration } = attachFakeSession();
+    const { verseNumber } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+
+    expect(broadcastHighlights()).toHaveLength(1);
+
+    await click(".sb-verse-toolbar-clear");
+
+    expect(removeSharedDecoration).toHaveBeenCalledWith(
+      `shared-highlight:GEN:1:${verseNumber}`
+    );
+    expect(broadcastHighlights()).toHaveLength(0);
+  });
+
+  it("also clears a personal highlight left on the verses while in a session", async () => {
+    // Highlight with no permission to broadcast (saved personally), then gain
+    // it — the saved highlight is still on the verse and clear has to take it.
+    attachFakeSession({ canDecorate: false });
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+    expect(readingState.highlights.value.highlights).toHaveLength(1);
+
+    attachFakeSession({ canDecorate: true });
+    await renderToolbar();
+    await click(".sb-verse-toolbar-clear");
+
+    expect(readingState.highlights.value.highlights).toHaveLength(0);
+  });
+
+  it("keeps clear enabled for a participant who cannot broadcast", async () => {
+    attachFakeSession({ canDecorate: false });
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+
+    expect(broadcastHighlights()).toHaveLength(0);
+    expect(readingState.highlights.value.highlights).toHaveLength(1);
+    expect(clearButton()?.disabled).toBe(false);
+  });
+
+  it("disables clear in a session once the broadcast copy has expired", async () => {
+    attachFakeSession();
+    const { readingState, verseNumber } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+
+    // Stand in for the session's highlight timer firing. Nothing was saved, so
+    // the verse is genuinely unhighlighted again and there is nothing to clear.
+    await act(async () => {
+      readingState.removeDecoration(`shared-highlight:GEN:1:${verseNumber}`);
+    });
+
+    expect(readingState.highlights.value.highlights).toHaveLength(0);
+    expect(clearButton()?.disabled).toBe(true);
+  });
+
+  it("leaves clear disabled in a session when nothing is highlighted", async () => {
+    attachFakeSession();
+    await selectFirstVerse();
+    await renderToolbar();
+    await click(".sb-verse-toolbar-highlight-trigger");
+
+    expect(clearButton()?.disabled).toBe(true);
   });
 });
 

--- a/test/unit/seed-bible/managers/SessionsManager.test.ts
+++ b/test/unit/seed-bible/managers/SessionsManager.test.ts
@@ -830,6 +830,56 @@ describe("SessionsManager", () => {
     expect(session.readingState.decorations.value).toEqual([remoteDecoration]);
   });
 
+  it("applies a shared decoration's highlight to the reading state", async () => {
+    mockMap = createMockSharedMap({
+      translationId: "BSB",
+      bookId: "GEN",
+      chapterNumber: 1,
+    });
+
+    // `toSessionDecorationInput` copies fields one at a time, so a decoration
+    // field that isn't listed there reaches nobody.
+    const remoteDecoration: VerseDecoration = {
+      id: "shared-highlight:GEN:1:3",
+      translationId: "BSB",
+      bookId: "GEN",
+      chapterNumber: 1,
+      verses: [3],
+      highlight: { colorId: "green" },
+    };
+
+    mockDecorationsMap = createMockSharedMap({
+      [JSON.stringify(["conn-other", "shared-highlight:GEN:1:3"])]:
+        remoteDecoration,
+    });
+    mockDocument.getMap.mockImplementation((name: string) => {
+      if (name === "options") {
+        return mockOptionsMap;
+      }
+
+      if (name === "decorations") {
+        return mockDecorationsMap;
+      }
+
+      return mockMap;
+    });
+
+    const manager = createSessionsManager(
+      os,
+      mockDataManager as any,
+      mockLoginManager as any,
+      mockHighlightsManager as any,
+      i18n
+    );
+    const session = await manager.joinSession("group-abc");
+
+    await waitFor(() => session.readingState.decorations.value.length === 1);
+
+    expect(session.readingState.decorations.value[0]?.highlight).toEqual({
+      colorId: "green",
+    });
+  });
+
   it("applies removeAfterMs from shared decorations", async () => {
     mockMap = createMockSharedMap({
       translationId: "BSB",

--- a/test/unit/twitchSub-extension/client/twitchSubManager.test.tsx
+++ b/test/unit/twitchSub-extension/client/twitchSubManager.test.tsx
@@ -445,21 +445,20 @@ describe("CreateTwitchSubState", () => {
       }),
     });
 
+    // The reader draws these itself now. Handing it the colour rather than CSS
+    // means a preset resolves against each viewer's theme, and it renders as an
+    // outline — a chat highlight isn't the reader's own.
     expect(decorateVerses).toHaveBeenCalledTimes(2);
     expect(decorateVerses).toHaveBeenNthCalledWith(1, "ROM", 8, 5, {
-      style: {
-        color: "inherit",
-        backgroundColor: null,
-      },
-      className: "sb-highlight-yellow",
+      highlight: { colorId: "yellow" },
       preserveOnChapterChange: true,
     });
     expect(decorateVerses).toHaveBeenNthCalledWith(2, "ROM", 8, [10, 11, 12], {
-      style: {
-        color: "#111111",
-        backgroundColor: "#ffeeaa",
+      highlight: {
+        colorId: "red",
+        customColor: "#ffeeaa",
+        customFontColor: "#111111",
       },
-      className: "sb-highlight-red",
       preserveOnChapterChange: true,
     });
   });


### PR DESCRIPTION
Closes #1590.

## What was wrong

Highlighting inside a shared session never created a highlight. It created a **decoration** — the generic per-verse styling channel — and hand-wrote CSS to imitate what a highlight looks like. That imitation broke in July.

`a89016678` ("highlights are now a separate svg layer rendered behind text content") moved highlight backgrounds out of CSS and into an SVG ribbon layer, reducing `.sb-highlight-<id>` to a font colour only. Anything still painting a highlight by applying that class silently stopped painting anything at all.

That accounts for both reported symptoms:

- **Built-in colours didn't work.** The decoration sent `className: "sb-highlight-yellow"` and no background. Custom colours survived only because they carried an inline `backgroundColor`. The person highlighting still saw their own colour, because the same action also saved a real highlight — but that lives in their own record and never reached anyone else.
- **Clear did nothing.** Clear removed the broadcast decoration but never the saved highlight, so the verse stayed coloured.

## The fix

Rather than patch the imitation, decorations can now carry a real highlight:

```ts
rs.decorateVerses(bookId, chapter, verse, { highlight: { colorId: "yellow" } }, id)
```

The reader folds those into its own highlight lookup, so they render through the existing ribbon layer — same rounded shape, same run merging, same fade in and out. Because the `colorId` travels rather than a resolved colour, a preset now renders in **each viewer's own theme**: a participant in dark mode sees their dark-mode yellow, not the sender's.

Three separate call sites were hand-rolling that CSS. This removes the pattern from the codebase.

## Rules for session highlights

Settled with the team over the course of this branch:

| Context | Saves personally | Broadcasts |
| --- | --- | --- |
| Not in a session | yes | — |
| In a session, not permitted to broadcast | yes | no |
| Broadcasting, duration = ∞ | yes | yes |
| Broadcasting, finite duration | no | yes |
| Broadcasting, signed out | no | yes |

A saved copy is always the author's alone — participants receive the broadcast, never a highlight of their own.

A broadcast **covers** a personal highlight rather than replacing it, so when a timed highlight expires the reader's own colour reappears underneath. An earlier design deleted the personal highlight instead; that was shipped in `ef4f1b261`, removed as a bug in `f11f39e55`, briefly restored from a stale comment during this work, and removed again.

## Visual treatment

A broadcast highlight draws as an **outline** — same colour, stroked, reduced fill — while the reader's own stays solid. Without this, a covering highlight and a personal one are indistinguishable, and expiry looks like losing your work.

Under ∞ the highlight is saved *and* broadcast, so it shows as an outline for everyone while the session is live and returns to solid when the user leaves. That needs no special handling: the decoration only exists inside the session tab.

<img width="1023" height="894" alt="image" src="https://github.com/user-attachments/assets/78c6f3a7-f493-422b-9a9f-dabc21a88c97" />

## Also fixed

- **A restricted participant couldn't highlight at all.** `8e3e79997` is titled *"Save user highlights when they aren't allowed to decorate sessions"* but wrote the inverted condition, so those users matched no branch: no saved highlight, and a local-only decoration that never synced and vanished after 16 seconds.
- **Signed-out users were interrupted by a login modal**, with the highlight applied behind it and then quietly not saved. Broadcasting needs only a connection id, so it no longer reaches for the save path. Where signing in *is* the point, the prompt now settles before anything is applied.
- **Clearing prompted for login even when nothing was saved.** Unhighlighting now returns early when no saved highlight covers the selection, which also drops a wasted record write for signed-in users.
- **Twitch chat highlights** had the same broken `sb-highlight-<id>` pattern and are migrated to the new field.
- **An unrecognised colour id painted a solid black bar.** `var(--sb-highlight-<id>-color)` with no fallback is invalid at computed-value time, and `fill` inherits down to its initial value of black. Now falls back to `transparent`. Reachable once Twitch colour ids — which come from a chat config, not our picker — started going through this layer.

## Known limitations

- Colour ids aren't validated against the theme's presets. An unsupported colour from Twitch chat (their test fixture uses `red`) now renders invisibly rather than as a black bar, but it still won't show.
- When two highlight-carrying decorations land on the same verse — a session broadcast and a Twitch highlight, say — the winner is decided by decoration array order, which can differ between clients. Session highlights use a deterministic per-verse id, so two of those can't collide.
- The broadcast stroke is centred on the ribbon path, so it extends ~1px past the measured bounds. Nothing clips it; adjacent differently-coloured ribbons may touch.

## Not included

Two session bugs found during two-user testing are **diagnosed but deliberately not in this branch**, to keep it reviewable:

- Re-highlighting a verse doesn't reset the expiry timer — the broadcast path arms a `setTimeout` per publish and never cancels the previous one, so a re-highlight inherits the original deadline.
- A second user highlighting a verse the first already highlighted is dropped — `decorationOwners` makes decoration ids first-writer-wins, so the second user's write is filtered out before it reaches the CRDT.

## Testing

199 test files / 3720 tests passing, `pnpm check:ts` clean, `pnpm lint` 0 errors. Roughly 950 lines of new test coverage across the reader, toolbar, sessions, and the Twitch extension.
