### PR TITLE
Add PostHog analytics events for reading plan lifecycle

### DIFF
--- a/packages/seed-bible/seed-bible/managers/ReadingPlansManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ReadingPlansManager.tsx
@@ -2217,6 +2217,7 @@ export function createReadingPlansManager(
   const deleteReadingPlan = async (plan: {
     recordName: string;
     address: string;
+    status: ReadingPlanStatus;
   }) => {
     const planId = formatReadingPlanId(plan.recordName, plan.address);
     const ownProgresses = userReadingPlanProgresses.value.filter(
@@ -2224,7 +2225,12 @@ export function createReadingPlansManager(
     );
     await os.eraseData(plan.recordName, `${plan.address}_metadata`);
     await os.eraseData(plan.recordName, plan.address);
-    captureEvent("reading_plan_deleted", { planId });
+    // A draft that was never finished never fired `reading_plan_created`, so
+    // discarding it here (see `discardEditingReadingPlan`) must not count as a
+    // delete — only a plan that actually got published is one.
+    if (plan.status === "complete") {
+      captureEvent("reading_plan_deleted", { planId });
+    }
     // Best effort: a progress that fails to erase leaves nothing broken behind
     // (it simply stops matching a plan), so it must not fail the delete.
     await Promise.all(

--- a/packages/seed-bible/seed-bible/managers/ReadingPlansManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ReadingPlansManager.tsx
@@ -185,6 +185,20 @@ export function formatReadingPlanId(
   return `rp_${recordName}_${address}`;
 }
 
+/** Session/reading totals for analytics, counted as the plan currently stands. */
+function readingPlanCounts(plan: ReadingPlan): {
+  totalSessions: number;
+  totalReadings: number;
+} {
+  return {
+    totalSessions: plan.sessions.length,
+    totalReadings: plan.sessions.reduce(
+      (sum, session) => sum + session.readings.length,
+      0
+    ),
+  };
+}
+
 /**
  * Creates a fresh progress record for a user starting a plan. `id` (unique) and
  * `nowMs` are passed in so this stays deterministic; the manager supplies them.
@@ -1885,6 +1899,24 @@ export function createReadingPlansManager(
           : [...userReadingPlans.value, metadata];
       });
       editingReadingPlanSaveError.value = false;
+      // Editing an already-published plan (`isNew: false`) autosaves the same
+      // way but isn't a "draft" in the lifecycle sense — it keeps its
+      // `"complete"` status throughout and reports via
+      // reading_plan_updated on finish, not here.
+      if (draft.isNew) {
+        captureEvent(
+          draft.persisted
+            ? "reading_plan_draft_updated"
+            : "reading_plan_draft_created",
+          {
+            planId: formatReadingPlanId(
+              draft.plan.recordName,
+              draft.plan.address
+            ),
+            ...readingPlanCounts(draft.plan),
+          }
+        );
+      }
     } catch (error) {
       console.error("Failed to save reading plan draft:", error);
       editingReadingPlanSaveError.value = true;
@@ -2197,11 +2229,7 @@ export function createReadingPlansManager(
       draft.isNew ? "reading_plan_created" : "reading_plan_updated",
       {
         planId: formatReadingPlanId(plan.recordName, plan.address),
-        totalSessions: plan.sessions.length,
-        totalReadings: plan.sessions.reduce(
-          (sum, session) => sum + session.readings.length,
-          0
-        ),
+        ...readingPlanCounts(plan),
       }
     );
     return plan;
@@ -2278,6 +2306,10 @@ export function createReadingPlansManager(
     }
     try {
       await deleteReadingPlan(draft.plan);
+      captureEvent("reading_plan_draft_discarded", {
+        planId: formatReadingPlanId(draft.plan.recordName, draft.plan.address),
+        ...readingPlanCounts(draft.plan),
+      });
     } catch (error) {
       console.error("Failed to discard reading plan draft:", error);
     }

--- a/packages/seed-bible/seed-bible/managers/ReadingPlansManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ReadingPlansManager.tsx
@@ -12,6 +12,7 @@ import {
 } from "./civilDate";
 import { CasualOSManager } from "./OsManager";
 import { v4 as uuid } from "uuid";
+import { captureEvent } from "./Utils";
 
 // ---------------------------------------------------------------------------
 // Cadence
@@ -1328,6 +1329,50 @@ export function summarizeCalendar(
   };
 }
 
+/**
+ * Fires the session/plan "finished" analytics events for whatever completion
+ * transitions happened between `previous` and `next`. Called from every path
+ * that persists progress, so a session completed via marking the whole
+ * session, the whole day, or its last individual reading is reported the same
+ * way. Only the incomplete -> complete direction fires: undoing progress, or
+ * re-saving a session that was already complete, must not re-emit.
+ */
+function captureProgressCompletionEvents(
+  plan: ReadingPlan | undefined,
+  previous: ReadingPlanProgress | undefined,
+  next: ReadingPlanProgress
+): void {
+  const previousSessions = new Map(
+    (previous?.sessions ?? []).map((s) => [s.sessionId, s])
+  );
+  for (const session of next.sessions) {
+    if (
+      session.completedAtMs &&
+      !previousSessions.get(session.sessionId)?.completedAtMs
+    ) {
+      captureEvent("reading_plan_session_finished", {
+        planId: next.planId,
+        progressId: next.id,
+        sessionId: session.sessionId,
+      });
+    }
+  }
+  if (!plan) {
+    return;
+  }
+  const previousPercent = previous
+    ? withProgressStats(plan, previous).percentComplete
+    : 0;
+  if (previousPercent < 1 && next.percentComplete === 1) {
+    captureEvent("reading_plan_finished", {
+      planId: next.planId,
+      progressId: next.id,
+      totalSessions: next.totalSessions,
+      totalReadings: next.totalReadings,
+    });
+  }
+}
+
 export function createReadingPlansManager(
   os: CasualOSManager,
   login: LoginManager
@@ -1564,16 +1609,24 @@ export function createReadingPlansManager(
   // recomputing the derived stats against the selected plan when it matches.
   const updateSelectedProgress = async (updated: ReadingPlanProgress) => {
     const plan = selectedReadingPlan.value;
-    const next =
+    const matchingPlan =
       plan &&
       formatReadingPlanId(plan.recordName, plan.address) === updated.planId
-        ? withProgressStats(plan, updated)
-        : updated;
+        ? plan
+        : undefined;
+    const previous =
+      selectedReadingPlanProgress.value?.id === updated.id
+        ? selectedReadingPlanProgress.value
+        : undefined;
+    const next = matchingPlan
+      ? withProgressStats(matchingPlan, updated)
+      : updated;
     selectedReadingPlanProgress.value = next;
     userReadingPlanProgresses.value = userReadingPlanProgresses.value.map(
       (p) => (p.id === next.id ? next : p)
     );
     await saveReadingPlanProgress(next);
+    captureProgressCompletionEvents(matchingPlan, previous, next);
   };
 
   const requireSelectedProgress = () => {
@@ -1616,9 +1669,25 @@ export function createReadingPlansManager(
   /** Marks an entire calendar day (all sessions and readings) complete/incomplete and saves. */
   const markDayComplete = async (day: CalendarReadingDay, complete = true) => {
     const current = requireSelectedProgress();
+    // Day completion is calendar information (which sessions fall on this day)
+    // that isn't visible from a plain progress diff, so it's checked here
+    // rather than centrally alongside session/plan completion.
+    const wasAlreadyComplete = day.sessions.every((cs) =>
+      isSessionComplete(
+        cs.session,
+        current.sessions.find((s) => s.sessionId === cs.session.id)
+      )
+    );
     await updateSelectedProgress(
       markDayCompleteInProgress(current, day, Date.now(), complete)
     );
+    if (complete && !wasAlreadyComplete) {
+      captureEvent("reading_plan_day_finished", {
+        planId: current.planId,
+        progressId: current.id,
+        dayOffset: day.dayOffset,
+      });
+    }
   };
 
   /** Marks one chapter of one reading complete/incomplete and saves. */
@@ -1651,6 +1720,9 @@ export function createReadingPlansManager(
     const plan = fullReadingPlans.value.find(
       (p) => formatReadingPlanId(p.recordName, p.address) === updated.planId
     );
+    const previous = userReadingPlanProgresses.value.find(
+      (p) => p.id === updated.id
+    );
     const next = plan ? withProgressStats(plan, updated) : updated;
     userReadingPlanProgresses.value = userReadingPlanProgresses.value.map(
       (p) => (p.id === next.id ? next : p)
@@ -1659,6 +1731,7 @@ export function createReadingPlansManager(
       selectedReadingPlanProgress.value = next;
     }
     await saveReadingPlanProgress(next);
+    captureProgressCompletionEvents(plan, previous, next);
   };
 
   /**
@@ -1758,6 +1831,12 @@ export function createReadingPlansManager(
       ...userReadingPlanProgresses.value,
       progress,
     ];
+    captureEvent("reading_plan_started", {
+      planId: progress.planId,
+      progressId: progress.id,
+      selfPaced: progress.selfPaced,
+      cadenceId: progress.selectedCadenceId,
+    });
     return progress;
   };
 
@@ -2114,6 +2193,17 @@ export function createReadingPlansManager(
     });
     editingReadingPlan.value = null;
     editingReadingPlanSaving.value = false;
+    captureEvent(
+      draft.isNew ? "reading_plan_created" : "reading_plan_updated",
+      {
+        planId: formatReadingPlanId(plan.recordName, plan.address),
+        totalSessions: plan.sessions.length,
+        totalReadings: plan.sessions.reduce(
+          (sum, session) => sum + session.readings.length,
+          0
+        ),
+      }
+    );
     return plan;
   };
 
@@ -2134,6 +2224,7 @@ export function createReadingPlansManager(
     );
     await os.eraseData(plan.recordName, `${plan.address}_metadata`);
     await os.eraseData(plan.recordName, plan.address);
+    captureEvent("reading_plan_deleted", { planId });
     // Best effort: a progress that fails to erase leaves nothing broken behind
     // (it simply stops matching a plan), so it must not fail the delete.
     await Promise.all(

--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -419,6 +419,7 @@ import {
 } from "./AIManager";
 import { z } from "zod";
 import { getDefaultTranslationForLanguage } from "./BibleReadingManager";
+import { captureEvent } from "./Utils";
 
 /**
  * Creates and wires the full Seed Bible application state graph.
@@ -1219,10 +1220,7 @@ export function createSeedBibleState(
     }, 5000);
 
     const posthogTimeoutId = setTimeout(() => {
-      if (typeof posthog === "undefined" || !posthog) {
-        return;
-      }
-      posthog?.capture("user_chapter_read", {
+      captureEvent("user_chapter_read", {
         translationId: chapter.translation.id,
         bookId: chapter.book.id,
         chapter: String(chapter.chapter.number),
@@ -1578,11 +1576,9 @@ export function createSeedBibleState(
         ? getSessionStartPosition(activeReadingState)
         : undefined
     );
-    if (typeof posthog !== "undefined" && posthog) {
-      posthog.capture("create_session", {
-        sessionId: session.id,
-      });
-    }
+    captureEvent("create_session", {
+      sessionId: session.id,
+    });
     locallyHostedSessionIds.add(session.id);
     wrapSessionLifecycle(session);
     // Auto-publish: the moment a shared tab is created, other logged-in
@@ -1597,11 +1593,9 @@ export function createSeedBibleState(
   const handleJoinSharedSession = async (id: string) => {
     closeSidebarAndSettings();
     const session = await sessions.joinSession(id);
-    if (typeof posthog !== "undefined" && posthog) {
-      posthog.capture("join_session", {
-        sessionId: session.id,
-      });
-    }
+    captureEvent("join_session", {
+      sessionId: session.id,
+    });
     wrapSessionLifecycle(session);
     const tab = tabs.addTab(session);
     tabsLayout.setSelectedSlotTab(tab.id);

--- a/packages/seed-bible/seed-bible/managers/Utils.tsx
+++ b/packages/seed-bible/seed-bible/managers/Utils.tsx
@@ -6,3 +6,14 @@ export function parseNumber(value: unknown, fallback: number): number {
   }
   return fallback;
 }
+
+/** Sends a PostHog event, no-op when `posthog` isn't present (SSR, tests). */
+export function captureEvent(
+  eventName: string,
+  properties?: Record<string, unknown>
+): void {
+  if (typeof posthog === "undefined" || !posthog) {
+    return;
+  }
+  posthog.capture(eventName, properties);
+}

--- a/test/unit/seed-bible/managers/ReadingPlansManager.test.ts
+++ b/test/unit/seed-bible/managers/ReadingPlansManager.test.ts
@@ -2105,6 +2105,35 @@ describe("createReadingPlansManager", () => {
       });
     });
 
+    it("discarding a never-finished draft does not capture reading_plan_deleted", async () => {
+      const manager = makeManager("user-1");
+      await flush();
+      vi.useFakeTimers();
+      try {
+        manager.startEditingReadingPlan();
+        manager.addReadingToEditingPlan({
+          type: "bible-verse",
+          ref: { bookId: "PSA", chapter: 1 },
+        });
+        // Let the debounced autosave persist the draft (status stays "draft"
+        // since finishEditingReadingPlan was never called).
+        await vi.advanceTimersByTimeAsync(2000);
+        expect(manager.editingReadingPlan.value!.persisted).toBe(true);
+        mockPosthogCapture.mockClear();
+
+        await manager.discardEditingReadingPlan();
+
+        // A draft that was never finished never fired reading_plan_created,
+        // so discarding it must not look like a delete either.
+        expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+          "reading_plan_deleted",
+          expect.anything()
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
     it("startReadingPlan captures reading_plan_started", async () => {
       const manager = makeManager("user-1");
       await flush();
@@ -2119,6 +2148,22 @@ describe("createReadingPlansManager", () => {
         progressId: progress.id,
         selfPaced: false,
         cadenceId: "every-other-day",
+      });
+    });
+
+    it("startReadingPlan captures reading_plan_started with a null cadenceId for a self-paced plan", async () => {
+      const manager = makeManager("user-1");
+      await flush();
+
+      const progress = await manager.startReadingPlan(metadataOf(makePlan()), {
+        selfPaced: true,
+      });
+
+      expect(mockPosthogCapture).toHaveBeenCalledWith("reading_plan_started", {
+        planId: progress.planId,
+        progressId: progress.id,
+        selfPaced: true,
+        cadenceId: null,
       });
     });
 
@@ -2222,6 +2267,22 @@ describe("createReadingPlansManager", () => {
           progressId: "progress-1",
           dayOffset: day.dayOffset,
         }
+      );
+      // The day's two sessions both just completed too - one
+      // reading_plan_session_finished per session, plus the one day event.
+      expect(
+        mockPosthogCapture.mock.calls.filter(
+          (c) => c[0] === "reading_plan_session_finished"
+        )
+      ).toHaveLength(2);
+      expect(mockPosthogCapture).toHaveBeenCalledTimes(3);
+
+      // Marking an already-complete day complete again must not re-fire.
+      mockPosthogCapture.mockClear();
+      await manager.markDayComplete(day);
+      expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+        "reading_plan_day_finished",
+        expect.anything()
       );
 
       mockPosthogCapture.mockClear();

--- a/test/unit/seed-bible/managers/ReadingPlansManager.test.ts
+++ b/test/unit/seed-bible/managers/ReadingPlansManager.test.ts
@@ -2105,7 +2105,7 @@ describe("createReadingPlansManager", () => {
       });
     });
 
-    it("discarding a never-finished draft does not capture reading_plan_deleted", async () => {
+    it("discarding a never-finished draft captures reading_plan_draft_discarded, not reading_plan_deleted", async () => {
       const manager = makeManager("user-1");
       await flush();
       vi.useFakeTimers();
@@ -2119,14 +2119,150 @@ describe("createReadingPlansManager", () => {
         // since finishEditingReadingPlan was never called).
         await vi.advanceTimersByTimeAsync(2000);
         expect(manager.editingReadingPlan.value!.persisted).toBe(true);
+        const plan = manager.editingReadingPlan.value!.plan;
         mockPosthogCapture.mockClear();
 
         await manager.discardEditingReadingPlan();
 
+        expect(mockPosthogCapture).toHaveBeenCalledWith(
+          "reading_plan_draft_discarded",
+          {
+            planId: `rp_${plan.recordName}_${plan.address}`,
+            totalSessions: 1,
+            totalReadings: 1,
+          }
+        );
         // A draft that was never finished never fired reading_plan_created,
         // so discarding it must not look like a delete either.
         expect(mockPosthogCapture).not.toHaveBeenCalledWith(
           "reading_plan_deleted",
+          expect.anything()
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("cancelEditingReadingPlan keeps the draft and does not capture reading_plan_draft_discarded", async () => {
+      const manager = makeManager("user-1");
+      await flush();
+      vi.useFakeTimers();
+      try {
+        manager.startEditingReadingPlan();
+        manager.addReadingToEditingPlan({
+          type: "bible-verse",
+          ref: { bookId: "PSA", chapter: 1 },
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        mockPosthogCapture.mockClear();
+
+        manager.cancelEditingReadingPlan();
+        await vi.advanceTimersByTimeAsync(2000);
+
+        expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+          "reading_plan_draft_discarded",
+          expect.anything()
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("autosaving a new draft captures reading_plan_draft_created on the first save, reading_plan_draft_updated after", async () => {
+      const manager = makeManager("user-1");
+      await flush();
+      vi.useFakeTimers();
+      try {
+        manager.startEditingReadingPlan();
+        manager.addReadingToEditingPlan({
+          type: "bible-verse",
+          ref: { bookId: "PSA", chapter: 1 },
+        });
+        await vi.advanceTimersByTimeAsync(2000);
+        const plan = manager.editingReadingPlan.value!.plan;
+
+        expect(mockPosthogCapture).toHaveBeenCalledWith(
+          "reading_plan_draft_created",
+          {
+            planId: `rp_${plan.recordName}_${plan.address}`,
+            totalSessions: 1,
+            totalReadings: 1,
+          }
+        );
+        expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+          "reading_plan_draft_updated",
+          expect.anything()
+        );
+
+        mockPosthogCapture.mockClear();
+        manager.updateEditingReadingPlan({ title: "Psalms" });
+        await vi.advanceTimersByTimeAsync(2000);
+
+        expect(mockPosthogCapture).toHaveBeenCalledWith(
+          "reading_plan_draft_updated",
+          {
+            planId: `rp_${plan.recordName}_${plan.address}`,
+            totalSessions: 1,
+            totalReadings: 1,
+          }
+        );
+        expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+          "reading_plan_draft_created",
+          expect.anything()
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("resuming a saved draft and editing it captures reading_plan_draft_updated, not created", async () => {
+      const draftPlan = makePlan({
+        status: "draft",
+        recordName: "user-1",
+        address: "draft-1",
+      });
+      const manager = makeManager("user-1");
+      await flush();
+      vi.useFakeTimers();
+      try {
+        manager.resumeEditingReadingPlan(draftPlan);
+        manager.updateEditingReadingPlan({ title: "Resumed" });
+        await vi.advanceTimersByTimeAsync(2000);
+
+        expect(mockPosthogCapture).toHaveBeenCalledWith(
+          "reading_plan_draft_updated",
+          {
+            planId: "rp_user-1_draft-1",
+            totalSessions: 3,
+            totalReadings: 3,
+          }
+        );
+        expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+          "reading_plan_draft_created",
+          expect.anything()
+        );
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("editing an already-published plan does not capture any draft event", async () => {
+      const plan = makePlan({ authorUserId: "user-1", recordName: "user-1" });
+      getDataMock.mockResolvedValue({ success: true, data: plan });
+      const manager = makeManager("user-1");
+      await flush();
+      vi.useFakeTimers();
+      try {
+        manager.editExistingReadingPlan(plan);
+        manager.updateEditingReadingPlan({ title: "Retitled" });
+        await vi.advanceTimersByTimeAsync(2000);
+
+        expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+          "reading_plan_draft_created",
+          expect.anything()
+        );
+        expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+          "reading_plan_draft_updated",
           expect.anything()
         );
       } finally {

--- a/test/unit/seed-bible/managers/ReadingPlansManager.test.ts
+++ b/test/unit/seed-bible/managers/ReadingPlansManager.test.ts
@@ -2037,6 +2037,246 @@ describe("createReadingPlansManager", () => {
     expect(saved.percentComplete).toBeCloseTo(1 / 3, 10);
     expect(saved.totalReadings).toBe(3);
   });
+
+  describe("analytics", () => {
+    let mockPosthogCapture: Mock;
+
+    beforeEach(() => {
+      mockPosthogCapture = vi.fn();
+      (globalThis as any).posthog = { capture: mockPosthogCapture };
+    });
+
+    afterEach(() => {
+      delete (globalThis as any).posthog;
+    });
+
+    it("finishEditingReadingPlan captures reading_plan_created for a new draft", async () => {
+      const manager = makeManager("user-1");
+      await flush();
+      manager.startEditingReadingPlan();
+      manager.addReadingToEditingPlan({
+        type: "bible-verse",
+        ref: { bookId: "PSA", chapter: 1 },
+      });
+
+      const plan = await manager.finishEditingReadingPlan();
+
+      expect(mockPosthogCapture).toHaveBeenCalledWith("reading_plan_created", {
+        planId: `rp_${plan!.recordName}_${plan!.address}`,
+        totalSessions: 1,
+        totalReadings: 1,
+      });
+      expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+        "reading_plan_updated",
+        expect.anything()
+      );
+    });
+
+    it("finishEditingReadingPlan captures reading_plan_updated for an existing plan", async () => {
+      const plan = makePlan({ authorUserId: "user-1", recordName: "user-1" });
+      getDataMock.mockResolvedValue({ success: true, data: plan });
+      const manager = makeManager("user-1");
+      await flush();
+      manager.editExistingReadingPlan(plan);
+      mockPosthogCapture.mockClear();
+
+      await manager.finishEditingReadingPlan();
+
+      expect(mockPosthogCapture).toHaveBeenCalledWith("reading_plan_updated", {
+        planId: "rp_user-1_plan-1",
+        totalSessions: 3,
+        totalReadings: 3,
+      });
+      expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+        "reading_plan_created",
+        expect.anything()
+      );
+    });
+
+    it("deleteReadingPlan captures reading_plan_deleted", async () => {
+      const plan = makePlan({ recordName: "user-1", address: "plan-1" });
+      const manager = makeManager("user-1");
+      await flush();
+
+      await manager.deleteReadingPlan(plan);
+
+      expect(mockPosthogCapture).toHaveBeenCalledWith("reading_plan_deleted", {
+        planId: "rp_user-1_plan-1",
+      });
+    });
+
+    it("startReadingPlan captures reading_plan_started", async () => {
+      const manager = makeManager("user-1");
+      await flush();
+
+      const progress = await manager.startReadingPlan(metadataOf(makePlan()), {
+        cadenceId: "every-other-day",
+        selfPaced: false,
+      });
+
+      expect(mockPosthogCapture).toHaveBeenCalledWith("reading_plan_started", {
+        planId: progress.planId,
+        progressId: progress.id,
+        selfPaced: false,
+        cadenceId: "every-other-day",
+      });
+    });
+
+    it("markSessionComplete captures reading_plan_session_finished exactly once, and doesn't refire when already complete", async () => {
+      const manager = makeManager("user-1");
+      await flush();
+      await manager.selectReadingPlanProgress(makeProgress());
+
+      await manager.markSessionComplete({
+        id: "s1",
+        readings: [reading("r1")],
+      });
+
+      expect(mockPosthogCapture).toHaveBeenCalledWith(
+        "reading_plan_session_finished",
+        {
+          planId: "rp_record-1_plan-1",
+          progressId: "progress-1",
+          sessionId: "s1",
+        }
+      );
+      expect(mockPosthogCapture).toHaveBeenCalledTimes(1);
+
+      mockPosthogCapture.mockClear();
+      await manager.markSessionComplete({
+        id: "s1",
+        readings: [reading("r1")],
+      });
+      expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+        "reading_plan_session_finished",
+        expect.anything()
+      );
+    });
+
+    it("completing a session's last reading also captures reading_plan_session_finished", async () => {
+      const manager = makeManager("user-1");
+      await flush();
+      await manager.selectReadingPlanProgress(makeProgress());
+      const session = { id: "s2", readings: [reading("r2a"), reading("r2b")] };
+
+      await manager.markReadingComplete(session, "r2a");
+      expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+        "reading_plan_session_finished",
+        expect.anything()
+      );
+
+      await manager.markReadingComplete(session, "r2b");
+      expect(mockPosthogCapture).toHaveBeenCalledWith(
+        "reading_plan_session_finished",
+        {
+          planId: "rp_record-1_plan-1",
+          progressId: "progress-1",
+          sessionId: "s2",
+        }
+      );
+    });
+
+    it("un-marking a session does not capture reading_plan_session_finished", async () => {
+      const manager = makeManager("user-1");
+      await flush();
+      await manager.selectReadingPlanProgress(makeProgress());
+      const session = { id: "s1", readings: [reading("r1")] };
+      await manager.markSessionComplete(session);
+      mockPosthogCapture.mockClear();
+
+      await manager.markSessionComplete(session, false);
+
+      expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+        "reading_plan_session_finished",
+        expect.anything()
+      );
+    });
+
+    it("markDayComplete captures reading_plan_day_finished only once every session on the day is complete", async () => {
+      const plan = makePlan({
+        sessions: [
+          { id: "s1", readings: [reading("r1")] },
+          { id: "s2", readings: [reading("r2")] },
+        ],
+      });
+      const progress = makeProgress({
+        customCadence: {
+          segments: [{ type: "read", days: 1, sessionsPerDay: 2 }],
+        },
+        timeZone: ZONE,
+      });
+      const manager = makeManager("user-1");
+      await manager.selectReadingPlanProgress(progress);
+      const day = getReadingCalendar(
+        plan,
+        progress,
+        START_MS
+      )[0] as CalendarReadingDay;
+
+      await manager.markDayComplete(day);
+
+      expect(mockPosthogCapture).toHaveBeenCalledWith(
+        "reading_plan_day_finished",
+        {
+          planId: "rp_record-1_plan-1",
+          progressId: "progress-1",
+          dayOffset: day.dayOffset,
+        }
+      );
+
+      mockPosthogCapture.mockClear();
+      await manager.markDayComplete(day, false);
+      expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+        "reading_plan_day_finished",
+        expect.anything()
+      );
+    });
+
+    it("completing the plan's last remaining session captures reading_plan_finished", async () => {
+      const plan = makePlan(); // 3 sessions, 1 reading each
+      getDataMock.mockResolvedValue({ success: true, data: plan });
+      const manager = makeManager("user-1");
+      await flush();
+      await manager.selectReadingPlan(metadataOf(plan));
+      await manager.selectReadingPlanProgress(makeProgress());
+
+      await manager.markSessionComplete({
+        id: "s1",
+        readings: [reading("r1")],
+      });
+      await manager.markSessionComplete({
+        id: "s2",
+        readings: [reading("r2")],
+      });
+      expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+        "reading_plan_finished",
+        expect.anything()
+      );
+
+      await manager.markSessionComplete({
+        id: "s3",
+        readings: [reading("r3")],
+      });
+
+      expect(mockPosthogCapture).toHaveBeenCalledWith("reading_plan_finished", {
+        planId: "rp_record-1_plan-1",
+        progressId: "progress-1",
+        totalSessions: 3,
+        totalReadings: 3,
+      });
+
+      mockPosthogCapture.mockClear();
+      // Already at 100% - re-saving must not re-fire.
+      await manager.markSessionComplete({
+        id: "s3",
+        readings: [reading("r3")],
+      });
+      expect(mockPosthogCapture).not.toHaveBeenCalledWith(
+        "reading_plan_finished",
+        expect.anything()
+      );
+    });
+  });
 });
 
 describe("progress updates", () => {


### PR DESCRIPTION
Fires reading_plan_created/updated/deleted/started/finished plus
day_finished and session_finished, covering every path that can
complete a session (whole-session, whole-day, or last-reading marks)
via a shared completion-diff helper. Extracts the repeated
posthog.capture guard into a captureEvent helper in Utils.tsx and
switches the existing user_chapter_read/create_session/join_session
call sites to use it.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CUcrgG3D7eGZJc6gmYXrWN