### PR TITLE
fix: Today screen no longer auto-opens over path-based deep links (#1600)

### DIFF
--- a/packages/seed-bible/seed-bible/managers/ReadingUrlPath.ts
+++ b/packages/seed-bible/seed-bible/managers/ReadingUrlPath.ts
@@ -222,3 +222,13 @@ export function buildReadingUrl(params: {
 
   return url;
 }
+
+/**
+ * Whether `url` points at a specific reading position (the canonical
+ * `/{lang}/{translationId}/{book}/{chapter}` path). No query-param fallback
+ * needed — `entry-ssr.tsx` already redirects legacy `?book=`/`?chapter=`
+ * URLs onto the canonical path before the app ever sees them.
+ */
+export function hasReadingUrlPosition(url: URL, basePath: string): boolean {
+  return parseReadingPath(url.pathname, basePath) !== null;
+}

--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -10,7 +10,11 @@ import {
   bibleLanguageToUiLocale,
   uiLocaleForDefaultTranslation,
 } from "../managers/BibleReadingManager";
-import { buildReadingPath } from "../managers/ReadingUrlPath";
+import {
+  buildReadingPath,
+  hasReadingUrlPosition,
+  parseReadingPath,
+} from "../managers/ReadingUrlPath";
 import type { OfflineTranslationStore } from "../managers/OfflineTranslationStore";
 import { createBibleToolsManager } from "../managers/BibleToolsManager";
 import type { ToolsManager } from "../managers/BibleToolsManager";
@@ -609,8 +613,9 @@ export function createSeedBibleState(
     i18n,
     readingExtensions
   );
-  // Close any fullscreen pane when the book/chapter params change, so
-  // navigating reveals the reader (every navigation path writes these params).
+  // Close any fullscreen pane when the book/chapter in the URL path changes,
+  // so navigating reveals the reader (every navigation path writes this
+  // position into the path — see `commitSelectedTabToUrl` in TabsManager).
   // The first location only sets a baseline, so load-time init doesn't close a
   // pane auto-opened for the same load (e.g. Today via `?today=open`).
   //
@@ -629,13 +634,12 @@ export function createSeedBibleState(
   let lastReadingLocation: string | null = null;
   effect(() => {
     const url = navigation.currentUrl.value;
-    const book = url.searchParams.get("book");
-    const chapter = url.searchParams.get("chapter");
-    if (!book || !chapter) {
+    const parsed = parseReadingPath(url.pathname, navigation.basePath);
+    if (!parsed) {
       return;
     }
 
-    const location = `${book}|${chapter}`;
+    const location = `${parsed.bookId ?? parsed.rawBookSegment}|${parsed.chapter}`;
     const previous = lastReadingLocation;
     lastReadingLocation = location;
 
@@ -656,9 +660,7 @@ export function createSeedBibleState(
     initialUrlParams.get("today") !== null
       ? initialUrlParams.get("today") === "open"
       : !(
-          initialUrlParams.has("book") ||
-          initialUrlParams.has("chapter") ||
-          initialUrlParams.has("verse") ||
+          hasReadingUrlPosition(navigation.initialUrl, navigation.basePath) ||
           initialUrlParams.has("sessionId")
         );
 

--- a/packages/today-screen/infrastructure/di/bootstrap.tsx
+++ b/packages/today-screen/infrastructure/di/bootstrap.tsx
@@ -17,6 +17,7 @@ import { getDefaultTranslationForLanguage } from "@packages/seed-bible/seed-bibl
 import type { VerseSearchResult } from "@packages/today-screen/domain/models/search";
 import { ReadingHistoryConfigProvider } from "../config/readingHistory/readingHistoryConfigProvider";
 import { getHighlightedWelcomeVerse } from "../config/translations/welcomeVerseMap";
+import { hasReadingUrlPosition } from "@packages/seed-bible/seed-bible/managers/ReadingUrlPath";
 
 export interface TodayScreenAPI {
   open: () => void;
@@ -359,22 +360,24 @@ export const bootstrapExtension = () => {
 
       // Today opens automatically on a cold load (no explicit `?today=`
       // param) as long as the URL isn't already pointing somewhere specific —
-      // a book/chapter/verse deep link, or a shared-session invite
-      // (`?sessionId=`). An explicit `?today=` param always wins either way,
-      // matching the deep-linkable modals in SeedBibleStateManager.
+      // a book/chapter deep link (the canonical
+      // `/{lang}/{translationId}/{book}/{chapter}` path), or a shared-session
+      // invite (`?sessionId=`). An explicit `?today=` param always wins
+      // either way, matching the deep-linkable modals in
+      // SeedBibleStateManager.
       //
       // This must read `initialUrl` (the URL as first loaded), not the live
       // `currentUrl`: TabsManager echoes the reader's current book/chapter
       // back into the URL as soon as it initializes (so links are always
       // shareable), which happens well before extensions finish loading. By
-      // the time this code runs, a cold load with no book/chapter param would
-      // already show `?book=GEN&chapter=1` in the live URL — indistinguishable
-      // from a real deep link unless we look at the URL from before that echo.
-      const initialUrlParams = context.navigation.initialUrl.searchParams;
+      // the time this code runs, a cold load with no reading position would
+      // already show the default book/chapter in the live URL's path —
+      // indistinguishable from a real deep link unless we look at the URL
+      // from before that echo.
+      const initialUrl = context.navigation.initialUrl;
+      const initialUrlParams = initialUrl.searchParams;
       const hasCompetingDeepLink =
-        initialUrlParams.has("book") ||
-        initialUrlParams.has("chapter") ||
-        initialUrlParams.has("verse") ||
+        hasReadingUrlPosition(initialUrl, context.navigation.basePath) ||
         initialUrlParams.has("sessionId");
       const requestedToday = initialUrlParams.get("today");
       const isTodayOpen = signal(

--- a/test/unit/seed-bible/managers/ReadingUrlPath.test.ts
+++ b/test/unit/seed-bible/managers/ReadingUrlPath.test.ts
@@ -2,6 +2,7 @@ import {
   DEFAULT_UI_LANGUAGE,
   buildReadingPath,
   buildReadingUrl,
+  hasReadingUrlPosition,
   parseReadingPath,
 } from "@packages/seed-bible/seed-bible/managers/ReadingUrlPath";
 
@@ -304,5 +305,40 @@ describe("buildReadingUrl", () => {
       expect(url.pathname).toBe("/en/AAB/genesis/1");
       expect(url.pathname.split("/").filter(Boolean)).toHaveLength(4);
     });
+  });
+});
+
+describe("hasReadingUrlPosition", () => {
+  const at = (href: string) => new URL(href);
+
+  it("is true for the 4-segment canonical path", () => {
+    expect(
+      hasReadingUrlPosition(at("https://seedbible.org/en/AAB/john/3"), "")
+    ).toBe(true);
+  });
+
+  it("is true for the 3-segment path (default language implied)", () => {
+    expect(
+      hasReadingUrlPosition(at("https://seedbible.org/AAB/john/3"), "")
+    ).toBe(true);
+  });
+
+  it("is false for a bare root", () => {
+    expect(hasReadingUrlPosition(at("https://seedbible.org/"), "")).toBe(false);
+  });
+
+  it("is false for legacy query params with no path — those never reach app code, since entry-ssr.tsx redirects them onto the canonical path first", () => {
+    expect(
+      hasReadingUrlPosition(at("https://seedbible.org/?book=GEN&chapter=1"), "")
+    ).toBe(false);
+  });
+
+  it("strips the deployment basePath before checking", () => {
+    expect(
+      hasReadingUrlPosition(
+        at("https://seedbible.org/b/some-branch/AAB/john/3"),
+        "/b/some-branch"
+      )
+    ).toBe(true);
   });
 });

--- a/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
+++ b/test/unit/seed-bible/managers/SeedBibleStateManager.test.ts
@@ -640,6 +640,25 @@ describe("createSeedBibleState", () => {
     expect(state.selector.isOpen.value).toBe(false);
   });
 
+  it("closes a fullscreen pane when navigating to a new chapter", async () => {
+    jsdom.reconfigure({ url: "https://example.com?useFreeBibleAPI=true" });
+    const state = await createState();
+    const readingState = state.tabs.tabs.value[0]!.readingState;
+    await waitFor(() => readingState.chapterData.value !== null);
+
+    state.panes.openPane({
+      placement: "fullscreen",
+      title: "Fullscreen Pane",
+      component: () => null,
+    });
+    expect(state.panes.panes.value).toHaveLength(1);
+
+    await readingState.selectChapter("EXO", 2);
+    await waitFor(() => readingState.bookId.value === "EXO");
+
+    expect(state.panes.panes.value).toHaveLength(0);
+  });
+
   describe("mobile tab slot restrictions", () => {
     // isMobile is derived from viewportWidth; the returned signal is the same
     // writable instance, so tests drive the mobile layout by writing to it.


### PR DESCRIPTION
## Summary

Fixes #1600. Today's "auto-open on cold load" check only looked at the legacy `?book=`/`?chapter=`/`?verse=` query params to detect a deep link. PR #1547 moved the reading position into the URL path, so those params are never present anymore — Today opened over every deep link instead of just bare loads.

Also found and fixed a related regression from the same PR: the effect that closes a fullscreen pane on chapter navigation read the same dead query params, so it silently stopped firing.

## Changes

- `ReadingUrlPath.ts`: new `hasReadingUrlPosition(url, basePath)` helper, backed by `parseReadingPath()`.
- `SeedBibleStateManager.tsx` / `today-screen/bootstrap.tsx`: both now call the shared helper instead of their own copy of the check.

## Test plan

- [x] Unit tests for `hasReadingUrlPosition()`.
- [x] Regression test: fullscreen pane closes on chapter navigation.
- [x] Full suite passing, typecheck clean.
