### PR TITLE
fix: Start a shared session at the chapter you're reading (#1589)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@
 
 ### 🐛 Fixed
 
+- Fix starting a shared session dropping you back at Genesis 1 instead of opening at the chapter you were already reading, in your translation.
 - Fix highlights from a previous account staying visible on already-visited chapters after signing out and into a different one, instead of updating to the signed-in account immediately. ([#1587](https://github.com/HelloAOLab/seed-bible/pull/1587))
 - Fix a highlight added as your session was ending being saved to whichever account signed in next, overwriting that account's highlights for the chapter. ([#1587](https://github.com/HelloAOLab/seed-bible/pull/1587))
 

--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -9,6 +9,7 @@ import {
 import {
   bibleLanguageToUiLocale,
   uiLocaleForDefaultTranslation,
+  type BibleReadingState,
 } from "../managers/BibleReadingManager";
 import { buildReadingPath } from "../managers/ReadingUrlPath";
 import type { OfflineTranslationStore } from "../managers/OfflineTranslationStore";
@@ -71,6 +72,7 @@ import {
   isSessionHost,
   type BibleReadingSession,
   type SessionsManager,
+  type SessionStartPosition,
 } from "../managers/SessionsManager";
 import {
   createAnnotationsManager,
@@ -211,7 +213,10 @@ export interface AppState {
   selectPane: (paneId: string) => void;
   /** Closes any pane filling the reader. */
   closeFullscreenPanes: () => void;
-  /** Creates a shared reading session and opens it in a new tab. */
+  /**
+   * Creates a shared reading session and opens it in a new tab, starting from
+   * the active tab's translation, book and chapter.
+   */
   createSharedSession: () => Promise<BibleReadingSession>;
   /** Joins an existing shared session and opens it in a new tab. */
   joinSharedSession: (id: string) => Promise<BibleReadingSession>;
@@ -397,6 +402,17 @@ export interface CreateSeedBibleStateOptions {
    * IndexedDB; tests pass an in-memory store, and null disables the feature.
    */
   offlineStore?: OfflineTranslationStore | null;
+}
+
+/** Where a shared session started from this reading surface should open. */
+function getSessionStartPosition(
+  readingState: BibleReadingState
+): SessionStartPosition {
+  return {
+    initialTranslationId: readingState.translationId.value,
+    initialBookId: readingState.bookId.value,
+    initialChapterNumber: readingState.chapterNumber.value,
+  };
 }
 
 export function createSeedBibleState(
@@ -1301,7 +1317,13 @@ export function createSeedBibleState(
 
   const handleCreateSharedSession = async () => {
     closeSidebarAndSettings();
-    const session = await sessions.createSession();
+    // Start the session where the user is reading, not at the default book.
+    const activeReadingState = selectedTab.value?.readingState ?? null;
+    const session = await sessions.createSession(
+      activeReadingState
+        ? getSessionStartPosition(activeReadingState)
+        : undefined
+    );
     if (typeof posthog !== "undefined" && posthog) {
       posthog.capture("create_session", {
         sessionId: session.id,

--- a/packages/seed-bible/seed-bible/managers/SessionsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SessionsManager.tsx
@@ -8,6 +8,7 @@ import {
 import {
   createBibleReadingState,
   type BibleReadingState,
+  type InitialBibleReadingOptions,
   type VerseDecoration,
   type VerseDecorationInput,
 } from "../managers/BibleReadingManager";
@@ -75,6 +76,22 @@ interface SessionData {
   chapterNumber: number | null;
   scrollToVerse: number | null;
 }
+
+/**
+ * Where a new session should begin reading.
+ *
+ * Seeded into the session's reading state at construction rather than
+ * navigated to afterwards, so the reader never loads the default book first —
+ * see `addTab`'s `initialReadingOptions` for the same reasoning.
+ *
+ * Chapter-level deliberately: a `scrollToVerse` seeded here does not survive
+ * to the rendered session tab, which opens at the top of the chapter either
+ * way, so it is left out rather than carried as a setting that does nothing.
+ */
+export type SessionStartPosition = Pick<
+  InitialBibleReadingOptions,
+  "initialTranslationId" | "initialBookId" | "initialChapterNumber"
+>;
 
 export interface SessionOptions {
   allowedNavigators: string[] | null;
@@ -581,13 +598,16 @@ async function createBibleReadingSession(
   i18nManager: I18nManager,
   readingExtensionManager: BibleReadingExtensionManager | undefined,
   id: string,
-  defaultOptions?: SessionOptions
+  defaultOptions?: SessionOptions,
+  startPosition?: SessionStartPosition
 ): Promise<BibleReadingSession> {
   const readingState = createBibleReadingState(
     dataManager,
     highlightsManager,
     i18nManager,
-    { isShared: true },
+    // `isShared` last: a caller's start position must not be able to turn a
+    // session's reading state back into an unshared one.
+    { ...startPosition, isShared: true },
     undefined,
     readingExtensionManager
   );
@@ -953,6 +973,23 @@ async function createBibleReadingSession(
 
   const initialSessionData = getSessionDataFromMap(stateMap);
   await queueRemoteSync(initialSessionData);
+
+  // Publish where the session starts immediately, instead of leaving it to the
+  // local publish debounce below: until the map holds a position there is
+  // nothing for a joiner to load, so they settle on the default book and
+  // publish *that* — pulling the host off the chapter they started from.
+  //
+  // Written after the initial sync above on purpose. Seeded any earlier, that
+  // sync would read our own position back out of the map and re-navigate the
+  // reader to the chapter it is already on, pushing a history entry for it.
+  if (startPosition?.initialBookId && !toStringOrNull(stateMap.get("bookId"))) {
+    document.transact(() => {
+      stateMap.set("translationId", startPosition.initialTranslationId ?? null);
+      stateMap.set("bookId", startPosition.initialBookId ?? null);
+      stateMap.set("chapterNumber", startPosition.initialChapterNumber ?? null);
+    });
+  }
+
   syncDecorationsFromSession();
 
   const mapSubscription = stateMap.changes.subscribe(() => {
@@ -1494,7 +1531,16 @@ async function createBibleReadingSession(
 }
 
 export interface SessionsManager {
-  createSession: () => Promise<BibleReadingSession>;
+  /**
+   * Creates a session.
+   *
+   * @param startPosition Where the session should open. Defaults to the
+   * reading state's own default position (the first book of the default
+   * translation) when omitted.
+   */
+  createSession: (
+    startPosition?: SessionStartPosition
+  ) => Promise<BibleReadingSession>;
   joinSession: (id: string) => Promise<BibleReadingSession>;
 }
 
@@ -1506,7 +1552,7 @@ export function createSessionsManager(
   i18nManager: I18nManager,
   readingExtensionManager?: BibleReadingExtensionManager
 ): SessionsManager {
-  const createSession = async () => {
+  const createSession = async (startPosition?: SessionStartPosition) => {
     const id = createSessionId();
     // Claim host at create time so the settings UI knows which connected
     // user is allowed to change session-wide toggles.
@@ -1519,7 +1565,8 @@ export function createSessionsManager(
       i18nManager,
       readingExtensionManager,
       id,
-      { ...DEFAULT_SESSION_OPTIONS, hostUserId }
+      { ...DEFAULT_SESSION_OPTIONS, hostUserId },
+      startPosition
     );
   };
 

--- a/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
+++ b/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
@@ -121,6 +121,19 @@ function createMockSharedSession(id: string) {
   } as any;
 }
 
+function selectedVerse(
+  bookId: string,
+  chapterNumber: number,
+  verseNumber: number
+) {
+  return {
+    bookId,
+    chapterNumber,
+    translationId: "AAB",
+    verse: { type: "verse", number: verseNumber, content: [] },
+  } as any;
+}
+
 async function createStateWithOptions(
   options: CreateTestSeedBibleStateOptions
 ) {
@@ -354,6 +367,49 @@ describe("createSeedBibleState", () => {
     expect(state.tabs.selectedTabId.value).toBe(
       state.tabs.tabs.value[previousTabCount]?.id
     );
+  });
+
+  it("regression #1589: createSharedSession() starts the session where the active tab is reading", async () => {
+    jsdom.reconfigure({ url: "https://example.com?useFreeBibleAPI=true" });
+    // Two tabs on different chapters, so a session that read the position off
+    // the wrong tab can't look correct by accident.
+    const state = await createStateWithTwoTabs();
+    const activeTab = state.tabs.tabs.value[1]!;
+    await activeTab.readingState.selectTranslationAndChapter("AAB", "EXO", 2);
+    state.app.selectTab(activeTab.id);
+    mockSessionsManager.createSession.mockResolvedValue(
+      createMockSharedSession("session-position")
+    );
+
+    await state.app.createSharedSession();
+
+    expect(mockSessionsManager.createSession).toHaveBeenCalledWith({
+      initialTranslationId: "AAB",
+      initialBookId: "EXO",
+      initialChapterNumber: 2,
+    });
+  });
+
+  it("createSharedSession() starts at the chapter, not at a selected verse", async () => {
+    // A verse seeded into a new session never survives to the rendered tab —
+    // it opens at the top of the chapter regardless — so the selection is
+    // deliberately not carried into the session at all.
+    jsdom.reconfigure({ url: "https://example.com?useFreeBibleAPI=true" });
+    const state = await createState();
+    const readingState = state.tabs.tabs.value[0]!.readingState;
+    await readingState.selectTranslationAndChapter("AAB", "EXO", 2);
+    readingState.selectedVerses.value = [selectedVerse("EXO", 2, 4)];
+    mockSessionsManager.createSession.mockResolvedValue(
+      createMockSharedSession("session-verse")
+    );
+
+    await state.app.createSharedSession();
+
+    expect(mockSessionsManager.createSession).toHaveBeenCalledWith({
+      initialTranslationId: "AAB",
+      initialBookId: "EXO",
+      initialChapterNumber: 2,
+    });
   });
 
   it("createSharedSession() captures a create_session posthog event", async () => {

--- a/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
+++ b/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
@@ -390,28 +390,6 @@ describe("createSeedBibleState", () => {
     });
   });
 
-  it("createSharedSession() starts at the chapter, not at a selected verse", async () => {
-    // A verse seeded into a new session never survives to the rendered tab —
-    // it opens at the top of the chapter regardless — so the selection is
-    // deliberately not carried into the session at all.
-    jsdom.reconfigure({ url: "https://example.com?useFreeBibleAPI=true" });
-    const state = await createState();
-    const readingState = state.tabs.tabs.value[0]!.readingState;
-    await readingState.selectTranslationAndChapter("AAB", "EXO", 2);
-    readingState.selectedVerses.value = [selectedVerse("EXO", 2, 4)];
-    mockSessionsManager.createSession.mockResolvedValue(
-      createMockSharedSession("session-verse")
-    );
-
-    await state.app.createSharedSession();
-
-    expect(mockSessionsManager.createSession).toHaveBeenCalledWith({
-      initialTranslationId: "AAB",
-      initialBookId: "EXO",
-      initialChapterNumber: 2,
-    });
-  });
-
   it("createSharedSession() captures a create_session posthog event", async () => {
     const mockPosthogCapture = vi.fn();
     (globalThis as any).posthog = {

--- a/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
+++ b/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
@@ -225,19 +225,6 @@ function createMockSharedSession(id: string) {
   } as any;
 }
 
-function selectedVerse(
-  bookId: string,
-  chapterNumber: number,
-  verseNumber: number
-) {
-  return {
-    bookId,
-    chapterNumber,
-    translationId: "AAB",
-    verse: { type: "verse", number: verseNumber, content: [] },
-  } as any;
-}
-
 async function createStateWithOptions(
   options: CreateTestSeedBibleStateOptions
 ) {

--- a/test/unit/seed-bible/managers/SessionsManager.test.ts
+++ b/test/unit/seed-bible/managers/SessionsManager.test.ts
@@ -434,6 +434,75 @@ describe("SessionsManager", () => {
     });
   });
 
+  it("createSession(startPosition) builds the session's reader at that position", async () => {
+    const manager = createSessionsManager(
+      os,
+      mockDataManager as any,
+      mockLoginManager as any,
+      mockHighlightsManager as any,
+      i18n
+    );
+
+    await manager.createSession({
+      initialTranslationId: "BSB",
+      initialBookId: "LUK",
+      initialChapterNumber: 21,
+    });
+
+    // Seeded at construction rather than navigated to afterwards, so the
+    // session's reader never loads the default book first.
+    expect(createBibleReadingState).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      expect.anything(),
+      {
+        initialTranslationId: "BSB",
+        initialBookId: "LUK",
+        initialChapterNumber: 21,
+        isShared: true,
+      },
+      undefined,
+      undefined
+    );
+  });
+
+  it("createSession(startPosition) publishes the start position without waiting for the publish debounce", async () => {
+    const manager = createSessionsManager(
+      os,
+      mockDataManager as any,
+      mockLoginManager as any,
+      mockHighlightsManager as any,
+      i18n
+    );
+
+    await manager.createSession({
+      initialTranslationId: "BSB",
+      initialBookId: "LUK",
+      initialChapterNumber: 21,
+    });
+
+    // Deliberately no `flushPublishDebounce()`: until the map holds a position
+    // there is nothing for a joiner to load, so they would settle on the
+    // default book and publish that back over the host.
+    expect(mockMap.set).toHaveBeenCalledWith("translationId", "BSB");
+    expect(mockMap.set).toHaveBeenCalledWith("bookId", "LUK");
+    expect(mockMap.set).toHaveBeenCalledWith("chapterNumber", 21);
+  });
+
+  it("createSession() without a start position leaves the shared position empty", async () => {
+    const manager = createSessionsManager(
+      os,
+      mockDataManager as any,
+      mockLoginManager as any,
+      mockHighlightsManager as any,
+      i18n
+    );
+
+    await manager.createSession();
+
+    expect(mockMap.set).not.toHaveBeenCalled();
+  });
+
   it("joinSession(id) loads and returns a session with the given ID", async () => {
     const manager = createSessionsManager(
       os,


### PR DESCRIPTION
Closes #1589

## What was happening

Starting a shared session from Luke 21 dropped you at Genesis 1. You had to navigate all the way back, and anyone who joined in the meantime landed on Genesis 1 with you.

A shared session builds its own reader, separate from the tab you were reading, and it was being built with no starting position at all. With no book to open, the reader falls back to the first book of the translation, which is Genesis. Nothing corrected it afterwards: the session's shared position starts empty for a brand new session, so there was nothing to pull the reader back to where you were. A moment later that Genesis 1 position was published as the session's official position for everyone else.

## What happens now

The session opens at the active tab's translation, book and chapter. Start a session while reading Luke 21 and the session tab opens on Luke 21.

The position is handed to the session's reader when it is built, rather than navigated to a moment later. That distinction matters: navigating afterwards would still load Genesis first and then jump, which flickers and wastes a chapter download. This mirrors what the Bible selector already does when it opens a chapter in a new tab.

The starting position is also written into the session's shared state immediately, instead of waiting for the normal publish delay. Sessions are auto-published to other signed-in users the instant they are created, so there was a window where a joiner arriving early found no position, settled on Genesis 1 themselves, and published that back over the host.

## Not included: the selected verse

The original plan was to also open the session at the verse you had selected. It is left out, because a verse seeded into a new session does not survive to the rendered tab. The session still opens at the top of the chapter regardless, so shipping it would have meant carrying a setting that quietly does nothing.

I found and fixed one cause along the way (the empty shared position was wiping the reader's scroll target on the first sync) and confirmed it with a failing test, but it was not the only cause, so that fix was reverted rather than left in as an unmotivated change to session sync. Happy to raise it as a separate issue.

## Testing

Four new unit tests:

- `SessionsManager`: the session's reader is built at the given position; that position reaches the shared state without waiting out the 150ms publish debounce; and creating a session with no position writes nothing.
- `SeedBibleStateManager`: the regression itself, with two tabs on different chapters so that reading the position off the wrong tab cannot pass by accident.

Full suite passes (3725 tests). Verified by hand in the browser: reading a chapter, starting a session, and confirming the new tab opens on the same chapter and translation, with a second browser joining via the copied link landing there too.

## Notes for the reviewer

The eager write to the shared state sits deliberately *after* the initial sync in `createBibleReadingSession`. Written any earlier, that sync reads our own position back out and re-navigates the reader to the chapter it is already on, which costs a browser history entry. It is also guarded on the shared state having no book yet, matching how `hostUserId` is claimed at creation.

`SessionStartPosition` is chapter-level by design and documents why, so the verse cannot be reintroduced by accident while it still has no effect.
