### PR TITLE
Style clear button with error color and consistent hover state

### DIFF
--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.inline.css
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.inline.css
@@ -1348,13 +1348,21 @@
 }
 
 .sb-verse-toolbar-mobile .sb-verse-toolbar-clear {
-  background: color-mix(in srgb, var(--sb-font-color), transparent 88%);
-  color: var(--sb-font-color);
+  background: color-mix(
+    in srgb,
+    var(--sb-error-color, #d64545),
+    transparent 85%
+  );
+  color: var(--sb-error-color, #d64545);
 }
 
 .sb-verse-toolbar-mobile .sb-verse-toolbar-clear:hover:not(:disabled) {
-  filter: none;
-  background: color-mix(in srgb, var(--sb-font-color), transparent 80%);
+  filter: brightness(0.95);
+  background: color-mix(
+    in srgb,
+    var(--sb-error-color, #d64545),
+    transparent 78%
+  );
 }
 
 .sb-verse-toolbar-mobile

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
@@ -2451,9 +2451,7 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                   })}
                   title={t("clear", { defaultValue: "Clear" })}
                 >
-                  <span className="material-symbols-outlined">
-                    {isSmallScreen.value ? "close" : "ink_eraser"}
-                  </span>
+                  <span className="material-symbols-outlined">ink_eraser</span>
                   <span className="sb-verse-toolbar-action-text">
                     {t("clear", { defaultValue: "Clear" })}
                   </span>


### PR DESCRIPTION
## Summary
Updated the "Clear" button in the mobile verse toolbar to use the error color scheme instead of the font color, and made the hover state consistent across screen sizes by removing the conditional icon swap.

## Changes
- **Color scheme**: Changed the clear button background and text from `var(--sb-font-color)` to `var(--sb-error-color, #d64545)` with appropriate fallback values. This makes the destructive action visually distinct.
- **Hover state**: Replaced `filter: none` with `filter: brightness(0.95)` on hover to provide a subtle visual feedback that works consistently regardless of the underlying color.
- **Icon consistency**: Removed the conditional logic that showed a "close" icon on small screens and "ink_eraser" on larger screens. Now always displays "ink_eraser" for a unified appearance.
- **Color mix adjustments**: Fine-tuned the transparency values in the `color-mix()` function (85% and 78%) to work better with the error color than the previous values (88% and 80%) did with the font color.

## Implementation Details
The error color with a light transparency creates a subtle red background that clearly signals a destructive action, while the brightness filter on hover provides feedback without needing to change the entire color scheme. This approach is more accessible and semantically clearer than using the generic font color for a destructive button.

https://claude.ai/code/session_01K2qKhUP1SCnEwXJN8v1EYP

Closes #1705 