### PR TITLE
Remove conditional close button styling for account settings

### DIFF
--- a/packages/seed-bible/seed-bible/components/Tabs/Tabs.css
+++ b/packages/seed-bible/seed-bible/components/Tabs/Tabs.css
@@ -1319,12 +1319,6 @@
     display: inline-flex;
   }
 
-  /* On mobile the account panel is dismissed via the bottom bar of options
-   * (e.g. the "Bible" tab), so the redundant X close button is hidden. */
-  .sb-sidebar-settings-close-button-account {
-    display: none;
-  }
-
   /* The desktop bottom-actions row (settings cog + self avatar) is hidden
    * on mobile — the bottom is now the Bible/Tabs switcher. */
   .sb-tabs-sidebar-mobile-open .sb-sidebar-bottom-actions {
@@ -1350,6 +1344,20 @@
     color: var(--sb-book-title-font-color);
     white-space: nowrap;
     text-overflow: ellipsis;
+  }
+
+  /* The settings sidebar (main list, and every settings subpage, including
+   * Account) shares .sb-sidebar-tabs-title with the tab-list header above,
+   * but its "Settings" heading isn't a book title — restore the plain
+   * heading style so it renders the same as on desktop. */
+  .sb-tabs-sidebar-mobile-open
+    .sb-sidebar-settings-view
+    .sb-sidebar-tabs-title {
+    flex: initial;
+    font-size: 1.125rem;
+    font-weight: 700;
+    font-family: inherit;
+    color: var(--sb-font-color);
   }
 
   /* Tab list takes the body of the sidebar; leave room at the bottom for

--- a/packages/seed-bible/seed-bible/components/Tabs/Tabs.tsx
+++ b/packages/seed-bible/seed-bible/components/Tabs/Tabs.tsx
@@ -927,7 +927,6 @@ export function Settings(props: SettingsProps) {
   const { state } = props;
   const { sidebar } = state;
   const { t } = useI18n();
-  const isAccountView = sidebar.requestedSettingsView.value === "account";
 
   return (
     <div className="sb-sidebar-settings-view">
@@ -935,9 +934,7 @@ export function Settings(props: SettingsProps) {
         <h3 className="sb-sidebar-tabs-title">{t("settings")}</h3>
         <button
           onClick={sidebar.closeSettings}
-          className={`sb-sidebar-settings-close-button${
-            isAccountView ? " sb-sidebar-settings-close-button-account" : ""
-          }`}
+          className="sb-sidebar-settings-close-button"
           aria-label={t("close-settings", { defaultValue: "Close Settings" })}
           title={t("close-settings", { defaultValue: "Close Settings" })}
         >


### PR DESCRIPTION
## Summary

Simplifies the settings sidebar close button by removing mobile-specific styling that hid the button on the account view. Instead, the settings heading now uses consistent styling across all settings pages (main list and subpages like Account), matching the desktop appearance.

## Changes

- **Removed conditional close button class** — The `sb-sidebar-settings-close-button-account` class and its associated `display: none` rule are no longer needed. The close button now appears consistently on all settings views, including the account page.

- **Added unified settings heading style** — New CSS rule restores plain heading styling for `.sb-sidebar-settings-view .sb-sidebar-tabs-title` on mobile, so the "Settings" heading renders the same way on mobile as it does on desktop (no longer styled as a book title).

- **Simplified component logic** — Removed the `isAccountView` check in the Settings component that conditionally applied the account-specific class. The close button now uses a single, unconditional class name.

## Implementation Details

The settings sidebar reuses the `.sb-sidebar-tabs-title` class (which normally styles book titles in the tab list), but the "Settings" heading isn't a book title. The new CSS rule explicitly overrides the inherited book-title styling (`flex`, `font-size`, `font-weight`, `font-family`, `color`) to restore the plain heading appearance, ensuring visual consistency across mobile and desktop.

https://claude.ai/code/session_012pmEzfb7EEhyZZRwkQm4JJ