### PR TITLE
Add IndexNow submission script to notify search engines of new chapters

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -41,6 +41,7 @@ jobs:
       ASSET_BASE_URL: ${{ vars.ASSET_BASE_URL }} # e.g. https://assets.seedbible.com/
       S3_BUCKET: ${{ secrets.DEPLOY_BUCKET }}
       AWS_REGION: ${{ vars.AWS_REGION }}
+      INDEXNOW_KEY: ${{ secrets.INDEXNOW_KEY }} # ships the IndexNow key-verification file; see script/index-sitemap-urls.ts
     steps:
       - uses: actions/checkout@v4
 

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ coverage/
 secrets.json
 .pnpm-store/*
 *.local.*
+/script/.indexnow-log.json

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "i18n": "tsx script/i18n.ts",
     "list-bible-translations": "tsx script/list-bible-translations.ts",
     "sitemap": "tsx script/generate-sitemap.ts",
+    "index-sitemap-urls": "tsx script/index-sitemap-urls.ts",
     "format": "prettier --write \"packages/**/*.{js,jsx,ts,tsx,css}\"",
     "format:changed": "pretty-quick",
     "prepare": "husky && tsx script/setupMergeDriver.ts"

--- a/packages/seed-bible/seed-bible/managers/FreeUseBibleAPI.tsx
+++ b/packages/seed-bible/seed-bible/managers/FreeUseBibleAPI.tsx
@@ -214,6 +214,16 @@ export interface TranslationBook {
 
 export interface TranslationBookChapter {
   /**
+   * The SHA-256 hash of this chapter's content.
+   *
+   * Comparing a previously fetched chapter's hash against this one is how we
+   * detect that the chapter's content changed since it was last fetched.
+   *
+   * Null or undefined if the API did not report a hash.
+   */
+  sha256?: string;
+
+  /**
    * The translation information for the book chapter.
    */
   translation: Translation;

--- a/script/generate-sitemap.ts
+++ b/script/generate-sitemap.ts
@@ -45,6 +45,7 @@ import {
   type BookChapters,
   type SitemapIndexEntry,
 } from "./lib/sitemap";
+import { mapWithConcurrency } from "./lib/concurrency";
 
 const DEFAULT_ORIGIN = "https://seedbible.org";
 const DEFAULT_OUT_DIR = path.join("standalone", "dist", "client");
@@ -145,32 +146,6 @@ function skipReason(): string | null {
 interface TranslationSitemap {
   translationId: string;
   urls: string[];
-}
-
-/** Runs `worker` over `items` with at most `limit` in flight at once. */
-async function mapWithConcurrency<T, R>(
-  items: readonly T[],
-  limit: number,
-  worker: (item: T, index: number) => Promise<R>
-): Promise<R[]> {
-  const results = new Array<R>(items.length);
-  let cursor = 0;
-
-  async function run(): Promise<void> {
-    while (true) {
-      const index = cursor++;
-      if (index >= items.length) {
-        return;
-      }
-      results[index] = await worker(items[index]!, index);
-    }
-  }
-
-  const workers = Array.from({ length: Math.min(limit, items.length) }, () =>
-    run()
-  );
-  await Promise.all(workers);
-  return results;
 }
 
 async function buildTranslationSitemap(
@@ -332,6 +307,17 @@ async function generate(options: Options): Promise<void> {
     renderRobots(origin),
     "utf-8"
   );
+
+  // Ships the IndexNow key-verification file (see script/index-sitemap-urls.ts)
+  // at the site root alongside robots.txt/sitemap.xml, riding the same S3-sync
+  // deploy path. A missing INDEXNOW_KEY just skips this — existing deploys are
+  // unaffected.
+  const indexNowKey = process.env.INDEXNOW_KEY?.trim();
+  if (indexNowKey) {
+    const keyFileName = `${indexNowKey}.txt`;
+    await writeFile(path.join(outDir, keyFileName), indexNowKey, "utf-8");
+    console.log(`  ${path.join(outDir, keyFileName)} (IndexNow key file)`);
+  }
 
   console.log("");
   console.log(

--- a/script/index-sitemap-urls.ts
+++ b/script/index-sitemap-urls.ts
@@ -1,0 +1,369 @@
+/**
+ * Manually submits the site's chapter URLs to IndexNow (https://www.indexnow.org)
+ * so participating search engines (Bing, Yandex, Naver, Seznam.cz, Yep) can pick
+ * up new/changed pages without waiting for their own crawl schedule.
+ *
+ * For every chapter, the Free Use Bible API's per-chapter `sha256` is compared
+ * against a local submission log (see `script/lib/indexNow.ts`); only chapters
+ * that are new or whose hash changed since the last successful submission are
+ * sent. The log is git-ignored and lives locally — re-running this script from
+ * a clean checkout resubmits everything once, then goes back to incremental.
+ *
+ * IndexNow verification requires a `<key>.txt` file containing the key,
+ * reachable at `keyLocation` on the same host as the submitted URLs.
+ * `script/generate-sitemap.ts` ships that file automatically (alongside
+ * robots.txt/sitemap.xml) whenever `INDEXNOW_KEY` is set at build time; the
+ * same key must be passed here via `INDEXNOW_KEY` or `--key`.
+ *
+ * Usage:
+ *   INDEXNOW_KEY=... pnpm index-sitemap-urls
+ *   pnpm index-sitemap-urls --key=... --dry-run
+ *   pnpm index-sitemap-urls --key=... --all-translations --concurrency=4
+ */
+import { program } from "commander";
+import {
+  FreeUseBibleAPI,
+  getDefaultAPIEndpoint,
+  type Translation,
+  type TranslationBook,
+} from "@packages/seed-bible/seed-bible/managers/FreeUseBibleAPI";
+import {
+  bibleLanguageToUiLocale,
+  buildChapterUrl,
+  buildTranslationParam,
+  chunk,
+  ensureTrailingSlash,
+} from "./lib/sitemap";
+import { mapWithConcurrency } from "./lib/concurrency";
+import {
+  DEFAULT_INDEXNOW_ENDPOINT,
+  INDEXNOW_MAX_URLS_PER_REQUEST,
+  buildIndexNowPayload,
+  readSubmissionLog,
+  submitIndexNowBatch,
+  writeSubmissionLog,
+} from "./lib/indexNow";
+
+const DEFAULT_ORIGIN = "https://seedbible.org";
+const DEFAULT_LOG_FILE = "script/.indexnow-log.json";
+const DEFAULT_CONCURRENCY = 8;
+
+interface Options {
+  origin: string;
+  endpoint: string;
+  key: string;
+  logFile: string;
+  allTranslations: boolean;
+  concurrency: number;
+  dryRun: boolean;
+  indexNowEndpoint: string;
+}
+
+function resolveOptions(cli: {
+  baseUrl?: string;
+  endpoint?: string;
+  key?: string;
+  log?: string;
+  allTranslations?: boolean;
+  concurrency?: string;
+  dryRun?: boolean;
+  indexnowEndpoint?: string;
+}): Options {
+  const origin = (
+    cli.baseUrl ??
+    process.env.SITE_ORIGIN ??
+    DEFAULT_ORIGIN
+  ).trim();
+
+  // Mirrors generate-sitemap.ts: no `useFreeBibleAPI` param → the private
+  // production mirror, so URLs match what the live site serves.
+  const endpoint = (
+    cli.endpoint ??
+    process.env.BIBLE_API_ENDPOINT ??
+    getDefaultAPIEndpoint(new URL(origin))
+  ).trim();
+
+  const key = (cli.key ?? process.env.INDEXNOW_KEY ?? "").trim();
+  if (!key) {
+    throw new Error(
+      "An IndexNow key is required. Pass --key=<key> or set the INDEXNOW_KEY environment variable."
+    );
+  }
+
+  const concurrency = cli.concurrency
+    ? Math.max(1, Number.parseInt(cli.concurrency, 10) || DEFAULT_CONCURRENCY)
+    : DEFAULT_CONCURRENCY;
+
+  return {
+    origin,
+    endpoint,
+    key,
+    logFile: cli.log ?? DEFAULT_LOG_FILE,
+    allTranslations: Boolean(cli.allTranslations),
+    concurrency,
+    dryRun: Boolean(cli.dryRun),
+    indexNowEndpoint: cli.indexnowEndpoint ?? DEFAULT_INDEXNOW_ENDPOINT,
+  };
+}
+
+interface ChapterCheck {
+  path: string;
+  url: string;
+  sha256: string | null;
+}
+
+async function checkChapter(
+  api: FreeUseBibleAPI,
+  origin: string,
+  translationParam: string,
+  translation: Translation,
+  book: TranslationBook,
+  chapter: number,
+  uiLocale: string | null
+): Promise<ChapterCheck | null> {
+  const url = buildChapterUrl(origin, {
+    translationId: translationParam,
+    bookId: book.id,
+    chapter,
+    uiLocale,
+  });
+  const path = new URL(url).pathname;
+
+  let response;
+  try {
+    response = await api.getTranslationBookChapter(
+      translation.id,
+      book.id,
+      chapter
+    );
+  } catch (error) {
+    console.warn(
+      `  ! Skipping ${translation.id}/${book.id}/${chapter}: failed to fetch chapter — ${
+        error instanceof Error ? error.message : String(error)
+      }`
+    );
+    return null;
+  }
+
+  return { path, url, sha256: response.sha256 ?? null };
+}
+
+async function main(): Promise<void> {
+  program
+    .name("index-sitemap-urls")
+    .description(
+      "Submits new/changed chapter URLs to IndexNow so search engines pick them up faster."
+    )
+    .option(
+      "--base-url <origin>",
+      `Site origin. Defaults to ${DEFAULT_ORIGIN} (or SITE_ORIGIN).`
+    )
+    .option(
+      "--endpoint <url>",
+      "Bible API endpoint. Defaults to the production default (or BIBLE_API_ENDPOINT)."
+    )
+    .option(
+      "--key <key>",
+      "IndexNow key. Defaults to the INDEXNOW_KEY environment variable."
+    )
+    .option(
+      "--log <file>",
+      `Path to the local submission log. Defaults to ${DEFAULT_LOG_FILE}.`
+    )
+    .option(
+      "--all-translations",
+      "Walk every translation instead of only ones mapped to a supported UI locale."
+    )
+    .option(
+      "--concurrency <n>",
+      `Max chapter fetches in flight at once. Defaults to ${DEFAULT_CONCURRENCY}.`
+    )
+    .option(
+      "--dry-run",
+      "Compute what would be submitted without submitting or touching the log."
+    )
+    .option(
+      "--indexnow-endpoint <url>",
+      `IndexNow submission endpoint. Defaults to ${DEFAULT_INDEXNOW_ENDPOINT}.`
+    )
+    .parse();
+
+  const options = resolveOptions(program.opts());
+
+  console.log(`Origin:            ${options.origin}`);
+  console.log(`Endpoint:          ${options.endpoint}`);
+  console.log(`Log file:          ${options.logFile}`);
+  console.log(`All translations:  ${options.allTranslations}`);
+  console.log(`Dry run:           ${options.dryRun}`);
+  console.log("");
+
+  const defaultEndpoint = getDefaultAPIEndpoint(new URL(options.origin));
+  const api = new FreeUseBibleAPI(options.endpoint);
+  const log = await readSubmissionLog(options.logFile);
+
+  const { translations } = await api.getAvailableTranslations();
+  console.log(`Fetched ${translations.length} translations.`);
+
+  const targetTranslations = options.allTranslations
+    ? translations
+    : translations.filter((t) => bibleLanguageToUiLocale(t.language));
+  console.log(
+    `Walking ${targetTranslations.length} translation(s)${
+      options.allTranslations ? "" : " (mapped to a supported UI locale)"
+    }.`
+  );
+
+  let checked = 0;
+  let skippedUnchanged = 0;
+  const pending: ChapterCheck[] = [];
+
+  for (const translation of targetTranslations) {
+    const uiLocale = bibleLanguageToUiLocale(translation.language);
+
+    let books: TranslationBook[];
+    try {
+      const response = await api.getTranslationBooks(translation.id);
+      books = response.books;
+    } catch (error) {
+      console.warn(
+        `  ! Skipping translation ${translation.id}: failed to load books — ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      continue;
+    }
+
+    const translationParam = buildTranslationParam(
+      translation.id,
+      options.endpoint,
+      defaultEndpoint
+    );
+
+    const chapterRefs: { book: TranslationBook; chapter: number }[] = [];
+    for (const book of books) {
+      if (book.numberOfChapters <= 0) {
+        continue;
+      }
+      for (let i = 0; i < book.numberOfChapters; i++) {
+        chapterRefs.push({ book, chapter: book.firstChapterNumber + i });
+      }
+    }
+
+    const results = await mapWithConcurrency(
+      chapterRefs,
+      options.concurrency,
+      ({ book, chapter }) =>
+        checkChapter(
+          api,
+          options.origin,
+          translationParam,
+          translation,
+          book,
+          chapter,
+          uiLocale
+        )
+    );
+
+    for (const result of results) {
+      if (!result) {
+        continue;
+      }
+      checked++;
+
+      if (result.sha256 === null) {
+        console.warn(
+          `  ! ${result.path} has no sha256 in the API response; submitting anyway.`
+        );
+        pending.push(result);
+        continue;
+      }
+
+      const previous = log[result.path];
+      if (previous && previous.submittedSha256 === result.sha256) {
+        skippedUnchanged++;
+        continue;
+      }
+
+      pending.push(result);
+    }
+  }
+
+  console.log("");
+  console.log(`Checked ${checked} chapter(s).`);
+  console.log(`  ${skippedUnchanged} unchanged (skipped).`);
+  console.log(`  ${pending.length} new/changed.`);
+
+  if (pending.length === 0) {
+    console.log("Nothing to submit.");
+    return;
+  }
+
+  if (options.dryRun) {
+    console.log("");
+    console.log("Dry run — would submit:");
+    for (const entry of pending.slice(0, 20)) {
+      console.log(`  ${entry.url}`);
+    }
+    if (pending.length > 20) {
+      console.log(`  ... and ${pending.length - 20} more.`);
+    }
+    return;
+  }
+
+  const host = new URL(options.origin).host;
+  const keyLocation = new URL(
+    `${options.key}.txt`,
+    ensureTrailingSlash(options.origin)
+  ).toString();
+
+  const batches = chunk(pending, INDEXNOW_MAX_URLS_PER_REQUEST);
+  let submitted = 0;
+  let failed = 0;
+
+  for (const batch of batches) {
+    const payload = buildIndexNowPayload({
+      host,
+      key: options.key,
+      keyLocation,
+      urlList: batch.map((entry) => entry.url),
+    });
+
+    try {
+      await submitIndexNowBatch(payload, options.indexNowEndpoint);
+    } catch (error) {
+      failed += batch.length;
+      console.error(
+        `Batch of ${batch.length} URL(s) failed: ${
+          error instanceof Error ? error.message : String(error)
+        }`
+      );
+      continue;
+    }
+
+    const submittedAt = new Date().toISOString();
+    for (const entry of batch) {
+      if (entry.sha256 !== null) {
+        log[entry.path] = {
+          path: entry.path,
+          submittedSha256: entry.sha256,
+          submittedAt,
+        };
+      }
+    }
+    await writeSubmissionLog(options.logFile, log);
+    submitted += batch.length;
+    console.log(`  Submitted batch of ${batch.length} URL(s).`);
+  }
+
+  console.log("");
+  console.log(`Submitted ${submitted} URL(s).`);
+  if (failed > 0) {
+    console.log(`${failed} URL(s) failed to submit.`);
+    process.exitCode = 1;
+  }
+}
+
+main().catch((error) => {
+  console.error("IndexNow submission failed:", error);
+  process.exitCode = 1;
+});

--- a/script/lib/concurrency.ts
+++ b/script/lib/concurrency.ts
@@ -1,0 +1,25 @@
+/** Runs `worker` over `items` with at most `limit` in flight at once. */
+export async function mapWithConcurrency<T, R>(
+  items: readonly T[],
+  limit: number,
+  worker: (item: T, index: number) => Promise<R>
+): Promise<R[]> {
+  const results = new Array<R>(items.length);
+  let cursor = 0;
+
+  async function run(): Promise<void> {
+    while (true) {
+      const index = cursor++;
+      if (index >= items.length) {
+        return;
+      }
+      results[index] = await worker(items[index]!, index);
+    }
+  }
+
+  const workers = Array.from({ length: Math.min(limit, items.length) }, () =>
+    run()
+  );
+  await Promise.all(workers);
+  return results;
+}

--- a/script/lib/indexNow.ts
+++ b/script/lib/indexNow.ts
@@ -1,0 +1,126 @@
+/**
+ * Pure/IO helpers for `script/index-sitemap-urls.ts`, split out so the tricky
+ * bits — the submission log's read-or-default shape and response-code
+ * handling — can be unit-tested without a network or a real submission log
+ * file on disk.
+ */
+import { readFile, writeFile } from "node:fs/promises";
+
+/** The default, shared IndexNow endpoint. Propagates to every participating engine. */
+export const DEFAULT_INDEXNOW_ENDPOINT = "https://api.indexnow.org/indexnow";
+
+/**
+ * The largest number of URLs IndexNow accepts in a single bulk submission
+ * request, per the protocol.
+ */
+export const INDEXNOW_MAX_URLS_PER_REQUEST = 10000;
+
+export interface IndexNowSubmissionEntry {
+  /** The chapter's canonical path, e.g. "/en/AAB/genesis/1". */
+  path: string;
+  /** The chapter content's sha256 at the time it was submitted. */
+  submittedSha256: string;
+  /** ISO timestamp of the successful submission. */
+  submittedAt: string;
+}
+
+/**
+ * State of every chapter path submitted so far, keyed by `path`. A map
+ * rather than an ever-growing array — re-running the script only needs each
+ * path's most recent submission to decide whether it changed, not a full
+ * history.
+ */
+export type IndexNowSubmissionLog = Record<string, IndexNowSubmissionEntry>;
+
+/**
+ * Reads a submission log from disk. Returns an empty log if the file doesn't
+ * exist yet — the first run of the script always has nothing to compare
+ * against.
+ */
+export async function readSubmissionLog(
+  filePath: string
+): Promise<IndexNowSubmissionLog> {
+  try {
+    const text = await readFile(filePath, "utf-8");
+    return JSON.parse(text) as IndexNowSubmissionLog;
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return {};
+    }
+    throw error;
+  }
+}
+
+export async function writeSubmissionLog(
+  filePath: string,
+  log: IndexNowSubmissionLog
+): Promise<void> {
+  await writeFile(filePath, JSON.stringify(log, null, 2), "utf-8");
+}
+
+export interface IndexNowPayload {
+  host: string;
+  key: string;
+  keyLocation: string;
+  urlList: string[];
+}
+
+/** Shapes the JSON body for an IndexNow bulk submission request. */
+export function buildIndexNowPayload(params: {
+  host: string;
+  key: string;
+  keyLocation: string;
+  urlList: readonly string[];
+}): IndexNowPayload {
+  return {
+    host: params.host,
+    key: params.key,
+    keyLocation: params.keyLocation,
+    urlList: [...params.urlList],
+  };
+}
+
+/** How many times a 429 (rate limited) response is retried before giving up. */
+const MAX_RATE_LIMIT_RETRIES = 3;
+const RATE_LIMIT_BACKOFF_MS = 2000;
+
+function delay(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Submits one batch of URLs to IndexNow. Treats HTTP 200/202 as success.
+ * Retries a 429 (rate limited) a few times with a fixed backoff; any other
+ * non-2xx status throws with a message describing what went wrong (403 in
+ * particular usually means the key file isn't reachable/valid yet).
+ */
+export async function submitIndexNowBatch(
+  payload: IndexNowPayload,
+  endpoint: string = DEFAULT_INDEXNOW_ENDPOINT
+): Promise<void> {
+  for (let attempt = 0; ; attempt++) {
+    const response = await fetch(endpoint, {
+      method: "POST",
+      headers: { "Content-Type": "application/json; charset=utf-8" },
+      body: JSON.stringify(payload),
+    });
+
+    if (response.status === 200 || response.status === 202) {
+      return;
+    }
+
+    if (response.status === 429 && attempt < MAX_RATE_LIMIT_RETRIES) {
+      await delay(RATE_LIMIT_BACKOFF_MS * (attempt + 1));
+      continue;
+    }
+
+    const body = await response.text().catch(() => "");
+    const hint =
+      response.status === 403
+        ? ` Check that the key file is reachable at ${payload.keyLocation} and contains exactly the key "${payload.key}".`
+        : "";
+    throw new Error(
+      `IndexNow submission failed (${response.status} ${response.statusText}) for ${payload.urlList.length} URL(s).${hint}${body ? ` Response: ${body}` : ""}`
+    );
+  }
+}

--- a/test/unit/script/lib/indexNow.test.ts
+++ b/test/unit/script/lib/indexNow.test.ts
@@ -1,0 +1,185 @@
+import { mkdtemp, rm } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import type { Mock } from "vitest";
+import {
+  DEFAULT_INDEXNOW_ENDPOINT,
+  INDEXNOW_MAX_URLS_PER_REQUEST,
+  buildIndexNowPayload,
+  readSubmissionLog,
+  submitIndexNowBatch,
+  writeSubmissionLog,
+  type IndexNowSubmissionLog,
+} from "../../../../script/lib/indexNow";
+
+describe("readSubmissionLog / writeSubmissionLog", () => {
+  let dir: string;
+
+  beforeEach(async () => {
+    dir = await mkdtemp(path.join(tmpdir(), "indexnow-log-"));
+  });
+
+  afterEach(async () => {
+    await rm(dir, { recursive: true, force: true });
+  });
+
+  it("returns an empty log when the file doesn't exist yet", async () => {
+    const log = await readSubmissionLog(path.join(dir, "missing.json"));
+    expect(log).toEqual({});
+  });
+
+  it("round-trips a log written to disk", async () => {
+    const filePath = path.join(dir, "log.json");
+    const log: IndexNowSubmissionLog = {
+      "/en/AAB/genesis/1": {
+        path: "/en/AAB/genesis/1",
+        submittedSha256: "abc123",
+        submittedAt: "2026-01-01T00:00:00.000Z",
+      },
+    };
+
+    await writeSubmissionLog(filePath, log);
+    const reloaded = await readSubmissionLog(filePath);
+
+    expect(reloaded).toEqual(log);
+  });
+
+  it("propagates errors other than a missing file", async () => {
+    // A directory can't be read as a file; readFile rejects with EISDIR.
+    await expect(readSubmissionLog(dir)).rejects.toThrow();
+  });
+});
+
+describe("buildIndexNowPayload", () => {
+  it("shapes the JSON body from the given parameters", () => {
+    const payload = buildIndexNowPayload({
+      host: "seedbible.org",
+      key: "the-key",
+      keyLocation: "https://seedbible.org/the-key.txt",
+      urlList: ["https://seedbible.org/en/AAB/genesis/1"],
+    });
+
+    expect(payload).toEqual({
+      host: "seedbible.org",
+      key: "the-key",
+      keyLocation: "https://seedbible.org/the-key.txt",
+      urlList: ["https://seedbible.org/en/AAB/genesis/1"],
+    });
+  });
+
+  it("copies the url list rather than aliasing the input array", () => {
+    const urlList = ["https://seedbible.org/en/AAB/genesis/1"];
+    const payload = buildIndexNowPayload({
+      host: "seedbible.org",
+      key: "the-key",
+      keyLocation: "https://seedbible.org/the-key.txt",
+      urlList,
+    });
+
+    urlList.push("https://seedbible.org/en/AAB/genesis/2");
+    expect(payload.urlList).toHaveLength(1);
+  });
+});
+
+describe("submitIndexNowBatch", () => {
+  let fetchMock: Mock;
+  let originalFetch: typeof globalThis.fetch;
+
+  beforeAll(() => {
+    originalFetch = globalThis.fetch;
+  });
+
+  beforeEach(() => {
+    fetchMock = vi.fn();
+    globalThis.fetch = fetchMock;
+  });
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  const payload = buildIndexNowPayload({
+    host: "seedbible.org",
+    key: "the-key",
+    keyLocation: "https://seedbible.org/the-key.txt",
+    urlList: ["https://seedbible.org/en/AAB/genesis/1"],
+  });
+
+  function response(status: number, statusText = "") {
+    return {
+      status,
+      statusText,
+      text: () => Promise.resolve(""),
+    };
+  }
+
+  it("resolves on 200", async () => {
+    fetchMock.mockResolvedValue(response(200, "OK"));
+    await expect(submitIndexNowBatch(payload)).resolves.toBeUndefined();
+    expect(fetchMock).toHaveBeenCalledWith(
+      DEFAULT_INDEXNOW_ENDPOINT,
+      expect.objectContaining({
+        method: "POST",
+        headers: { "Content-Type": "application/json; charset=utf-8" },
+        body: JSON.stringify(payload),
+      })
+    );
+  });
+
+  it("resolves on 202", async () => {
+    fetchMock.mockResolvedValue(response(202, "Accepted"));
+    await expect(submitIndexNowBatch(payload)).resolves.toBeUndefined();
+  });
+
+  it("throws a descriptive error on 403, mentioning the key location", async () => {
+    fetchMock.mockResolvedValue(response(403, "Forbidden"));
+    await expect(submitIndexNowBatch(payload)).rejects.toThrow(
+      /403.*keyLocation|403[\s\S]*the-key\.txt/i
+    );
+  });
+
+  it("throws on 400", async () => {
+    fetchMock.mockResolvedValue(response(400, "Bad Request"));
+    await expect(submitIndexNowBatch(payload)).rejects.toThrow(/400/);
+  });
+
+  it("retries a 429 and eventually succeeds", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchMock
+        .mockResolvedValueOnce(response(429, "Too Many Requests"))
+        .mockResolvedValueOnce(response(200, "OK"));
+
+      const result = submitIndexNowBatch(payload);
+      await vi.runAllTimersAsync();
+
+      await expect(result).resolves.toBeUndefined();
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("gives up after repeated 429s", async () => {
+    vi.useFakeTimers();
+    try {
+      fetchMock.mockResolvedValue(response(429, "Too Many Requests"));
+
+      const result = submitIndexNowBatch(payload);
+      // Attached before the timers advance so Node never sees this rejection
+      // as unhandled, even momentarily, once the final retry rejects below.
+      result.catch(() => {});
+      await vi.runAllTimersAsync();
+
+      await expect(result).rejects.toThrow(/429/);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+});
+
+describe("INDEXNOW_MAX_URLS_PER_REQUEST", () => {
+  it("matches the protocol's bulk submission limit", () => {
+    expect(INDEXNOW_MAX_URLS_PER_REQUEST).toBe(10000);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a new script that submits chapter URLs to IndexNow, allowing participating search engines (Bing, Yandex, Naver, Seznam.cz, Yep) to discover new or updated Bible chapters without waiting for their own crawl schedules. The script tracks which chapters have been submitted via a local log, so re-running it only submits chapters that are new or whose content has changed.

## Key Changes

- **New script `script/index-sitemap-urls.ts`**: Walks all translations and their chapters, compares each chapter's SHA-256 hash against a local submission log, and batches new/changed URLs to IndexNow. Supports dry-run mode, configurable concurrency, and environment-based configuration (origin, API endpoint, IndexNow key).

- **New helper module `script/lib/indexNow.ts`**: Handles submission log I/O (read-or-default, write), IndexNow payload construction, and batch submission with retry logic for rate limiting (429 responses). Includes detailed error messages for common failures (e.g., 403 suggests the key file isn't reachable).

- **New test suite `test/unit/script/lib/indexNow.test.ts`**: Unit tests for log round-tripping, payload building, and response code handling (200/202 success, 429 retry with backoff, 403 with helpful hint, other errors).

- **Extracted `script/lib/concurrency.ts`**: Moved the `mapWithConcurrency` helper from `generate-sitemap.ts` into a shared module so both the sitemap and IndexNow scripts can use it for parallel chapter fetches.

- **Updated `script/generate-sitemap.ts`**: Now imports `mapWithConcurrency` from the new shared module. Also writes the IndexNow key-verification file (`<key>.txt`) to the output directory when `INDEXNOW_KEY` is set at build time, so the key file ships alongside robots.txt and sitemap.xml.

- **Updated `FreeUseBibleAPI.tsx`**: Added `sha256?: string` field to `TranslationBookChapter` interface so the script can detect when chapter content changes.

- **Updated CI/CD**: Added `INDEXNOW_KEY` secret to the GitHub Actions workflow so the key file is generated during the build.

- **Updated `.gitignore`**: Ignores the local submission log (`script/.indexnow-log.json`).

- **Updated `package.json`**: Added `index-sitemap-urls` npm script.

## Implementation Details

- The script compares each chapter's SHA-256 hash (from the API response) against the submission log. Only chapters with a new hash or no prior entry are submitted.
- Submissions are batched (up to 10,000 URLs per request, per the IndexNow protocol) and sent to the default IndexNow endpoint.
- Rate limiting (429) is retried up to 3 times with exponential backoff (2s, 4s, 6s).
- The submission log is updated only after a batch succeeds, so failed submissions don't corrupt the log.
- The script supports `--all-translations` to walk every translation (not just ones mapped to a supported UI locale) and `--dry-run` to preview what would be submitted without actually submitting or updating the log.

https://claude.ai/code/session_01Wg6c197U6bF8kzD3zrL4E5