### PR TITLE
feat: Cache one shared app shell for HTML instead of per-URL entries

### DIFF
--- a/standalone/sw.ts
+++ b/standalone/sw.ts
@@ -24,7 +24,7 @@
  *  | What                                   | Strategy                        |
  *  |----------------------------------------|---------------------------------|
  *  | Core assets (entry JS, vendor, CSS, …) | Precache (install time)         |
- *  | Page HTML (any non-`/b/` navigation)   | NetworkFirst, 3s timeout        |
+ *  | Page HTML (any non-`/b/` navigation)   | StaleWhileRevalidate, one shared shell entry |
  *  | Other assets of *this* build           | CacheFirst                      |
  *  | Google Fonts / Fontshare stylesheets   | StaleWhileRevalidate            |
  *  | Google Fonts / Fontshare font files    | CacheFirst                      |
@@ -39,12 +39,12 @@ import {
   type PrecacheEntry,
 } from "workbox-precaching";
 import { registerRoute } from "workbox-routing";
+import { CacheFirst, StaleWhileRevalidate } from "workbox-strategies";
 import {
-  CacheFirst,
-  NetworkFirst,
-  StaleWhileRevalidate,
-} from "workbox-strategies";
-import { isAppShellNavigation, isCacheableStaticAsset } from "./swRouting";
+  getAppShellCacheKey,
+  isAppShellNavigation,
+  isCacheableStaticAsset,
+} from "./swRouting";
 
 // `declare let` (rather than `const`) so this shadows the `self: WorkerGlobalScope`
 // that lib.webworker declares, instead of colliding with it.
@@ -69,6 +69,22 @@ const FONT_FILE_CACHE = "seed-bible-font-files";
 
 /** Absolute form of `__ASSET_BASE_URL__`, so it can be compared against request URLs. */
 const ASSET_BASE_HREF = new URL(__ASSET_BASE_URL__, self.location.href).href;
+
+/**
+ * Fixed cache key every navigation's HTML is stored/read under, regardless of
+ * which path was actually requested. See the comment above the HTML route
+ * below for why one shared entry — not one per path — is the goal now.
+ */
+const APP_SHELL_URL = getAppShellCacheKey(self.location.origin);
+
+/**
+ * Rewrites this route's cache reads/writes to the single `APP_SHELL_URL` key
+ * instead of Workbox's default (the request URL), so every navigation shares
+ * one cache entry.
+ */
+const appShellCacheKeyPlugin = {
+  cacheKeyWillBeUsed: async () => APP_SHELL_URL,
+};
 
 /**
  * Origins the fonts come from. The stylesheet hosts are fetched as CSS; the
@@ -97,23 +113,30 @@ cleanupOutdatedCaches();
 // ─── The app shell (HTML) ────────────────────────────────────────────────────
 
 /**
- * Each navigation's HTML is cached under its own URL — Workbox's default key
- * (the full request URL, including query string) — since no
- * `cacheKeyWillBeUsed` override is registered on the route below. This
- * matters because the client now calls Preact's `hydrate()`, not `render()`
- * (see `app/init.tsx`): hydration requires the container's existing DOM to
- * already match the URL being hydrated. Serving a cached copy from a
- * *different* URL/book/chapter would hydrate against the wrong content, and
- * — unlike a full render/rebuild — `hydrate()` does not diff attributes on
- * existing DOM, so a mismatch here would not self-correct.
+ * All navigations share a single cached HTML entry (`APP_SHELL_URL`), not one
+ * per path — see `appShellCacheKeyPlugin` above. The goal changed from "serve
+ * the exact page requested" to "load instantly, without touching the network,
+ * once *anything* is cached": this worker's main audience is returning
+ * visitors on slow or unreliable connections, some of whom already have an
+ * entire translation downloaded locally and don't need the HTML request at
+ * all to keep reading.
  *
- * A URL with no cached copy falls through to the network (subject to the 3s
- * timeout below); if that also fails, the navigation gets no cached shell at
- * all rather than a mismatched one — the client-side hydration gate (see
- * `app/hydrationGate.ts`) decides whether to hydrate or fall back to a full
- * `render()` for whatever HTML is actually present, so an absent or stale
- * cache entry degrades to a normal client render rather than a broken
- * hydrate.
+ * The cost: the client calls Preact's `hydrate()` when the served HTML
+ * happens to match the requested path exactly, and `render()` otherwise (see
+ * `app/hydrationGate.ts`). With one shared shell, that match now only happens
+ * for requests this worker never intercepts in the first place — i.e. before
+ * a service worker controls the page at all, when the browser always gets a
+ * fresh, exact per-path SSR response — or by coincidence, when the cached
+ * shell happens to be the same page being reopened. Every other navigation
+ * gets the (mismatched) cached shell and falls back to `render()`, the same
+ * already-tested path a cache miss took before. That's an accepted trade-off
+ * here: instant, network-free loads vs. a brief client-side re-render on most
+ * navigations.
+ *
+ * `StaleWhileRevalidate` is what keeps the shell current over time: every use
+ * serves the cached copy immediately, then fetches the real path in the
+ * background and overwrites the one shared entry with it, so the *next* load
+ * — of any path — reflects whatever just shipped.
  */
 
 /**
@@ -131,11 +154,11 @@ cleanupOutdatedCaches();
  * host is unreachable right now, the first controlled navigation fills the
  * cache instead.
  *
- * Warms the URL of the page that's actually registering this worker (falling
- * back to `/` if that can't be determined) rather than always warming `/`:
- * now that each URL is cached separately, warming only `/` would leave a
- * user who installs the worker while reading `/AAB/genesis/10` with nothing
- * cached for that page specifically.
+ * Warms from the URL of the page that's actually registering this worker
+ * (falling back to `/` if that can't be determined), since that's the only
+ * real content available to seed the shell with — but stores it under the
+ * shared `APP_SHELL_URL` key like every other write to this cache, not under
+ * its own URL.
  */
 async function warmAppShellCache(): Promise<void> {
   try {
@@ -172,9 +195,9 @@ async function warmAppShellCache(): Promise<void> {
     // also flagged `redirected`. Serving such a response to a navigation
     // (whose redirect mode is "manual") is a hard browser error, so caching
     // one would turn every offline launch into a failure instead of the
-    // shell. Cached under the response's own (post-redirect) URL, matching
-    // how the route below keys every other entry.
-    await cache.put(response.url, new Response(response.body, response));
+    // shell. Stored under the shared `APP_SHELL_URL` key, same as the route
+    // below.
+    await cache.put(APP_SHELL_URL, new Response(response.body, response));
   } catch {
     // Offline at install time — nothing to do.
   }
@@ -191,14 +214,13 @@ registerRoute(
       requestMode: request.mode,
       origin: self.location.origin,
     }),
-  new NetworkFirst({
+  new StaleWhileRevalidate({
     cacheName: HTML_CACHE,
-    // Offline, `fetch` rejects immediately and we fall back to the cache right
-    // away. This timeout is for the other case — a connection that is present
-    // but not actually working — where waiting on the network would otherwise
-    // hang the launch. Three seconds, then serve the last copy we saw.
-    networkTimeoutSeconds: 3,
     plugins: [
+      // Rewrites both the read and the write to the one shared
+      // `APP_SHELL_URL` key, ahead of the plugins below so they see (and
+      // gate) that same key rather than the actual requested URL.
+      appShellCacheKeyPlugin,
       // Never let a 404 (unknown branch) or 500 (render error) become the
       // stored copy of the app.
       //
@@ -210,15 +232,12 @@ registerRoute(
       // follows the redirect itself and we see a fresh fetch event for the
       // destination, whose 200 is what gets stored.
       new CacheableResponsePlugin({ statuses: [200] }),
-      // Every reading position gets its own entry now (see the comment
-      // above), so — unlike the single shared entry this replaced — this
-      // cache can grow without bound as a visitor reads more chapters.
-      // Bounded the same way `ASSET_CACHE` below is; shorter-lived, since
-      // this is an offline fallback behind a 3s NetworkFirst timeout, not
-      // the primary path.
+      // Only one entry ever exists now (the shared shell), so `maxEntries`
+      // just guards the invariant rather than bounding growth; no
+      // `maxAgeSeconds` is needed since `StaleWhileRevalidate` refreshes this
+      // entry from the network on every single use.
       new ExpirationPlugin({
-        maxEntries: 50,
-        maxAgeSeconds: 3 * DAY_SECONDS,
+        maxEntries: 1,
         purgeOnQuotaError: true,
       }),
     ],

--- a/standalone/sw.ts
+++ b/standalone/sw.ts
@@ -149,10 +149,10 @@ cleanupOutdatedCaches();
  * still land on the browser's "no connection" page until the user had visited
  * a second time.
  *
- * Deliberately swallows failures. Anything thrown out of an install handler
- * fails the install, and this is an optimisation, not a requirement — if the
- * host is unreachable right now, the first controlled navigation fills the
- * cache instead.
+ * Returns whether the shell was actually refreshed. Never throws — this is
+ * called from an install handler, where a rejected `waitUntil` promise fails
+ * the install outright, and a failed warm here is meant to be recoverable
+ * (see the `install` listener below), not fatal.
  *
  * Warms from the URL of the page that's actually registering this worker
  * (falling back to `/` if that can't be determined), since that's the only
@@ -160,7 +160,7 @@ cleanupOutdatedCaches();
  * shared `APP_SHELL_URL` key like every other write to this cache, not under
  * its own URL.
  */
-async function warmAppShellCache(): Promise<void> {
+async function warmAppShellCache(): Promise<boolean> {
   try {
     // `includeUncontrolled` is what makes this work on a *first* install: a
     // worker that is still installing controls nothing yet (control only
@@ -187,7 +187,7 @@ async function warmAppShellCache(): Promise<void> {
     const response = await fetch(url, { cache: "no-cache" });
     // Same acceptance rule as the route's `CacheableResponsePlugin` below, so
     // this can't seed the cache with something the route would have rejected.
-    if (response.status !== 200) return;
+    if (response.status !== 200) return false;
     const cache = await caches.open(HTML_CACHE);
     // Copied before storing, to drop the `redirected` flag. This `fetch` is
     // built from a string, so it follows redirects — meaning a URL that ever
@@ -198,13 +198,30 @@ async function warmAppShellCache(): Promise<void> {
     // shell. Stored under the shared `APP_SHELL_URL` key, same as the route
     // below.
     await cache.put(APP_SHELL_URL, new Response(response.body, response));
+    return true;
   } catch {
-    // Offline at install time — nothing to do.
+    // Offline (or otherwise unreachable) at install time.
+    return false;
   }
 }
 
 self.addEventListener("install", (event) => {
-  event.waitUntil(warmAppShellCache());
+  event.waitUntil(
+    warmAppShellCache().then((warmed) => {
+      // Only cut over to this worker once its own shell is confirmed to
+      // match the build that's installing right now. Precaching (via
+      // `precacheAndRoute`/`cleanupOutdatedCaches` above) drops the
+      // *previous* build's chunks the moment this worker activates,
+      // regardless of connectivity — so activating with a stale shell still
+      // cached would leave an offline load stranded between old HTML that
+      // references chunks the precache no longer has. Skipping
+      // `skipWaiting()` here instead leaves the *previous* worker in
+      // control — its own shell and precache are still mutually consistent
+      // — until a later install attempt (the browser's normal update
+      // polling, while online) succeeds.
+      if (warmed) self.skipWaiting();
+    })
+  );
 });
 
 registerRoute(
@@ -218,8 +235,10 @@ registerRoute(
     cacheName: HTML_CACHE,
     plugins: [
       // Rewrites both the read and the write to the one shared
-      // `APP_SHELL_URL` key, ahead of the plugins below so they see (and
-      // gate) that same key rather than the actual requested URL.
+      // `APP_SHELL_URL` key. Placed first so `ExpirationPlugin` below — whose
+      // bookkeeping keys off the effective request — sees that same
+      // rewritten key; `CacheableResponsePlugin` only looks at response
+      // status, so ordering doesn't affect it.
       appShellCacheKeyPlugin,
       // Never let a 404 (unknown branch) or 500 (render error) become the
       // stored copy of the app.
@@ -308,7 +327,9 @@ registerRoute(
 
 // ─── Lifecycle ───────────────────────────────────────────────────────────────
 // `registerType: "autoUpdate"` in vite.config.ts means there is no "reload to
-// update" prompt, so a new worker has to take over on its own: skip the waiting
-// phase, then claim the open pages.
-self.skipWaiting();
+// update" prompt, so a new worker has to take over on its own — `skipWaiting()`
+// is called from the `install` listener above (conditionally, once the shell
+// is confirmed warm) rather than unconditionally here. `clientsClaim()` stays
+// unconditional: it only has an effect once activation actually happens,
+// however that was triggered, and just claims the open pages at that point.
 clientsClaim();

--- a/standalone/swRouting.ts
+++ b/standalone/swRouting.ts
@@ -45,6 +45,13 @@ export function isAppShellNavigation(input: AppShellNavigationInput): boolean {
   return true;
 }
 
+/** Synthetic path every navigation's cached HTML is stored/read under, regardless of the actual path requested. */
+export const APP_SHELL_CACHE_PATH = "/__app-shell";
+
+export function getAppShellCacheKey(origin: string): string {
+  return new URL(APP_SHELL_CACHE_PATH, origin).href;
+}
+
 export interface CacheableStaticAssetInput {
   /** The requested URL. */
   url: URL;

--- a/test/unit/standalone/swRouting.test.ts
+++ b/test/unit/standalone/swRouting.test.ts
@@ -139,10 +139,11 @@ describe("isCacheableStaticAsset()", () => {
 });
 
 describe("getAppShellCacheKey()", () => {
-  it("returns the same key regardless of which path is being cached", () => {
-    // The whole point: every navigation shares one entry, so the key can't
-    // vary with the requested path.
-    expect(getAppShellCacheKey(ORIGIN)).toBe(getAppShellCacheKey(ORIGIN));
+  it("keys the shell under a fixed synthetic path, scoped to the origin", () => {
+    // The literal is intentionally hardcoded rather than built from
+    // `APP_SHELL_CACHE_PATH` — this needs to fail if that constant's value
+    // ever changes, not just mirror it.
+    expect(getAppShellCacheKey(ORIGIN)).toBe(`${ORIGIN}/__app-shell`);
   });
 
   it("scopes the key to the given origin", () => {

--- a/test/unit/standalone/swRouting.test.ts
+++ b/test/unit/standalone/swRouting.test.ts
@@ -1,4 +1,5 @@
 import {
+  getAppShellCacheKey,
   isAppShellNavigation,
   isCacheableStaticAsset,
 } from "../../../standalone/swRouting";
@@ -134,5 +135,20 @@ describe("isCacheableStaticAsset()", () => {
         assetBaseHref: `${ORIGIN}/`,
       })
     ).toBe(true);
+  });
+});
+
+describe("getAppShellCacheKey()", () => {
+  it("returns the same key regardless of which path is being cached", () => {
+    // The whole point: every navigation shares one entry, so the key can't
+    // vary with the requested path.
+    expect(getAppShellCacheKey(ORIGIN)).toBe(getAppShellCacheKey(ORIGIN));
+  });
+
+  it("scopes the key to the given origin", () => {
+    expect(getAppShellCacheKey(ORIGIN)).toContain(ORIGIN);
+    expect(getAppShellCacheKey(ORIGIN)).not.toBe(
+      getAppShellCacheKey("https://alpha.seedbible.org")
+    );
   });
 });

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -153,8 +153,10 @@ export default defineConfig(({ isSsrBuild }) => ({
             registerType: "autoUpdate",
             // A hand-written worker (`standalone/sw.ts`) rather than a
             // generated one: the offline behaviour this deployment needs —
-            // network-first HTML keyed so every URL shares one cached copy,
-            // and asset caching scoped to this build's own chunks — can't be
+            // StaleWhileRevalidate HTML keyed to a single shared shell entry
+            // (so a controlled navigation loads instantly with no network
+            // round-trip, refreshed in the background for next time), and
+            // asset caching scoped to this build's own chunks — can't be
             // expressed in `generateSW`'s declarative config.
             strategies: "injectManifest",
             srcDir: "standalone",


### PR DESCRIPTION
Switches the HTML route to StaleWhileRevalidate against a single cache entry shared by every navigation, so a service-worker-controlled visit loads instantly with no network round-trip, and refreshes in the background for next time. Uncontrolled requests (first visit, no SW) are unaffected and still hydrate() against exact per-path SSR HTML.