### PR TITLE
Login Modal opens on forced logout

### DIFF
--- a/packages/seed-bible/seed-bible/components/ToastHost/ToastHost.css
+++ b/packages/seed-bible/seed-bible/components/ToastHost/ToastHost.css
@@ -122,7 +122,7 @@
   left: 50%;
   bottom: 6rem;
   transform: translateX(-50%);
-  z-index: 1000;
+  z-index: 10002; /* was 1000 — above every overlay, incl. the raised tutorial (10001) */
   display: flex;
   justify-content: center;
   max-width: min(90vw, 26.25rem);

--- a/packages/seed-bible/seed-bible/managers/LoginManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/LoginManager.tsx
@@ -348,6 +348,10 @@ export function createLoginManager({
    * parse — so the call could only fail; it costs a round trip on a path often taken
    * while connectivity is poor; and for a banned account it can never succeed.
    *
+   * Also opens the login screen. A forced sign-out only happens when there was a real
+   * session, so the user was not anonymous — offering sign-in again is a convenience,
+   * not a hindrance. (A deliberate `logout()` does not go through here.)
+   *
    * `sessionEnded` is left set rather than reset, which is what lets a sign-out during
    * construction still reach the toast: `SeedBibleStateManager` wires that effect much
    * later, and an effect reads its dependencies eagerly on its first run. Don't
@@ -370,6 +374,10 @@ export function createLoginManager({
       reason,
       id: ++sessionEndedCount,
     };
+    // Skip during SSR — there is no interactive login surface to show.
+    if (!import.meta.env.SSR) {
+      isLoginOpen.value = true;
+    }
   };
 
   /** Signs the user out because the server reported the session key dead. */
@@ -600,6 +608,7 @@ export function createLoginManager({
   }
 
   async function cancelLogin() {
+    isLoginOpen.value = false;
     if (loginPromise && rejectLoginPromise) {
       rejectLoginPromise(new Error("Login cancelled"));
       loginPromise = null;
@@ -668,6 +677,9 @@ export function createLoginManager({
         id: userId.value,
         email: result.email,
       };
+      // Close even when login was opened by a forced sign-out (no `login()`
+      // promise) — that path never reaches `loginCore`'s `finally`.
+      isLoginOpen.value = false;
       if (resolveLoginPromise) {
         resolveLoginPromise(userInfo.value);
         resolveLoginPromise = null;

--- a/test/unit/seed-bible/managers/LoginManager.test.ts
+++ b/test/unit/seed-bible/managers/LoginManager.test.ts
@@ -512,6 +512,44 @@ describe("createLoginManager", () => {
       expect(localStorage.getItem("connectionKey")).toBe(null);
     });
 
+    it("opens the login screen so the user can sign back in", async () => {
+      // Forced sign-out only happens when there was a real session, so offering
+      // the login UI is a convenience rather than surprising an anonymous user.
+      const manager = await signOutViaGetUserInfo("session_expired");
+
+      expect(manager.isLoginOpen.value).toBe(true);
+    });
+
+    it("closes the login screen when the user dismisses it after a forced sign-out", async () => {
+      const manager = await signOutViaGetUserInfo("session_expired");
+      expect(manager.isLoginOpen.value).toBe(true);
+
+      await manager.cancelLogin();
+
+      expect(manager.isLoginOpen.value).toBe(false);
+    });
+
+    it("closes the login screen when the user signs back in after a forced sign-out", async () => {
+      const manager = await signOutViaGetUserInfo("session_expired");
+      expect(manager.isLoginOpen.value).toBe(true);
+
+      // The forced-sign-out path left getUserInfo returning failure; restore a
+      // healthy response so the new login can finish.
+      getUserInfoMock.mockResolvedValue({
+        success: true,
+        email: EMAIL,
+        userId: USER_ID,
+      });
+
+      const request = await manager.requestLoginByEmail(EMAIL);
+      if (!request.success)
+        throw new Error("expected login request to succeed");
+      await manager.submitLoginCode("123456", request);
+
+      await waitFor(() => manager.userId.value === USER_ID);
+      expect(manager.isLoginOpen.value).toBe(false);
+    });
+
     it("does not call revokeSession when signing out for a dead session", async () => {
       // The session is already gone server side, so the round trip could only fail.
       await signOutViaGetUserInfo("session_expired");
@@ -662,6 +700,8 @@ describe("createLoginManager", () => {
 
       // Nothing expired here, so the message must not say so.
       expect(manager.sessionEnded.value?.reason).toBe("signed_out");
+      // Same convenience as any other forced sign-out: they had a stored session.
+      expect(manager.isLoginOpen.value).toBe(true);
     });
 
     it("leaves the user signed out rather than half-authenticated", () => {
@@ -702,6 +742,8 @@ describe("createLoginManager", () => {
 
       expect(os.sessionKey.value).toBe(null);
       expect(manager.sessionEnded.value).toBe(null);
+      // Deliberate logout is not a forced sign-out — don't push the login UI.
+      expect(manager.isLoginOpen.value).toBe(false);
     });
 
     it("signs out locally even when revokeSession rejects", async () => {


### PR DESCRIPTION
Fixes: #1621 

I have done asked thing but 

What I’d want eyes on in review:

Force-open bypasses login() — modal is driven by isLoginOpen, not the login() promise. That’s fine if dismiss + successful re-auth always clear the flag (they should now). Reviewers should verify those two close paths, since that’s the easy place to leave a stuck overlay.

Don’t expand this to voluntary logout — that would punish intentional sign-out and surprise anonymous/guest flows. The invariant “only forceSignOut opens it” is the important line to protect.