### PR TITLE
Improve how branding configs are handled

### DIFF
--- a/packages/seed-bible/seed-bible/app/appConfig.tsx
+++ b/packages/seed-bible/seed-bible/app/appConfig.tsx
@@ -19,6 +19,10 @@ export interface BrandingConfig {
   disabledToolbarTools?: string[];
   defaultTranslationId?: string;
 }
+
+// Injected from Vite
+declare const __BRANDING_CONFIG__: BrandingConfig | undefined;
+
 export interface AppConfig {
   /**
    * Path prefix this deployment is mounted under, e.g. "/d/branch-develop".
@@ -54,6 +58,7 @@ export const DEFAULT_APP_CONFIG: AppConfig = {
   renderedAsMobile: false,
   renderedAsWebKit: false,
   acceptedLanguages: [],
+  branding: import.meta.env.VITEST ? undefined : __BRANDING_CONFIG__,
 };
 
 /**

--- a/standalone/entry-ssr.tsx
+++ b/standalone/entry-ssr.tsx
@@ -19,6 +19,7 @@ import {
   stripBasePath,
 } from "@packages/seed-bible/seed-bible/managers/ReadingUrlPath";
 import { getPreferredSupportedLanguage } from "@packages/seed-bible/seed-bible/i18n/I18nManager";
+import { DEFAULT_APP_CONFIG } from "@packages/seed-bible/dist/app/appConfig";
 
 /** A single chunk record from a Vite client manifest. */
 interface ManifestChunk {
@@ -364,17 +365,20 @@ export async function render(
   | { redirectTo: string; redirectStatus?: number; vary?: string }
   | string
 > {
-  const { config } = options;
+  const { config: injectedConfig } = options;
 
-  const redirectTo = legacyReadingUrlRedirect(options.path, config.basePath);
+  const redirectTo = legacyReadingUrlRedirect(
+    options.path,
+    injectedConfig.basePath
+  );
   if (redirectTo) {
     return { redirectTo };
   }
 
   const languageRedirectTo = acceptLanguageRedirect(
     options.path,
-    config.basePath,
-    config.acceptedLanguages
+    injectedConfig.basePath,
+    injectedConfig.acceptedLanguages
   );
   if (languageRedirectTo) {
     return {
@@ -383,6 +387,13 @@ export async function render(
       vary: "Accept-Language",
     };
   }
+
+  // Combine the injected config with the defaults
+  // This allows the server to read the injected branding config and pass it to the app during SSR, while still providing defaults for any missing values.
+  const config = {
+    ...DEFAULT_APP_CONFIG,
+    ...injectedConfig,
+  };
 
   // A pure URL-level check (no network involved): a canonical-shaped path
   // whose book segment doesn't resolve even via a fuzzy match has nothing

--- a/standalone/entry-ssr.tsx
+++ b/standalone/entry-ssr.tsx
@@ -1,6 +1,7 @@
 import { renderToStringAsync } from "preact-render-to-string";
 import { Main } from "../packages/seed-bible/seed-bible/app/main";
 import type { AppConfig } from "../packages/seed-bible/seed-bible/app/appConfig";
+import { DEFAULT_APP_CONFIG } from "../packages/seed-bible/seed-bible/app/appConfig";
 import { createSeedBibleState } from "@packages/seed-bible/seed-bible/managers/SeedBibleStateManager";
 import {
   findClosestBookId,
@@ -19,7 +20,6 @@ import {
   stripBasePath,
 } from "@packages/seed-bible/seed-bible/managers/ReadingUrlPath";
 import { getPreferredSupportedLanguage } from "@packages/seed-bible/seed-bible/i18n/I18nManager";
-import { DEFAULT_APP_CONFIG } from "../packages/seed-bible/dist/app/appConfig";
 
 /** A single chunk record from a Vite client manifest. */
 interface ManifestChunk {

--- a/standalone/entry-ssr.tsx
+++ b/standalone/entry-ssr.tsx
@@ -19,7 +19,7 @@ import {
   stripBasePath,
 } from "@packages/seed-bible/seed-bible/managers/ReadingUrlPath";
 import { getPreferredSupportedLanguage } from "@packages/seed-bible/seed-bible/i18n/I18nManager";
-import { DEFAULT_APP_CONFIG } from "@packages/seed-bible/dist/app/appConfig";
+import { DEFAULT_APP_CONFIG } from "../packages/seed-bible/dist/app/appConfig";
 
 /** A single chunk record from a Vite client manifest. */
 interface ManifestChunk {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -51,6 +51,10 @@ const brandingConfig = existsSync(
     )
   : undefined;
 
+if (brandingConfig) {
+  console.log("[vite.config.ts] Using branding config:", brandingConfig);
+}
+
 function withTrailingSlash(url: string): string {
   return url.endsWith("/") ? url : `${url}/`;
 }

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -3,7 +3,7 @@ import { defineConfig } from "vite";
 import preact from "@preact/preset-vite";
 import path from "path";
 import { execSync } from "child_process";
-import { readFileSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { analyzer } from "vite-bundle-analyzer";
 import { VitePWA } from "vite-plugin-pwa";
 import { patternPlugin } from "./script/lib/vite-plugin-patterns";
@@ -42,6 +42,14 @@ const assetBaseUrl =
 // deploy branch is set), and pin its files/scope to the site root regardless of
 // where the versioned chunks live.
 const isRootBuild = !deployBranch || deployBranch === "main";
+
+const brandingConfig = existsSync(
+  path.resolve(__dirname, "seed-bible.branding.json")
+)
+  ? JSON.parse(
+      readFileSync(path.resolve(__dirname, "seed-bible.branding.json"), "utf-8")
+    )
+  : undefined;
 
 function withTrailingSlash(url: string): string {
   return url.endsWith("/") ? url : `${url}/`;
@@ -123,6 +131,8 @@ export default defineConfig(({ isSsrBuild }) => ({
     // assets apart from another branch deployment's. vite-plugin-pwa reuses
     // this `define` block when it compiles the worker.
     __ASSET_BASE_URL__: JSON.stringify(assetBaseUrl),
+
+    __BRANDING_CONFIG__: JSON.stringify(brandingConfig),
   },
 
   plugins: [


### PR DESCRIPTION
Previously, the branding config was just directly injected into the Seed Bible code whenever it was needed.

Now, you can specify a `seed-bible.branding.json` file at the root of the repo that includes the branding config that should be used.

Here's an example:

```
{
  "appName": "My Seed Bible",
  "shortName": "Bible",
  "logo": "https://example.com/my-logo.png",
  "icon": "https://example.com/my-icon.png",
  "websiteUrl": "https://example.com",
  "disabledToolbarTools": ["open-discover"],
  "defaultTranslationId": "eng_kjv"
}
```