### PR TITLE
fix: restore missing branding declaration in createSeedBibleState

### DIFF
--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -448,6 +448,7 @@ export function createSeedBibleState(
     initialHref: options.initialHref,
     basePath: options.config?.basePath,
   });
+  const branding = options.config?.branding;
   const api = new FreeUseBibleAPI(
     getDefaultAPIEndpoint(navigation.currentUrl.value)
   );


### PR DESCRIPTION
## Summary
- `develop` currently fails `pnpm check:ts` (TS2304: Cannot find name 'branding') at `SeedBibleStateManager.tsx:497`, which also fails CI on every other open PR since Actions checks out the PR/develop merge ref.
- Traced the regression to the merge of #1610 ("added config for disabling multiple tools"): that PR changed `createBibleToolsManager()` to `createBibleToolsManager(branding)` and declared `const branding = options.config?.branding;` on its own branch (where CI was green), but the merge into `develop` kept the call site and dropped the declaration — likely a conflict-resolution mistake with the concurrent OpenTelemetry PR (#1557) touching the same function.
- Restores the one-line declaration so `branding` is back in scope before it's used (both for `createBibleToolsManager(branding)` and the existing `appName: branding?.appName` usage further down).

## Test plan
- [x] `pnpm check:ts` — clean (was failing with TS2304 before this change)
- [x] `pnpm test` — 4433/4433 passing