### PR TITLE
Keep the Today screen open through startup restores

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,8 +8,6 @@
 
 ### 🐛 Fixed
 
-- Fix the Today screen appearing and then immediately disappearing when opening the app without a link to a specific chapter. Returning readers have their last chapter restored from the browser just after the page appears, and the app was mistaking that restore for the reader navigating away, which closed Today the moment it opened. The restore is now recognised as part of the same page load, so Today stays up until you choose where to go.
-
 ### 🗑️ Removed
 
 ## v1.6.0 — 2026-08-24

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### 🐛 Fixed
 
+- Fix the Today screen appearing and then immediately disappearing when opening the app without a link to a specific chapter. Returning readers have their last chapter restored from the browser just after the page appears, and the app was mistaking that restore for the reader navigating away, which closed Today the moment it opened. The restore is now recognised as part of the same page load, so Today stays up until you choose where to go.
+
 ### 🗑️ Removed
 
 ## v1.6.0 — 2026-08-24

--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -767,11 +767,14 @@ export function createSeedBibleState(
     if (previous === null || previous === location) {
       return;
     }
-    // The saved reading position arriving from `localStorage` is still part of
-    // this load, not a navigation away from it — see `restoringStoredState`.
-    // The baseline above is updated first, so the restored position becomes
-    // the position everything after it is compared against.
-    if (restoringStoredState) {
+    // A restore is not a navigation: the reader hasn't gone anywhere, the app is
+    // catching the URL up to state that only arrived after the load — the saved
+    // tabs from `localStorage` (see `restoringStoredState`) or the profile's
+    // saved translation, which reaches this effect at all because it can fall
+    // back to a different book (see `isRestoringProfileTranslation`). The
+    // baseline above is updated first in both cases, so the restored position
+    // becomes the position everything after it is compared against.
+    if (restoringStoredState || tabs.isRestoringProfileTranslation()) {
       return;
     }
     panes.closeFullscreenPanes();

--- a/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SeedBibleStateManager.tsx
@@ -726,6 +726,14 @@ export function createSeedBibleState(
     discover,
     chats
   );
+  // True only while `hydrateFromStorage` below is applying the saved tab state.
+  // Restoring the tabs replaces the URL-seeded boot tab, and the reader commits
+  // the restored book/chapter to the address bar — a URL move that looks exactly
+  // like a navigation to the effect below, but is the tail end of the same page
+  // load. Without this, a returning visitor whose last chapter wasn't the boot
+  // default watched Today open and then immediately close again.
+  let restoringStoredState = false;
+
   // Close any fullscreen pane when the book/chapter in the URL path changes,
   // so navigating reveals the reader (every navigation path writes this
   // position into the path — see `commitSelectedTabToUrl` in TabsManager).
@@ -757,6 +765,13 @@ export function createSeedBibleState(
     lastReadingLocation = location;
 
     if (previous === null || previous === location) {
+      return;
+    }
+    // The saved reading position arriving from `localStorage` is still part of
+    // this load, not a navigation away from it — see `restoringStoredState`.
+    // The baseline above is updated first, so the restored position becomes
+    // the position everything after it is compared against.
+    if (restoringStoredState) {
       return;
     }
     panes.closeFullscreenPanes();
@@ -1090,19 +1105,26 @@ export function createSeedBibleState(
    * first render. See `AppState.hydrateFromStorage`.
    */
   const hydrateFromStorage = () => {
-    batch(() => {
-      // Tabs before slots: slots are bound to tab objects by id, and restoring
-      // tabs replaces those objects wholesale.
-      tabs.hydrateStoredTabs();
-      tabsLayout.hydrateStoredLayout();
-      data.hydrateCachedCatalog();
-      selector.hydrateStoredViewMode();
-      tutorial.hydrateStoredFlags();
-      onboarding.hydrateStoredFlags();
-      // Unblocks the persistence effect above, which now sees the restored tab
-      // list rather than the URL-only seed.
-      tabsRestored.value = true;
-    });
+    // `batch` flushes its effects before it returns, so the reader's write of
+    // the restored position to the URL lands inside this window.
+    restoringStoredState = true;
+    try {
+      batch(() => {
+        // Tabs before slots: slots are bound to tab objects by id, and restoring
+        // tabs replaces those objects wholesale.
+        tabs.hydrateStoredTabs();
+        tabsLayout.hydrateStoredLayout();
+        data.hydrateCachedCatalog();
+        selector.hydrateStoredViewMode();
+        tutorial.hydrateStoredFlags();
+        onboarding.hydrateStoredFlags();
+        // Unblocks the persistence effect above, which now sees the restored tab
+        // list rather than the URL-only seed.
+        tabsRestored.value = true;
+      });
+    } finally {
+      restoringStoredState = false;
+    }
     // Deliberately outside the batch: this can set `promptVisible`, and it must
     // observe the settled reader state rather than a half-applied one.
     tutorial.armAutoStart();

--- a/packages/seed-bible/seed-bible/managers/TabsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/TabsManager.tsx
@@ -377,6 +377,20 @@ export interface TabsManager {
    * re-render instead. Idempotent.
    */
   hydrateStoredTabs: () => void;
+
+  /**
+   * Whether the profile's saved translation is being written to the URL at this
+   * instant. Consumers that watch the URL for "the reader moved" must treat that
+   * write as a restore rather than a navigation — it can change the book or
+   * chapter (see `applySavedTranslation`) without the reader having gone
+   * anywhere.
+   *
+   * Deliberately a getter rather than a signal: it is only meaningful read
+   * synchronously from inside the URL-change effect it exists to inform, and
+   * making it reactive would invite subscribers that then re-run on a value
+   * guaranteed to be `false` again by the time they saw it.
+   */
+  isRestoringProfileTranslation: () => boolean;
 }
 
 /**
@@ -815,6 +829,17 @@ export function createTabs(
       });
     });
 
+  // True only while `applySavedTranslation` below writes the restored position
+  // to the URL. That write can move the book or chapter — a saved translation
+  // that lacks the book you're on falls back to its first book, and an
+  // out-of-range chapter is clamped — which looks exactly like a navigation to
+  // the fullscreen-pane effect in `SeedBibleStateManager`, even though the
+  // reader hasn't gone anywhere. Without this, a signed-in reader arriving on
+  // Today with a partial saved translation watched it open and then immediately
+  // close again. Read synchronously, never subscribed to, so a plain boolean
+  // rather than a signal.
+  let restoringProfileTranslation = false;
+
   // Restores the profile's saved translation on the given reading state.
   // `selectTranslationAndChapter` clamps an out-of-range chapter but throws
   // if the current book isn't in the target translation at all (a partial/
@@ -907,7 +932,15 @@ export function createTabs(
     // recomputes the desired translation from the URL, finds none, and
     // reverts this restore straight back to the default.
     if (selectedTab.peek()?.readingState === readingState) {
-      commitSelectedTabToUrl({ replace: true });
+      // Marked as a restore for the duration of the write: `commitSelectedTabToUrl`
+      // updates the URL synchronously and everything watching it runs before this
+      // returns, so the flag doesn't need to span the awaits above.
+      restoringProfileTranslation = true;
+      try {
+        commitSelectedTabToUrl({ replace: true });
+      } finally {
+        restoringProfileTranslation = false;
+      }
     }
   };
 
@@ -1049,5 +1082,6 @@ export function createTabs(
     removeTab,
     selectTab,
     hydrateStoredTabs,
+    isRestoringProfileTranslation: () => restoringProfileTranslation,
   };
 }

--- a/test/unit/seed-bible/managers/todayStaysOpenOnBoot.test.ts
+++ b/test/unit/seed-bible/managers/todayStaysOpenOnBoot.test.ts
@@ -7,6 +7,7 @@ import {
   createResponse,
   makeChapter,
   makeUrl,
+  nivBooks,
   translations,
 } from "./testUtils/mockBibleApiData";
 import { TODAY_PANE_ID } from "@packages/seed-bible/seed-bible/managers/TodayManager";
@@ -26,6 +27,21 @@ function responsesForBootAndRestore() {
     ),
     [makeUrl("/api/AAB/EXO/2.json", PRIVATE_API_ENDPOINT)]: createResponse(
       makeChapter(aabBooks, "EXO", 2)
+    ),
+  };
+}
+
+/**
+ * Genesis 1 is the boot tab's default; NIV is the profile's saved translation
+ * and contains Matthew only, so it cannot hold the book the boot tab is on.
+ */
+function responsesForBootAndSavedTranslation() {
+  return {
+    ...responsesForBootAndRestore(),
+    [makeUrl("/api/NIV/books.json", PRIVATE_API_ENDPOINT)]:
+      createResponse(nivBooks),
+    [makeUrl("/api/NIV/MAT/1.json", PRIVATE_API_ENDPOINT)]: createResponse(
+      makeChapter(nivBooks, "MAT", 1)
     ),
   };
 }
@@ -76,6 +92,37 @@ describe("Today on a cold load with no reading position in the URL", () => {
       2000
     );
     expect(window.location.pathname).toBe("/en/AAB/exodus/2");
+
+    expect(state.today.isOpen.value).toBe(true);
+    expect(
+      state.panes.panes.value.some((pane) => pane.id === TODAY_PANE_ID)
+    ).toBe(true);
+  });
+
+  it("stays open while the profile's saved translation is restored", async () => {
+    window.history.replaceState(null, "", "/");
+
+    const state = await createTestSeedBibleState({
+      responses: responsesForBootAndSavedTranslation(),
+      todayOpen: "fromUrl",
+    });
+
+    // The boot tab is on Genesis, which the saved translation doesn't contain —
+    // that mismatch is what makes the restore move the book, and moving the book
+    // is what reaches the fullscreen-pane effect at all.
+    expect(state.app.selectedTab.value?.readingState.bookId.value).toBe("GEN");
+    expect(state.today.isOpen.value).toBe(true);
+
+    state.login.profile.value = { name: "", config: { translationId: "NIV" } };
+
+    // Same reasoning as above: the restore has to have actually landed, or
+    // "Today is still open" holds for the uninteresting reason that nothing
+    // moved the reader.
+    await waitFor(
+      () => state.app.selectedTab.value?.readingState.bookId.value === "MAT",
+      2000
+    );
+    expect(window.location.pathname).toBe("/en/NIV/matthew/1");
 
     expect(state.today.isOpen.value).toBe(true);
     expect(

--- a/test/unit/seed-bible/managers/todayStaysOpenOnBoot.test.ts
+++ b/test/unit/seed-bible/managers/todayStaysOpenOnBoot.test.ts
@@ -1,0 +1,85 @@
+import {
+  createTestSeedBibleState,
+  waitFor,
+} from "../testUtils/createTestSeedBibleState";
+import {
+  aabBooks,
+  createResponse,
+  makeChapter,
+  makeUrl,
+  translations,
+} from "./testUtils/mockBibleApiData";
+import { TODAY_PANE_ID } from "@packages/seed-bible/seed-bible/managers/TodayManager";
+
+/** The app defaults to the private API endpoint, so responses key on it. */
+const PRIVATE_API_ENDPOINT = "https://vmfnri.helloao.org";
+
+/** Genesis 1 is the boot tab's default; Exodus 2 is what storage restores. */
+function responsesForBootAndRestore() {
+  return {
+    [makeUrl("/api/available_translations.json", PRIVATE_API_ENDPOINT)]:
+      createResponse(translations),
+    [makeUrl("/api/AAB/books.json", PRIVATE_API_ENDPOINT)]:
+      createResponse(aabBooks),
+    [makeUrl("/api/AAB/GEN/1.json", PRIVATE_API_ENDPOINT)]: createResponse(
+      makeChapter(aabBooks, "GEN", 1)
+    ),
+    [makeUrl("/api/AAB/EXO/2.json", PRIVATE_API_ENDPOINT)]: createResponse(
+      makeChapter(aabBooks, "EXO", 2)
+    ),
+  };
+}
+
+function storeTabOnExodus2(): void {
+  window.localStorage.setItem(
+    "sb-tabs-state",
+    JSON.stringify({
+      version: 1,
+      tabs: [
+        { id: "tab-1", translationId: "AAB", bookId: "EXO", chapterNumber: 2 },
+      ],
+      selectedTabId: "tab-1",
+      layout: "single",
+      slotTabIds: ["tab-1"],
+      selectedSlotIndex: 0,
+    })
+  );
+}
+
+/**
+ * A visitor arriving with no reading position in the URL should land on Today
+ * and stay there. A returning visitor also brings a saved reading position from
+ * `localStorage`, which the app restores just after the first render — and the
+ * reader writes that restored book/chapter into the address bar. That write is
+ * the tail end of the same page load, not a navigation, so it must not count as
+ * one: treating it as a navigation closed the fullscreen pane Today had just
+ * opened, and the screen appeared and vanished again.
+ */
+describe("Today on a cold load with no reading position in the URL", () => {
+  afterEach(() => {
+    window.localStorage.removeItem("sb-tabs-state");
+  });
+
+  it("stays open while the saved reading position is restored", async () => {
+    window.history.replaceState(null, "", "/");
+    storeTabOnExodus2();
+
+    const state = await createTestSeedBibleState({
+      responses: responsesForBootAndRestore(),
+      todayOpen: "fromUrl",
+    });
+
+    // The restore has to have actually happened, or "Today is still open" holds
+    // for the uninteresting reason that nothing moved the reader at all.
+    await waitFor(
+      () => state.app.selectedTab.value?.readingState.bookId.value === "EXO",
+      2000
+    );
+    expect(window.location.pathname).toBe("/en/AAB/exodus/2");
+
+    expect(state.today.isOpen.value).toBe(true);
+    expect(
+      state.panes.panes.value.some((pane) => pane.id === TODAY_PANE_ID)
+    ).toBe(true);
+  });
+});


### PR DESCRIPTION
## What's wrong

Opening the app without a link to a specific chapter auto-opens the Today screen, but it appeared and then vanished a moment later.

**Before:** you open `https://alpha.seedbible.org/`, Today shows for a fraction of a second, then closes and dumps you in the reader. 

**Now:** Today opens and stays up until you choose where to go.

There are two separate triggers with one shared cause, and this PR fixes both.

## Root cause

A rule in `SeedBibleStateManager` closes any fullscreen screen (Today included) whenever the book or chapter in the address bar changes, so that navigating always reveals the reader. It only sees the URL — never *why* the URL changed.

Two things move the URL after the page has already loaded, and neither is the reader going anywhere:

1. **Saved tabs.** Just after the first render, the app restores your last reading position from browser storage and writes it into the address bar. The boot tab commits Genesis 1, the restore then commits wherever you actually left off, and that second write read as "the user navigated." This hit every returning reader whose last chapter wasn't Genesis 1 — a first-time visitor has nothing stored, which is why it looked intermittent.
2. **Saved translation.** For a signed-in reader, the app restores the translation saved in their profile once it arrives over the network. If that translation doesn't contain the book they're on (an NT-only translation while you're in Genesis), it falls back to the translation's first book — changing the book in the address bar, and closing Today by the same rule. An out-of-range chapter gets clamped the same way.

A pure translation swap never triggered it: the rule compares only book and chapter, deliberately ignoring the translation segment of the path.

## The fix

Both restores are now marked as restores while they write to the URL, so the rule re-baselines the reading position instead of counting it as a move away from one. In both cases the baseline is updated *before* the check, so the restored position becomes what everything after it is compared against — a real navigation afterwards still closes fullscreen screens exactly as before.

The two windows have different shapes because the restores do:

- **Saved tabs** — `restoringStoredState` wraps the whole `batch(...)` in `hydrateFromStorage`. That works because `batch()` flushes its queued effects synchronously before returning, so the reader's URL commit lands inside the window.
- **Saved translation** — `restoringProfileTranslation` wraps only the single `commitSelectedTabToUrl` call at the end of `applySavedTranslation`. This restore is asynchronous (it awaits the tab going idle, then a network fetch for the translation's book list), so a flag spanning the whole function would be true across those awaits and could swallow a genuine navigation. A one-call window is enough because `selectTranslationAndChapter` is called with `{ updateUrl: false }`, which returns before emitting any navigation — that final commit is the only URL write in the whole restore.

`TabsManager` exposes its flag as `isRestoringProfileTranslation()`. It's a getter rather than a signal on purpose: it's only meaningful read synchronously from inside the effect it informs, and making it reactive would invite subscribers that re-run on a value already back to `false` by the time they saw it.

## Testing

Two regression tests in `test/unit/seed-bible/managers/todayStaysOpenOnBoot.test.ts`, each confirmed **red before its fix and green after**.

Both boot at `/` with no `?today=` param, so the real auto-open heuristic decides rather than a test flag. Each waits for the restore to actually land — asserting the book moved *and* the pathname changed — before checking that Today is still up, so neither can pass for the boring reason that nothing moved the reader at all.

- `stays open while the saved reading position is restored` — seeds stored tabs pointing at Exodus 2, asserts the URL reaches `/en/AAB/exodus/2` with Today still open.
- `stays open while the profile's saved translation is restored` — boots on Genesis, then sets a profile whose saved translation is the Matthew-only `NIV` fixture, asserts the URL reaches `/en/NIV/matthew/1` with Today still open.

Full suite: **226 files, 5271 tests, all passing.** `pnpm check:ts` reports 0 visible errors (6 suppressed, pre-existing). ESLint clean on all changed files.

Also verified by hand in the browser against the manual repro for the saved-translation case: sign in, click a partial translation in the selector so it persists to your profile, clear site data so the next boot starts on the Genesis 1 default, then load the bare URL.

## Trade-offs worth a reviewer's attention

**These flags are exactly as strong as the synchronous window they cover.** Nothing structurally enforces that the URL write stays synchronous — if someone later debounces `commitSelectedTabToUrl`, or makes `hydrateStoredTabs` await something, a flag will already be back to `false` when the write lands and the flicker returns. Both call sites carry comments saying so, and the two regression tests are the real guard rail.

**A structurally stronger fix was considered and rejected as too broad for this bug.** Real navigations push a history entry while both restores commit a `replace`, so the effect could distinguish them that way instead of by flag. But back/forward arrives via `popstate` rather than a push, so "replace means not a navigation" isn't complete on its own — it's a genuine refactor of every fullscreen-pane-closing path, with its own edge cases.
