### PR TITLE
Add two-way postMessage bridge between PortalComponent and its ao.bot iframe

### DIFF
--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -94,11 +94,11 @@ On the pattern side (the code that runs inside the portal's iframe), use CasualO
 // send a message out to the host page
 await os.sendEmbedMessage({ type: "featureClicked", featureId });
 
+// onEmbedMessage.tsx
 // receive messages sent from the host page
-export function onEmbedMessage(data: { origin: string; message: any }) {
-  if (data.message?.type === "highlightFeature") {
-    highlightFeature(data.message.featureId);
-  }
+let data = that;
+if (data.message?.type === "highlightFeature") {
+  highlightFeature(data.message.featureId);
 }
 ```
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -59,3 +59,47 @@ context.panes.openPane({
   },
 });
 ```
+
+### Messaging with a Portal
+
+`query` only gets data into a pattern once, at the moment its iframe is created — changing `query` on a later render does not reach an already-open portal. To send and receive messages after the portal has opened, use `PortalComponent`'s `ref` and `onMessage`:
+
+```typescript
+const portalRef = useRef<PortalComponentHandle>(null);
+
+context.panes.openPane({
+  placement: "floating",
+  title: "My Portal",
+  component: () => (
+    <PortalComponent
+      ref={portalRef}
+      portal="map"
+      portalType="map"
+      pattern={myPattern}
+      inst={inst}
+      onMessage={(message) => {
+        // handle a message sent from inside the pattern via os.sendEmbedMessage
+      }}
+    />
+  ),
+});
+
+// later, send a message into the pattern:
+portalRef.current?.sendMessage({ type: "highlightFeature", featureId });
+```
+
+On the pattern side (the code that runs inside the portal's iframe), use CasualOS's built-in embed-message APIs:
+
+```typescript
+// send a message out to the host page
+await os.sendEmbedMessage({ type: "featureClicked", featureId });
+
+// receive messages sent from the host page
+export function onEmbedMessage(data: { origin: string; message: any }) {
+  if (data.message?.type === "highlightFeature") {
+    highlightFeature(data.message.featureId);
+  }
+}
+```
+
+The iframe loads asynchronously, so a pattern should send a `{ type: "ready" }`-style message once its `onInstJoined`/`onEggHatch` handler has run, and the host should wait to see that before calling `sendMessage` for the first time — otherwise the very first message can be sent before the pattern is listening and will be silently dropped.

--- a/packages/seed-bible/seed-bible/components/PortalComponent/PortalComponent.tsx
+++ b/packages/seed-bible/seed-bible/components/PortalComponent/PortalComponent.tsx
@@ -1,7 +1,16 @@
 import "./PortalComponent.css";
-import { useRef } from "preact/hooks";
+import { useEffect, useImperativeHandle, useRef } from "preact/hooks";
+import { forwardRef } from "preact/compat";
 
 export type CasualOSPattern = { name: string } | { aux: string };
+
+/** The origin of every `ao.bot` portal iframe — the only origin trusted for postMessage traffic in or out. */
+const AO_BOT_ORIGIN = "https://ao.bot";
+
+export interface PortalComponentHandle {
+  /** Sends a message into the portal's CasualOS instance via `postMessage`. */
+  sendMessage: (message: unknown) => void;
+}
 
 export interface PortalComponentProps {
   /** Grid/map portal identifier to load in the iframe. */
@@ -18,12 +27,14 @@ export interface PortalComponentProps {
   pattern: CasualOSPattern | null;
   /** Query parameters for the portal's content. */
   query?: Record<string, string> | null;
+  /** Called with each message the portal's CasualOS instance sends via `os.sendEmbedMessage`. */
+  onMessage?: (message: unknown) => void;
 }
 
 /** Builds the `ao.bot` iframe URL for a portal from its props. */
 function buildIframeUrl(props: PortalComponentProps): string {
   const { portal, portalType, pattern, inst } = props;
-  const iframeUrl = new URL("https://ao.bot/");
+  const iframeUrl = new URL(AO_BOT_ORIGIN);
 
   iframeUrl.searchParams.set("inst", inst);
 
@@ -54,7 +65,10 @@ function buildIframeUrl(props: PortalComponentProps): string {
  * Renders a CasualOS grid or map portal as a cross-origin `ao.bot` iframe.
  * Intended to be used as a pane's `component` (see `PanesManager.openPane`).
  */
-export function PortalComponent(props: PortalComponentProps) {
+export const PortalComponent = forwardRef<
+  PortalComponentHandle,
+  PortalComponentProps
+>(function PortalComponent(props, ref) {
   const { portal, portalType } = props;
   const portalTitle = portalType === "map" ? "Map Portal" : "Grid Portal";
 
@@ -74,6 +88,41 @@ export function PortalComponent(props: PortalComponentProps) {
     iframeSrcRef.current = buildIframeUrl(props);
   }
 
+  const iframeRef = useRef<HTMLIFrameElement>(null);
+
+  // Kept fresh on every render but never used to resubscribe the listener
+  // below — see the effect's empty dependency array for why.
+  const onMessageRef = useRef(props.onMessage);
+  onMessageRef.current = props.onMessage;
+
+  useImperativeHandle(ref, () => ({
+    sendMessage: (message: unknown) => {
+      iframeRef.current?.contentWindow?.postMessage(message, AO_BOT_ORIGIN);
+    },
+  }));
+
+  // Registered once for the life of the mounted instance, matching the
+  // "compute once" approach used for iframeSrcRef above: `onMessage` is read
+  // through `onMessageRef` so a caller passing a fresh function identity each
+  // render doesn't tear down and recreate the listener.
+  useEffect(() => {
+    const handleMessage = (event: MessageEvent) => {
+      // The origin check alone isn't enough — more than one PortalComponent
+      // (and its own ao.bot iframe) can be mounted at once via floating
+      // panes, so the source check ensures this instance only reacts to
+      // messages from its own iframe, not a sibling portal's.
+      if (
+        event.origin !== AO_BOT_ORIGIN ||
+        event.source !== iframeRef.current?.contentWindow
+      ) {
+        return;
+      }
+      onMessageRef.current?.(event.data);
+    };
+    window.addEventListener("message", handleMessage);
+    return () => window.removeEventListener("message", handleMessage);
+  }, []);
+
   let allow = "";
 
   if (import.meta.env.DEV) {
@@ -87,6 +136,7 @@ export function PortalComponent(props: PortalComponentProps) {
         <div className="sb-grid-portal-pane-name">{portal}</div>
       </div>
       <iframe
+        ref={iframeRef}
         className="sb-grid-portal-pane-iframe"
         src={iframeSrcRef.current}
         referrerPolicy={"origin-when-cross-origin"}
@@ -94,4 +144,4 @@ export function PortalComponent(props: PortalComponentProps) {
       ></iframe>
     </>
   );
-}
+});

--- a/patterns/pattern-typings/AuxLibraryDefinitions.d.ts
+++ b/patterns/pattern-typings/AuxLibraryDefinitions.d.ts
@@ -15699,6 +15699,13 @@ interface Os {
      * @param defaultValue The value.
      */
     createContext<T>(defaultValue: T): PreactContext<T>;
+
+    /**
+     * Sends an embed message to the parent window. This is useful for communicating with the parent window when running inside an iframe.
+     * @param message The message to send.
+     * @param targetOrigin The target origin that the message should be sent to. Defaults to "*", which means that the message will be sent to any origin.
+     */
+    sendEmbedMessage(message: any, targetOrigin?: string): void;
   };
 
   appCompat: {

--- a/test/unit/seed-bible/components/PortalComponent.test.tsx
+++ b/test/unit/seed-bible/components/PortalComponent.test.tsx
@@ -1,9 +1,10 @@
-import { render } from "preact";
+import { render, createRef } from "preact";
 import { act } from "preact/test-utils";
 import { computed, signal } from "@preact/signals";
 import {
   PortalComponent,
   type PortalComponentProps,
+  type PortalComponentHandle,
 } from "@packages/seed-bible/seed-bible/components/PortalComponent/PortalComponent";
 import { PaneLayout } from "@packages/seed-bible/seed-bible/components/PaneLayout/PaneLayout";
 import { createPanes } from "@packages/seed-bible/seed-bible/managers/PanesManager";
@@ -99,6 +100,172 @@ describe("PortalComponent", () => {
     const iframeAfter = iframeOf(container);
     expect(iframeAfter).toBe(iframeBefore);
     expect(iframeAfter.src).toBe(srcBefore);
+  });
+});
+
+describe("PortalComponent postMessage bridge", () => {
+  let container: HTMLDivElement;
+
+  beforeEach(() => {
+    container = document.createElement("div");
+    document.body.appendChild(container);
+  });
+
+  afterEach(() => {
+    render(null, container);
+    container.remove();
+  });
+
+  it("sends messages into the iframe via the imperative handle", () => {
+    const ref = createRef<PortalComponentHandle>();
+
+    act(() => {
+      render(
+        <PortalComponent
+          ref={ref}
+          portal="map"
+          portalType="map"
+          inst="inst-1"
+          pattern={null}
+        />,
+        container
+      );
+    });
+
+    const iframe = iframeOf(container);
+    const postMessage = vi.spyOn(iframe.contentWindow!, "postMessage");
+
+    ref.current?.sendMessage({ type: "highlightFeature", featureId: "abc" });
+
+    expect(postMessage).toHaveBeenCalledWith(
+      { type: "highlightFeature", featureId: "abc" },
+      "https://ao.bot"
+    );
+  });
+
+  it("calls onMessage for a message from the portal's own iframe at the trusted origin", () => {
+    const onMessage = vi.fn();
+
+    act(() => {
+      render(
+        <PortalComponent
+          portal="map"
+          portalType="map"
+          inst="inst-1"
+          pattern={null}
+          onMessage={onMessage}
+        />,
+        container
+      );
+    });
+
+    const iframe = iframeOf(container);
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: "https://ao.bot",
+        source: iframe.contentWindow,
+        data: { type: "featureClicked", featureId: "abc" },
+      })
+    );
+
+    expect(onMessage).toHaveBeenCalledWith({
+      type: "featureClicked",
+      featureId: "abc",
+    });
+  });
+
+  it("ignores a message from an untrusted origin", () => {
+    const onMessage = vi.fn();
+
+    act(() => {
+      render(
+        <PortalComponent
+          portal="map"
+          portalType="map"
+          inst="inst-1"
+          pattern={null}
+          onMessage={onMessage}
+        />,
+        container
+      );
+    });
+
+    const iframe = iframeOf(container);
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: "https://evil.example",
+        source: iframe.contentWindow,
+        data: { type: "featureClicked" },
+      })
+    );
+
+    expect(onMessage).not.toHaveBeenCalled();
+  });
+
+  it("ignores a same-origin message from a different portal's iframe", () => {
+    const onMessage = vi.fn();
+
+    act(() => {
+      render(
+        <PortalComponent
+          portal="map"
+          portalType="map"
+          inst="inst-1"
+          pattern={null}
+          onMessage={onMessage}
+        />,
+        container
+      );
+    });
+
+    // A second, unrelated iframe standing in for a sibling PortalComponent's
+    // own ao.bot iframe mounted elsewhere on the page.
+    const otherIframe = document.createElement("iframe");
+    document.body.appendChild(otherIframe);
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: "https://ao.bot",
+        source: otherIframe.contentWindow,
+        data: { type: "featureClicked" },
+      })
+    );
+
+    expect(onMessage).not.toHaveBeenCalled();
+    otherIframe.remove();
+  });
+
+  it("stops calling onMessage once unmounted", () => {
+    const onMessage = vi.fn();
+
+    act(() => {
+      render(
+        <PortalComponent
+          portal="map"
+          portalType="map"
+          inst="inst-1"
+          pattern={null}
+          onMessage={onMessage}
+        />,
+        container
+      );
+    });
+
+    const iframeContentWindow = iframeOf(container).contentWindow;
+
+    act(() => {
+      render(null, container);
+    });
+
+    window.dispatchEvent(
+      new MessageEvent("message", {
+        origin: "https://ao.bot",
+        source: iframeContentWindow,
+        data: { type: "featureClicked" },
+      })
+    );
+
+    expect(onMessage).not.toHaveBeenCalled();
   });
 });
 


### PR DESCRIPTION
## Summary
- `PortalComponent` now supports sending messages into its `ao.bot` iframe (`ref` + `sendMessage`) and receiving messages back out (`onMessage` prop), mirroring the host-side pattern from [casual-simulation/casualos#866](https://github.com/casual-simulation/casualos/pull/866) (`os.sendEmbedMessage` / `@onEmbedMessage`).
- Inbound messages are validated against both origin (`https://ao.bot`) and `event.source` (the specific iframe's `contentWindow`), so messages can't be spoofed and multiple simultaneously-open portals don't cross-talk.
- Documented the new messaging API, including the pattern-side `os.sendEmbedMessage`/`onEmbedMessage` usage and the readiness-handshake caveat, in `DEVELOPERS.md`.

## Test plan
- [x] `pnpm vitest run PortalComponent.test.tsx` — 8 tests pass, including send/receive, wrong-origin rejection, wrong-iframe (sibling portal) rejection, and listener cleanup on unmount
- [x] Confirmed the two rejection tests fail (red) when the origin/source guard is reverted, then pass again once restored
- [x] `pnpm check:ts` — 0 errors
- [x] `pnpm lint` — 0 errors (pre-existing unrelated warnings only)
- [ ] Manual end-to-end check against a live `ao.bot` deployment that supports `os.sendEmbedMessage`/`@onEmbedMessage`

🤖 Generated with [Claude Code](https://claude.com/claude-code)