### PR TITLE
fix: stub clearBranchDeviceCache in all SessionsManager tests

### DIFF
--- a/test/unit/seed-bible/managers/SessionsManager.test.ts
+++ b/test/unit/seed-bible/managers/SessionsManager.test.ts
@@ -397,6 +397,12 @@ describe("SessionsManager", () => {
     getSharedDocumentMock = vi
       .spyOn(os, "getSharedDocument")
       .mockResolvedValue(mockDocument as unknown as SharedDocument);
+    // The real implementation lazily builds an inst client, which opens a
+    // real websocket connection — stub it everywhere so a sync-status test
+    // that flips false→true (which triggers a presence rebuild) can't
+    // trigger a real network connection whose async events fire after the
+    // test has finished and crash an unrelated, later test.
+    vi.spyOn(os, "clearBranchDeviceCache").mockImplementation(() => undefined);
     mockDataManager = {};
     mockLoginManager = {
       getUserProfile: vi.fn(async (userId: string) => ({


### PR DESCRIPTION
The isSynced sync-status test flips synced false→true, which triggers
SessionsManager's presence-rebuild path and calls the real (unmocked)
os.clearBranchDeviceCache(). That lazily opens a genuine websocket
connection to auth.seedbible.org. Locally the connection never
completes, but on GitHub Actions' runners it can, and the resulting
async socket event fires after the test finishes, hitting an
undici/jsdom Event-realm mismatch that crashes an unrelated, later
test with "Unhandled Errors". Stubbing the method for every test in
this file (not just the presence-recovery describe block) removes the
real network call entirely.