### PR TITLE
Route meta tag image URLs through Vite's asset pipeline

### DIFF
--- a/index.html
+++ b/index.html
@@ -25,6 +25,8 @@
     <link rel="dns-prefetch" href="https://i.seedbible.org" />
     <link rel="dns-prefetch" href="https://auth.seedbible.org" />
     <meta property="og:type" content="website" />
+    <!-- `content` is rewritten at build time to the emitted asset's absolute
+         URL — see script/lib/vite-plugin-html-meta-assets.ts. -->
     <meta
       property="og:image"
       content="/standalone/img/SeedBibleLogoBlackOnWhiteBackground.jpg"

--- a/script/lib/htmlMetaAssets.ts
+++ b/script/lib/htmlMetaAssets.ts
@@ -1,0 +1,157 @@
+/**
+ * Routing image URLs written in `<meta content="...">` through Vite's asset
+ * pipeline.
+ *
+ * Vite rewrites asset URLs in the HTML entry for a fixed set of tag/attribute
+ * pairs — `link[href]`, `img[src|srcset]`, `source`, `video`, and two SVG ones.
+ * `meta[content]` is not among them, so `index.html`'s `og:image` was left
+ * verbatim and its file was never emitted: the social preview pointed at
+ * `/standalone/img/...`, a path that exists only in the repo (`publicDir` is
+ * off, so nothing copies it into the build) and 404s in production.
+ *
+ * Rather than re-implement emitting, hashing and base-prefixing, the transform
+ * borrows the machinery that already works. Before Vite reads the HTML, each
+ * targeted meta's path is copied onto a carrier `<link>`; Vite rewrites that
+ * `href` exactly as it does the favicon's; afterwards the rewritten value is
+ * copied back into the meta and the carrier is deleted.
+ *
+ * Pure string functions so `test/unit/script/lib/htmlMetaAssets.test.ts` can pin
+ * them down without running a build.
+ */
+
+/** Meta tags whose `content` names an image that should be built like an asset. */
+export const META_ASSET_KEYS = [
+  "og:image",
+  "og:image:secure_url",
+  "twitter:image",
+];
+
+/**
+ * The carrier's `rel`. Deliberately not a real one: `preload` would work just as
+ * well for the build, but it also makes browsers download the 1200x630 social
+ * image on every page load. A rel no browser knows is ignored, and the tag is
+ * removed before the HTML ships anyway.
+ */
+const CARRIER_REL = "seed-bible-meta-asset";
+
+const META_TAG_RE = /<meta\b[^>]*>/gi;
+const LINK_TAG_RE = /<link\b[^>]*>/gi;
+const IMAGE_EXT_RE = /\.(png|jpe?g|gif|svg|webp|avif|ico)(\?[^#]*)?(#.*)?$/i;
+
+function readAttr(tag: string, name: string): string | null {
+  const match = new RegExp(
+    `\\b${name}\\s*=\\s*("([^"]*)"|'([^']*)')`,
+    "i"
+  ).exec(tag);
+  if (!match) return null;
+  return match[2] ?? match[3] ?? null;
+}
+
+function setAttr(tag: string, name: string, value: string): string {
+  const escaped = value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+  return tag.replace(
+    new RegExp(`(\\b${name}\\s*=\\s*)("[^"]*"|'[^']*')`, "i"),
+    (_match, prefix: string) => `${prefix}"${escaped}"`
+  );
+}
+
+/** The `property` or `name` a meta tag is identified by, lowercased. */
+function metaKey(tag: string): string | null {
+  const key = readAttr(tag, "property") ?? readAttr(tag, "name");
+  return key ? key.toLowerCase() : null;
+}
+
+/**
+ * Whether a `content` value names a file in this repo (as opposed to a remote
+ * URL or an inline data URI) that Vite should emit.
+ */
+export function isLocalAssetPath(value: string): boolean {
+  if (!value) return false;
+  // Any scheme — `https:`, `data:` — and protocol-relative URLs are already
+  // wherever they are going to be served from.
+  if (/^[a-z][a-z0-9+.-]*:/i.test(value) || value.startsWith("//"))
+    return false;
+  if (!value.startsWith("/") && !value.startsWith("./")) return false;
+  return IMAGE_EXT_RE.test(value);
+}
+
+/**
+ * Adds one carrier `<link>` per targeted meta tag, so Vite emits the file and
+ * rewrites the URL. Run before Vite reads the HTML.
+ */
+export function injectMetaAssetCarriers(html: string): string {
+  const carriers: string[] = [];
+  const seen = new Set<string>();
+
+  for (const [tag] of html.matchAll(META_TAG_RE)) {
+    const key = metaKey(tag);
+    if (!key || !META_ASSET_KEYS.includes(key)) continue;
+
+    const content = readAttr(tag, "content");
+    if (!content || !isLocalAssetPath(content) || seen.has(key)) continue;
+
+    seen.add(key);
+    carriers.push(
+      `<link rel="${CARRIER_REL}" data-meta-asset="${key}" href="${content}">`
+    );
+  }
+
+  if (carriers.length === 0) return html;
+
+  const block = carriers.join("\n");
+  return /<\/head>/i.test(html)
+    ? html.replace(/<\/head>/i, () => `${block}\n</head>`)
+    : `${html}\n${block}`;
+}
+
+export interface ResolveMetaAssetOptions {
+  /**
+   * Origin used to absolutize a URL Vite left root-relative. Only reached when
+   * `base` is `/` — a plain local build — since a deployed build's `base` is
+   * already the absolute CDN root.
+   */
+  siteOrigin: string;
+}
+
+/**
+ * Copies each carrier's rewritten `href` into its meta tag's `content` and
+ * removes the carriers. Run after Vite has processed the HTML.
+ *
+ * The value may still be a `__VITE_ASSET__<hash>__` placeholder depending on
+ * when the html plugin resolves those relative to this hook. That is fine: the
+ * resolution pass is a global replace over the whole document, so a copied
+ * placeholder resolves along with the original. It is also why absolutizing
+ * keys off a leading `/` — a placeholder has none, so it is passed through
+ * untouched and picks up the absolute `base` when it is resolved.
+ */
+export function resolveMetaAssetCarriers(
+  html: string,
+  options: ResolveMetaAssetOptions
+): string {
+  const origin = options.siteOrigin.replace(/\/+$/, "");
+  const resolved = new Map<string, string>();
+
+  const withoutCarriers = html.replace(LINK_TAG_RE, (tag) => {
+    const key = readAttr(tag, "data-meta-asset")?.toLowerCase();
+    if (!key) return tag;
+
+    const href = readAttr(tag, "href");
+    if (href) {
+      resolved.set(
+        key,
+        href.startsWith("/") && !href.startsWith("//")
+          ? `${origin}${href}`
+          : href
+      );
+    }
+    return "";
+  });
+
+  if (resolved.size === 0) return html;
+
+  return withoutCarriers.replace(META_TAG_RE, (tag) => {
+    const key = metaKey(tag);
+    const url = key ? resolved.get(key) : undefined;
+    return url ? setAttr(tag, "content", url) : tag;
+  });
+}

--- a/script/lib/vite-plugin-html-meta-assets.ts
+++ b/script/lib/vite-plugin-html-meta-assets.ts
@@ -1,0 +1,52 @@
+import type { Plugin } from "vite";
+import {
+  injectMetaAssetCarriers,
+  resolveMetaAssetCarriers,
+} from "./htmlMetaAssets";
+
+// The transform itself lives in `./htmlMetaAssets` so it can be unit tested
+// without running a build; this only wires the two halves to the hooks that
+// bracket Vite's own HTML processing.
+
+/** Fallback origin, matching `script/generate-sitemap.ts`. */
+const DEFAULT_ORIGIN = "https://seedbible.org";
+
+export interface HtmlMetaAssetsOptions {
+  siteOrigin?: string;
+}
+
+/**
+ * Makes image URLs in `<meta content="...">` — `og:image` and friends — build
+ * like any other HTML asset reference: emitted into `assets/` with a content
+ * hash and rewritten to the absolute URL they are served from.
+ *
+ * Build-only. In dev the paths in `index.html` point at files Vite's static
+ * middleware already serves from the project root, so there is nothing to fix.
+ */
+export function htmlMetaAssetsPlugin(
+  options: HtmlMetaAssetsOptions = {}
+): Plugin[] {
+  const siteOrigin =
+    options.siteOrigin ?? process.env.SITE_ORIGIN ?? DEFAULT_ORIGIN;
+
+  // Two plugins rather than one: a plugin carries a single `transformIndexHtml`
+  // hook, and this needs to run on both sides of Vite's.
+  return [
+    {
+      name: "vite-plugin-html-meta-assets:pre",
+      apply: "build",
+      transformIndexHtml: {
+        order: "pre",
+        handler: (html) => injectMetaAssetCarriers(html),
+      },
+    },
+    {
+      name: "vite-plugin-html-meta-assets:post",
+      apply: "build",
+      transformIndexHtml: {
+        order: "post",
+        handler: (html) => resolveMetaAssetCarriers(html, { siteOrigin }),
+      },
+    },
+  ];
+}

--- a/test/unit/script/lib/htmlMetaAssets.test.ts
+++ b/test/unit/script/lib/htmlMetaAssets.test.ts
@@ -1,0 +1,157 @@
+import {
+  injectMetaAssetCarriers,
+  isLocalAssetPath,
+  resolveMetaAssetCarriers,
+} from "../../../../script/lib/htmlMetaAssets";
+
+const SITE_ORIGIN = "https://seedbible.org";
+const OG_PATH = "/standalone/img/SeedBibleLogoBlackOnWhiteBackground.jpg";
+const BUILT_URL =
+  "https://assets.example/branches/main/abc123/assets/SeedBibleLogo-HASH.jpg";
+
+/**
+ * The shape `index.html` actually has: the og:image tag is spread over several
+ * lines, and there are meta tags around it that must be left alone.
+ */
+function createHtml(ogContent = OG_PATH): string {
+  return `<!doctype html>
+<html>
+  <head>
+    <link rel="icon" href="/standalone/img/favicon.ico" />
+    <meta property="og:type" content="website" />
+    <meta
+      property="og:image"
+      content="${ogContent}"
+    />
+    <meta property="og:image:width" content="1200" />
+  </head>
+  <body></body>
+</html>`;
+}
+
+/** The carrier links a `pre` pass added, as Vite would leave them. */
+function carriersIn(html: string): string[] {
+  return [...html.matchAll(/<link\b[^>]*data-meta-asset[^>]*>/gi)].map(
+    ([tag]) => tag
+  );
+}
+
+function ogImageContent(html: string): string | null {
+  const match = /<meta\s[^>]*og:image"[^>]*>/i.exec(html);
+  if (!match) return null;
+  return /content\s*=\s*"([^"]*)"/i.exec(match[0])?.[1] ?? null;
+}
+
+describe("isLocalAssetPath()", () => {
+  it("accepts repo-relative image paths", () => {
+    expect(isLocalAssetPath(OG_PATH)).toBe(true);
+    expect(isLocalAssetPath("./logo.png")).toBe(true);
+    expect(isLocalAssetPath("/img/icon.svg?v=2")).toBe(true);
+  });
+
+  it("rejects anything already served from somewhere else", () => {
+    expect(isLocalAssetPath("https://cdn.example/logo.jpg")).toBe(false);
+    expect(isLocalAssetPath("//cdn.example/logo.jpg")).toBe(false);
+    expect(isLocalAssetPath("data:image/png;base64,AAAA")).toBe(false);
+  });
+
+  it("rejects paths that are not images", () => {
+    expect(isLocalAssetPath("/standalone/index.tsx")).toBe(false);
+    expect(isLocalAssetPath("")).toBe(false);
+  });
+});
+
+describe("injectMetaAssetCarriers()", () => {
+  it("adds one carrier link per targeted meta tag", () => {
+    const carriers = carriersIn(injectMetaAssetCarriers(createHtml()));
+
+    expect(carriers).toHaveLength(1);
+    expect(carriers[0]).toContain(`href="${OG_PATH}"`);
+    expect(carriers[0]).toContain('data-meta-asset="og:image"');
+  });
+
+  it("puts the carriers inside <head>, where Vite processes links", () => {
+    const html = injectMetaAssetCarriers(createHtml());
+
+    expect(html.indexOf("data-meta-asset")).toBeLessThan(
+      html.indexOf("</head>")
+    );
+  });
+
+  it("does not use a rel that would make browsers fetch the image", () => {
+    expect(injectMetaAssetCarriers(createHtml())).not.toContain(
+      'rel="preload"'
+    );
+  });
+
+  it("leaves an og:image that is already absolute alone", () => {
+    const html = createHtml("https://cdn.example/logo.jpg");
+
+    expect(injectMetaAssetCarriers(html)).toBe(html);
+  });
+
+  it("is a no-op when there is nothing to carry", () => {
+    const html = "<html><head><title>x</title></head><body></body></html>";
+
+    expect(injectMetaAssetCarriers(html)).toBe(html);
+  });
+});
+
+describe("resolveMetaAssetCarriers()", () => {
+  /** Stands in for Vite: rewrites the carrier's href the way it does a favicon. */
+  function afterVite(html: string, builtUrl: string): string {
+    return html.replace(
+      /(<link\b[^>]*data-meta-asset[^>]*\bhref=")[^"]*(")/i,
+      (_match, prefix: string, suffix: string) =>
+        `${prefix}${builtUrl}${suffix}`
+    );
+  }
+
+  function round(builtUrl: string): string {
+    return resolveMetaAssetCarriers(
+      afterVite(injectMetaAssetCarriers(createHtml()), builtUrl),
+      { siteOrigin: SITE_ORIGIN }
+    );
+  }
+
+  it("copies the built URL into the meta tag", () => {
+    expect(ogImageContent(round(BUILT_URL))).toBe(BUILT_URL);
+  });
+
+  it("removes the carrier links", () => {
+    expect(carriersIn(round(BUILT_URL))).toEqual([]);
+  });
+
+  it("passes an unresolved Vite asset placeholder through verbatim", () => {
+    // The html plugin's own resolution pass is a global replace, so a copied
+    // placeholder is resolved along with the original.
+    const placeholder = "__VITE_ASSET__a1b2c3__";
+
+    expect(ogImageContent(round(placeholder))).toBe(placeholder);
+  });
+
+  it("absolutizes a root-relative URL against the site origin", () => {
+    expect(ogImageContent(round("/assets/SeedBibleLogo-HASH.jpg"))).toBe(
+      `${SITE_ORIGIN}/assets/SeedBibleLogo-HASH.jpg`
+    );
+  });
+
+  it("does not prefix a URL that is already absolute", () => {
+    expect(ogImageContent(round(BUILT_URL))).not.toContain(SITE_ORIGIN);
+  });
+
+  it("leaves the surrounding meta tags untouched", () => {
+    const html = round(BUILT_URL);
+
+    expect(html).toContain('<meta property="og:type" content="website" />');
+    expect(html).toContain('<meta property="og:image:width" content="1200" />');
+  });
+
+  it("is a no-op when no carriers were injected", () => {
+    const html = createHtml();
+
+    expect(resolveMetaAssetCarriers(html, { siteOrigin: SITE_ORIGIN })).toBe(
+      html
+    );
+  });
+});

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ import {
   type ViteManifestChunk,
 } from "./script/lib/precacheManifest";
 import { extensionsPlugin } from "./script/lib/vite-plugin-extensions";
+import { htmlMetaAssetsPlugin } from "./script/lib/vite-plugin-html-meta-assets";
 
 // Each branch+version deployment gets its OWN copy of its hashed assets, so the
 // asset URL is namespaced by branch and build id: assets for a build live at
@@ -128,6 +129,7 @@ export default defineConfig(({ isSsrBuild }) => ({
     preact(),
     patternPlugin(),
     extensionsPlugin(),
+    htmlMetaAssetsPlugin(),
     // Only the root build ships a service worker (see `isRootBuild` above).
     ...(isRootBuild
       ? [


### PR DESCRIPTION
## Summary

Social preview images referenced in `<meta content="...">` tags (like `og:image`) were not being processed by Vite's asset pipeline during builds. This meant the image files were never emitted to the build output, and the URLs in production pointed to paths that only existed in the repository, resulting in 404s.

This change makes Vite treat meta tag image URLs the same way it treats other HTML asset references: emitting them to `assets/` with content hashes and rewriting them to their final absolute URLs.

## How it works

Rather than re-implementing Vite's asset emission and hashing logic, the solution borrows Vite's existing machinery:

1. **Before Vite processes HTML** (`pre` hook): For each targeted meta tag (`og:image`, `og:image:secure_url`, `twitter:image`), inject a temporary carrier `<link>` tag with the image path in its `href` attribute.

2. **Vite's normal processing**: Vite rewrites the carrier link's `href` exactly as it does for favicons and other assets — emitting the file, hashing it, and rewriting the URL.

3. **After Vite processes HTML** (`post` hook): Copy the rewritten URL from the carrier link back into the meta tag's `content` attribute and remove the carrier link.

The carrier uses a custom `rel` value that browsers don't recognize, so they ignore it and don't fetch the social image on every page load. The tag is removed before the HTML ships anyway.

## Key changes

- **`script/lib/htmlMetaAssets.ts`** — Pure string transformation functions:
  - `isLocalAssetPath()` — Identifies image URLs that should be built (repo-relative paths with image extensions), excluding remote URLs and data URIs
  - `injectMetaAssetCarriers()` — Adds temporary carrier `<link>` tags before Vite processes the HTML
  - `resolveMetaAssetCarriers()` — Copies rewritten URLs back into meta tags and removes carriers after Vite processes the HTML

- **`script/lib/vite-plugin-html-meta-assets.ts`** — Vite plugin that wires the transforms to the `transformIndexHtml` hooks that bracket Vite's own HTML processing

- **`test/unit/script/lib/htmlMetaAssets.test.ts`** — Comprehensive unit tests for the transform functions, covering local vs. remote URLs, placeholder resolution, and edge cases

- **`vite.config.ts`** — Registers the new plugin in the build pipeline

- **`index.html`** — Updated `og:image` meta tag with a comment explaining that its `content` is rewritten at build time

## Implementation notes

- The transforms are pure string functions so they can be unit tested without running a full build
- Vite asset placeholders (`__VITE_ASSET__<hash>__`) are passed through verbatim and resolved by Vite's global replacement pass
- Root-relative URLs are absolutized against a configurable site origin (defaults to `https://seedbible.org`, can be overridden via `SITE_ORIGIN` env var)
- The plugin only runs during builds; in dev, the paths in `index.html` already point at files Vite's static middleware serves

https://claude.ai/code/session_01ExTFFfwvQaagCQG9yrdv4J