### PR TITLE
Give Dark theme similar orange accents to the light theme

### DIFF
--- a/packages/seed-bible/seed-bible/managers/ThemeManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/ThemeManager.tsx
@@ -653,10 +653,10 @@ const DARK_THEME: BibleTheme = {
   id: "dark",
   name: "Dark",
   variables: {
-    primaryColor: "#e6e6e6",
+    primaryColor: "#e07b4c",
     primaryFontColor: "#111111",
 
-    secondaryColor: "#262626",
+    secondaryColor: "#433228",
     secondaryFontColor: "#f5f5f5",
 
     tertiaryColor: "#1c1c1c",


### PR DESCRIPTION
This PR changes the primary and secondary colors of the Dark theme to match the style of the Light theme.

<img width="1054" height="940" alt="image" src="https://github.com/user-attachments/assets/4de2d483-e1b7-401a-b34c-aa3668b64689" />

<img width="328" height="943" alt="image" src="https://github.com/user-attachments/assets/28c94fc0-4333-4bb6-a716-28cf58c15f78" />
<img width="318" height="938" alt="image" src="https://github.com/user-attachments/assets/cc8bfce2-6cf6-43d1-86c0-56cba724313b" />

<img width="1054" height="943" alt="image" src="https://github.com/user-attachments/assets/6e034c0f-fa2c-4f04-b81e-bac9c58762ca" />
<img width="1048" height="940" alt="image" src="https://github.com/user-attachments/assets/ff887246-3bd8-4031-8d6d-8a74e70b8998" />


