### PR TITLE
test: unmount the reader between tests to stop a post-teardown render

### DIFF
--- a/test/unit/seed-bible/components/BibleReader.test.tsx
+++ b/test/unit/seed-bible/components/BibleReader.test.tsx
@@ -311,7 +311,15 @@ describe("BibleReader", () => {
   });
 
   afterEach(() => {
-    // render(null, container);
+    // Detaching the container is not enough: the tree stays mounted, so its
+    // effect cleanups never run and a late async update (the reader's skeleton
+    // timer, an un-awaited retry) still diffs into a document that Vitest has
+    // since torn down — an unhandled "document is not defined" rejection.
+    // Unmounting clears the component's parent DOM, which makes preact drop
+    // those updates instead.
+    act(() => {
+      render(null, container);
+    });
     container.remove();
   });
 


### PR DESCRIPTION
The suite intermittently failed with an unhandled
"ReferenceError: document is not defined" raised inside preact's DOM
diff. Vitest attributed it to BibleReader.test.tsx, and every assertion
passed — only the stray rejection failed the run.

BibleReader.test.tsx never unmounted what it rendered: the afterEach
detached the container but left the commented-out `render(null,
container)` in place, so all 61 trees stayed mounted for the whole file
with their timers, listeners and signal subscriptions live. A late async
update — the reader's CHAPTER_SKELETON_DELAY_MS skeleton timer, or the
un-awaited retry handler's `setRetrying(false)` — could therefore still
reach preact's diff after Vitest had torn the file's jsdom environment
down, at which point `document` no longer existed.

Unmounting inside `act` runs the effect cleanups and clears each
component's parent DOM, which is what makes preact drop a late update
instead of diffing it. Measured before and after on this file: two
un-cleared 500ms timers were pending when it finished, now zero.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01NmPLJDywRiYx7LjTYcf994