### PR TITLE
Fix CSS specificity issue in chapter decoration diminish rule

### DIFF
--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
@@ -991,7 +991,13 @@
 }
 
 .sb-chapter-decoration-diminish {
-  .sb-verse,
+  /* Excluding the decorated verses here (rather than relying on the
+     `.sb-verse:has(.sb-verse-decoration-diminish)` override above to win)
+     matters because both selectors have equal specificity (two classes) —
+     a tie the later-declared rule would otherwise win regardless of which
+     one is meant to take precedence, silently dimming the very verses this
+     decoration exists to keep bright. */
+  .sb-verse:not(:has(.sb-verse-decoration-diminish)),
   .sb-chapter-heading {
     animation: diminish-in-out 3s ease-in-out;
   }


### PR DESCRIPTION
## Summary

Fixed a CSS specificity bug where decorated verses were being incorrectly dimmed by the chapter decoration animation, defeating the purpose of the verse-level decoration.

## The Problem

The `.sb-chapter-decoration-diminish` rule was applying a `diminish-in-out` animation to all `.sb-verse` elements. A later rule tried to override this for verses with `.sb-verse-decoration-diminish` using `:has()`, but both selectors had equal specificity (two classes each). In CSS, when specificity ties, the later-declared rule wins — which meant the override rule would always win, but only by accident of declaration order. This created a fragile situation where the very verses meant to stay bright were being dimmed instead.

## The Fix

Changed the selector from `.sb-verse` to `.sb-verse:not(:has(.sb-verse-decoration-diminish))`. This explicitly excludes decorated verses from the animation at the point of declaration, rather than relying on a later override rule to win a specificity tie.

**Before:**
```css
.sb-chapter-decoration-diminish {
  .sb-verse,
  .sb-chapter-heading {
    animation: diminish-in-out 3s ease-in-out;
  }
}
```

**After:**
```css
.sb-chapter-decoration-diminish {
  .sb-verse:not(:has(.sb-verse-decoration-diminish)),
  .sb-chapter-heading {
    animation: diminish-in-out 3s ease-in-out;
  }
}
```

## Implementation Details

- Added a detailed comment explaining why the `:not(:has())` approach is necessary, to prevent future maintainers from "simplifying" this back to the buggy version
- The fix ensures decorated verses remain bright during the chapter decoration animation, as intended

https://claude.ai/code/session_01Xyx28saQvm6N57aSvUH4ew