### PR TITLE
Clear verse selection after applying or clearing highlights

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@
 
 ### 🔧 Changed
 
+- Applying or clearing a highlight now clears the verse selection and closes the verse toolbar automatically, instead of leaving the selection and toolbar open after every highlight action.
+
 ### 🐛 Fixed
 
 ### 🗑️ Removed

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
@@ -393,9 +393,13 @@ function removeSharedHighlightsFromSelection(
  *   covers it for as long as it lives (the reader draws a decoration highlight
  *   over a saved one) and it reappears when the broadcast expires.
  *
- * Either way, the verse selection is cleared once the highlight is applied —
+ * By default the verse selection is cleared once the highlight is applied —
  * the selection and its toolbar were otherwise left sitting open after every
- * highlight, forcing an extra dismiss (#1704).
+ * highlight, forcing an extra dismiss (#1704). `clearSelection` lets a caller
+ * opt out: the custom-color picker's live-drag commits pass `false` so the
+ * selection survives while the color dialog is still open, letting the user
+ * keep tweaking the shade instead of losing the selection after the first
+ * settled color.
  */
 function applyHighlightWithSession(
   rs: BibleReadingState,
@@ -405,26 +409,28 @@ function applyHighlightWithSession(
     customColor?: string;
     customFontColor?: string;
   },
-  isSignedIn: boolean
+  isSignedIn: boolean,
+  clearSelection = true
 ): void {
   if (!session || !session.userCanDecorate(session.localSessionId.value)) {
     // A participant who can't broadcast used to match neither branch here, so
     // highlighting silently did nothing for them. Saving is the only thing this
     // can mean, so a signed-out user is asked to sign in before it applies.
     void rs.highlightSelectedVerses(details);
+  } else {
+    const duration = session.options.value.highlightDurationSeconds;
+    const isTransient = duration !== null && duration > 0;
+
+    if (!isTransient && isSignedIn) {
+      void rs.highlightSelectedVerses(details);
+    }
+
+    broadcastDecorationToSession(session, rs, details);
+  }
+
+  if (clearSelection) {
     rs.clearSelectedVerses();
-    return;
   }
-
-  const duration = session.options.value.highlightDurationSeconds;
-  const isTransient = duration !== null && duration > 0;
-
-  if (!isTransient && isSignedIn) {
-    void rs.highlightSelectedVerses(details);
-  }
-
-  broadcastDecorationToSession(session, rs, details);
-  rs.clearSelectedVerses();
 }
 
 /**
@@ -1196,30 +1202,79 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
   );
   const selectionUI = useComputed(() => settings.settings.value.selectionUI);
 
-  // Debounce the commit so rapid `change` events from the native color
-  // picker (fired as the user drags) don't add each intermediate color to
-  // the custom palette — only the final settled color is saved.
+  // The most recent color from a still-pending debounce, so a blur that
+  // lands before the debounce fires can apply it immediately instead of
+  // losing it. `null` once there's nothing pending.
+  const customColorPendingRef = useRef<string | null>(null);
+  // Whether any color from the current "Add custom color" session has been
+  // applied yet — distinguishes "the dialog closed after picking a color"
+  // (clear the selection) from "the dialog closed without picking one"
+  // (leave the selection alone; nothing happened).
+  const customColorAppliedRef = useRef(false);
+
+  const applyCustomColor = (color: string, clearSelection: boolean) => {
+    settings.addCustomHighlightColor(color);
+    const rs = readingState.value;
+    if (rs) {
+      applyHighlightWithSession(
+        rs,
+        sessionState.value,
+        {
+          colorId: "yellow",
+          customColor: color,
+          customFontColor: getContrastTextColor(color),
+        },
+        !!login.userId.value,
+        clearSelection
+      );
+    }
+    customColorAppliedRef.current = true;
+  };
+
+  // Debounce the commit so rapid `input`/`change` events from the native
+  // color picker (fired as the user drags) don't add each intermediate color
+  // to the custom palette — only the settled color is saved. These debounced
+  // commits never clear the selection themselves: the color dialog may still
+  // be open, and clearing here would silently drop any further tweaking
+  // within the same dialog session (#1725). The selection is cleared for real
+  // in `finishCustomColor`, once the input actually loses focus.
   const commitCustomColor = (color: string) => {
     if (customColorCommitTimeoutRef.current !== null) {
       window.clearTimeout(customColorCommitTimeoutRef.current);
     }
+    customColorPendingRef.current = color;
     customColorCommitTimeoutRef.current = window.setTimeout(() => {
-      settings.addCustomHighlightColor(color);
-      const rs = readingState.value;
-      if (rs) {
-        applyHighlightWithSession(
-          rs,
-          sessionState.value,
-          {
-            colorId: "yellow",
-            customColor: color,
-            customFontColor: getContrastTextColor(color),
-          },
-          !!login.userId.value
-        );
-      }
       customColorCommitTimeoutRef.current = null;
+      const pending = customColorPendingRef.current;
+      customColorPendingRef.current = null;
+      if (pending !== null) {
+        applyCustomColor(pending, false);
+      }
     }, 300);
+  };
+
+  // Runs when the color input loses focus, i.e. the OS color dialog closed —
+  // the reliable "the user is done" signal, since the native `change` event
+  // this input would otherwise fire is what `onChange` gets rewritten to
+  // listen for as `input` (see the `onChange`/`onInput` props below), so it
+  // can't be used to distinguish "still dragging" from "done" on its own.
+  // Flushes a still-debounced pick immediately rather than waiting the
+  // remaining 300ms, and only clears the selection if a color was actually
+  // applied this dialog session (closing without picking one leaves the
+  // selection untouched, same as before).
+  const finishCustomColor = () => {
+    if (customColorCommitTimeoutRef.current !== null) {
+      window.clearTimeout(customColorCommitTimeoutRef.current);
+      customColorCommitTimeoutRef.current = null;
+    }
+    const pending = customColorPendingRef.current;
+    customColorPendingRef.current = null;
+    if (pending !== null) {
+      applyCustomColor(pending, true);
+    } else if (customColorAppliedRef.current) {
+      readingState.value?.clearSelectedVerses();
+    }
+    customColorAppliedRef.current = false;
   };
 
   // Clear removes a saved highlight *and* the session's broadcast copy, so it
@@ -2424,6 +2479,7 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                     const target = event.currentTarget as HTMLInputElement;
                     commitCustomColor(target.value);
                   }}
+                  onBlur={finishCustomColor}
                 />
 
                 <button

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
@@ -392,6 +392,10 @@ function removeSharedHighlightsFromSelection(
  *   leave any existing personal highlight on those verses alone. The broadcast
  *   covers it for as long as it lives (the reader draws a decoration highlight
  *   over a saved one) and it reappears when the broadcast expires.
+ *
+ * Either way, the verse selection is cleared once the highlight is applied —
+ * the selection and its toolbar were otherwise left sitting open after every
+ * highlight, forcing an extra dismiss (#1704).
  */
 function applyHighlightWithSession(
   rs: BibleReadingState,
@@ -408,6 +412,7 @@ function applyHighlightWithSession(
     // highlighting silently did nothing for them. Saving is the only thing this
     // can mean, so a signed-out user is asked to sign in before it applies.
     void rs.highlightSelectedVerses(details);
+    rs.clearSelectedVerses();
     return;
   }
 
@@ -419,6 +424,7 @@ function applyHighlightWithSession(
   }
 
   broadcastDecorationToSession(session, rs, details);
+  rs.clearSelectedVerses();
 }
 
 /**
@@ -2445,6 +2451,9 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                     // while the user had no permission to broadcast — and
                     // "clear" has to mean the verse ends up unhighlighted.
                     void rs.unhighlightSelectedVerses();
+                    // Clearing a highlight should clear the selection too,
+                    // same as applying one (#1704).
+                    rs.clearSelectedVerses();
                   }}
                   aria-label={t("clear-highlight", {
                     defaultValue: "Clear highlight",

--- a/test/unit/seed-bible/components/BibleReaderToolbar.test.tsx
+++ b/test/unit/seed-bible/components/BibleReaderToolbar.test.tsx
@@ -733,6 +733,131 @@ describe("BibleReaderToolbar — clearing highlights", () => {
 
     expect(clearButton()?.disabled).toBe(true);
   });
+
+  /**
+   * Fires the native colour input's `input` event, as the OS colour dialog
+   * would while the user drags. (Preact rewrites this input's `onChange` to
+   * also listen for the native `input` event rather than `change` — see
+   * `preact/compat`'s `onChangeInputType` — so both of the component's
+   * `onChange`/`onInput` handlers respond to this, same as a real browser.)
+   */
+  function dragCustomColor(value: string) {
+    const input = container.querySelector<HTMLInputElement>(
+      ".sb-verse-toolbar-color-input"
+    );
+    if (!input) {
+      throw new Error("No element matched .sb-verse-toolbar-color-input");
+    }
+    input.value = value;
+    input.dispatchEvent(new Event("input", { bubbles: true }));
+  }
+
+  /**
+   * Blurs the colour input, as closing the native colour dialog would.
+   * (Preact rewrites `onBlur` to listen for the native `focusout` event.)
+   */
+  function closeCustomColorDialog() {
+    const input = container.querySelector<HTMLInputElement>(
+      ".sb-verse-toolbar-color-input"
+    );
+    if (!input) {
+      throw new Error("No element matched .sb-verse-toolbar-color-input");
+    }
+    input.dispatchEvent(new Event("focusout", { bubbles: true }));
+  }
+
+  it("applies a live-dragged custom color without clearing the selection, clearing only once the dialog closes", async () => {
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPicker();
+
+    // Fake timers only start now — `click()` (used by `openPicker()`) awaits
+    // a real `setTimeout`, which would never resolve once timers are faked.
+    vi.useFakeTimers();
+    try {
+      // The OS colour dialog fires `input` continuously while dragging.
+      await act(async () => {
+        dragCustomColor("#112233");
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      // The debounced live-drag commit applies the color, but the selection
+      // (and picker) stays open so the user can keep adjusting the shade —
+      // clearing here would silently drop any further tweaking (#1725).
+      expect(readingState.highlights.value.highlights).toHaveLength(1);
+      expect(readingState.highlights.value.highlights[0]?.customColor).toBe(
+        "#112233"
+      );
+      expect(readingState.selectedVerses.value).toHaveLength(1);
+      expect(
+        container.querySelector(".sb-verse-toolbar-color-input")
+      ).not.toBeNull();
+
+      // Still dragging — another live commit updates the color and still
+      // doesn't clear the selection.
+      await act(async () => {
+        dragCustomColor("#334455");
+        await vi.advanceTimersByTimeAsync(300);
+      });
+
+      expect(readingState.highlights.value.highlights).toHaveLength(1);
+      expect(readingState.highlights.value.highlights[0]?.customColor).toBe(
+        "#334455"
+      );
+      expect(readingState.selectedVerses.value).toHaveLength(1);
+
+      // The dialog closes: the color already settled 300ms ago, so this just
+      // clears the selection, same as any other highlight action.
+      await act(async () => {
+        closeCustomColorDialog();
+      });
+
+      expect(readingState.highlights.value.highlights).toHaveLength(1);
+      expect(readingState.highlights.value.highlights[0]?.customColor).toBe(
+        "#334455"
+      );
+      expect(readingState.selectedVerses.value).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("flushes a still-pending custom color immediately when the dialog closes before the debounce settles", async () => {
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPicker();
+
+    vi.useFakeTimers();
+    try {
+      // Pick a color and close the dialog right away, well inside the 300ms
+      // debounce window — the pending pick shouldn't be lost to the delay.
+      await act(async () => {
+        dragCustomColor("#112233");
+        closeCustomColorDialog();
+      });
+
+      expect(readingState.highlights.value.highlights).toHaveLength(1);
+      expect(readingState.highlights.value.highlights[0]?.customColor).toBe(
+        "#112233"
+      );
+      expect(readingState.selectedVerses.value).toHaveLength(0);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("leaves the selection untouched when the color dialog closes without picking a color", async () => {
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPicker();
+
+    await act(async () => {
+      closeCustomColorDialog();
+    });
+
+    expect(readingState.highlights.value.highlights).toHaveLength(0);
+    expect(readingState.selectedVerses.value).toHaveLength(1);
+  });
 });
 
 describe("BibleReaderToolbar mobile More menu", () => {

--- a/test/unit/seed-bible/components/BibleReaderToolbar.test.tsx
+++ b/test/unit/seed-bible/components/BibleReaderToolbar.test.tsx
@@ -459,11 +459,21 @@ describe("BibleReaderToolbar — clearing highlights", () => {
     });
   }
 
-  /** Clicks the first preset colour, opening the picker first if it is closed. */
-  async function openPickerAndHighlight() {
+  /**
+   * Opens the highlight colour picker if it is closed. The picker (and the
+   * "Clear" button, which lives inside it) auto-closes whenever the
+   * selection is cleared, so this has to run again after every highlight —
+   * highlighting always clears the selection (#1704).
+   */
+  async function openPicker() {
     if (!container.querySelector(".sb-verse-toolbar-color-button")) {
       await click(".sb-verse-toolbar-highlight-trigger");
     }
+  }
+
+  /** Clicks the first preset colour, opening the picker first if it is closed. */
+  async function openPickerAndHighlight() {
+    await openPicker();
     await click(".sb-verse-toolbar-color-button");
   }
 
@@ -487,9 +497,47 @@ describe("BibleReaderToolbar — clearing highlights", () => {
 
     expect(readingState.highlights.value.highlights).toHaveLength(1);
 
+    // Highlighting clears the selection (and with it, the verse toolbar) —
+    // reselect the verse and reopen the picker to bring the clear button
+    // back before clicking it.
+    await selectFirstVerse();
+    await openPicker();
     await click(".sb-verse-toolbar-clear");
 
     expect(readingState.highlights.value.highlights).toHaveLength(0);
+  });
+
+  it("clears the verse selection and closes the toolbar after applying a highlight", async () => {
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+
+    expect(readingState.selectedVerses.value).toHaveLength(1);
+    expect(container.querySelector(".sb-verse-toolbar")).not.toBeNull();
+
+    await openPickerAndHighlight();
+
+    expect(readingState.highlights.value.highlights).toHaveLength(1);
+    expect(readingState.selectedVerses.value).toHaveLength(0);
+    expect(container.querySelector(".sb-verse-toolbar")).toBeNull();
+  });
+
+  it("clears the verse selection and closes the toolbar after clearing a highlight", async () => {
+    const { readingState } = await selectFirstVerse();
+    await renderToolbar();
+    await openPickerAndHighlight();
+    expect(readingState.highlights.value.highlights).toHaveLength(1);
+
+    // Highlighting already cleared the selection — reselect it and reopen the
+    // picker to bring the clear button back.
+    await selectFirstVerse();
+    expect(container.querySelector(".sb-verse-toolbar")).not.toBeNull();
+    await openPicker();
+
+    await click(".sb-verse-toolbar-clear");
+
+    expect(readingState.highlights.value.highlights).toHaveLength(0);
+    expect(readingState.selectedVerses.value).toHaveLength(0);
+    expect(container.querySelector(".sb-verse-toolbar")).toBeNull();
   });
 
   it("broadcasts without saving when the session expires highlights", async () => {
@@ -528,6 +576,9 @@ describe("BibleReaderToolbar — clearing highlights", () => {
     await act(async () => {
       options.value = { ...options.value, highlightDurationSeconds: 16 };
     });
+    // Highlighting cleared the selection made above — reselect the verse to
+    // re-highlight it.
+    await selectFirstVerse();
     await openPickerAndHighlight();
 
     // The broadcast covers the saved highlight while it lives and uncovers it
@@ -558,6 +609,10 @@ describe("BibleReaderToolbar — clearing highlights", () => {
     await selectFirstVerse();
     await renderToolbar();
     await openPickerAndHighlight();
+    // Highlighting cleared the selection — reselect it and reopen the picker
+    // to bring the clear button back.
+    await selectFirstVerse();
+    await openPicker();
 
     // Nothing was ever saved, so clearing has no write to make — and asking for
     // an account to undo something that never persisted is pure interruption.
@@ -603,6 +658,10 @@ describe("BibleReaderToolbar — clearing highlights", () => {
 
     expect(broadcastHighlights()).toHaveLength(1);
 
+    // Highlighting cleared the selection — reselect it and reopen the picker
+    // to bring the clear button back.
+    await selectFirstVerse();
+    await openPicker();
     await click(".sb-verse-toolbar-clear");
 
     expect(removeSharedDecoration).toHaveBeenCalledWith(
@@ -622,6 +681,10 @@ describe("BibleReaderToolbar — clearing highlights", () => {
 
     attachFakeSession({ canDecorate: true });
     await renderToolbar();
+    // Highlighting cleared the selection — reselect it and reopen the picker
+    // to bring the clear button back.
+    await selectFirstVerse();
+    await openPicker();
     await click(".sb-verse-toolbar-clear");
 
     expect(readingState.highlights.value.highlights).toHaveLength(0);
@@ -632,6 +695,10 @@ describe("BibleReaderToolbar — clearing highlights", () => {
     const { readingState } = await selectFirstVerse();
     await renderToolbar();
     await openPickerAndHighlight();
+    // Highlighting cleared the selection — reselect it and reopen the picker
+    // so the clear button is showing again to check.
+    await selectFirstVerse();
+    await openPicker();
 
     expect(broadcastHighlights()).toHaveLength(0);
     expect(readingState.highlights.value.highlights).toHaveLength(1);
@@ -643,6 +710,10 @@ describe("BibleReaderToolbar — clearing highlights", () => {
     const { readingState, verseNumber } = await selectFirstVerse();
     await renderToolbar();
     await openPickerAndHighlight();
+    // Highlighting cleared the selection — reselect it and reopen the picker
+    // so the clear button is showing again to check.
+    await selectFirstVerse();
+    await openPicker();
 
     // Stand in for the session's highlight timer firing. Nothing was saved, so
     // the verse is genuinely unhighlighted again and there is nothing to clear.


### PR DESCRIPTION
## Summary

Applying or clearing a highlight now automatically clears the verse selection and closes the verse toolbar, instead of leaving them open after every highlight action.

## Changes

**Source code:**
- Modified `applyHighlightWithSession()` in `BibleReaderToolbar.tsx` to call `rs.clearSelectedVerses()` after applying a highlight (both for signed-out users and those with active sessions)
- Modified the "clear highlight" button handler to also call `rs.clearSelectedVerses()` after unhighlighting verses
- Updated the JSDoc comment on `applyHighlightWithSession()` to document this behavior

**Tests:**
- Refactored the test helper `openPickerAndHighlight()` to extract a new `openPicker()` helper, since the picker auto-closes whenever the selection is cleared
- Updated all existing tests in the "clearing highlights" suite to re-select the verse and re-open the picker after highlighting, since that action now clears the selection
- Added two new test cases:
  - "clears the verse selection and closes the toolbar after applying a highlight" — verifies the selection and toolbar are gone after highlighting
  - "clears the verse selection and closes the toolbar after clearing a highlight" — verifies the selection and toolbar are gone after clearing

**Changelog:**
- Added entry documenting the new behavior

## Implementation Details

The fix addresses issue #1704, where the verse toolbar would remain open after every highlight action, forcing users to manually dismiss it. Now both `applyHighlightWithSession()` paths (signed-out and signed-in) and the clear highlight handler call `clearSelectedVerses()` to close the toolbar automatically.

The picker (and the "Clear" button inside it) auto-closes when the selection is cleared, so tests now must re-select and re-open the picker before clicking "Clear" in subsequent assertions.

https://claude.ai/code/session_01TudS19YJkcvKE3cpvu1nj1