### PR TITLE
Defer Today's URL-derived open state until after mount

### DIFF
--- a/packages/seed-bible/seed-bible/app/main.tsx
+++ b/packages/seed-bible/seed-bible/app/main.tsx
@@ -161,6 +161,15 @@ function MainBody({
     state.app.hydrateFromStorage();
   }, []);
 
+  // Deferred real read, same reason as the three above: `isOpen` seeds
+  // `false` to match SSR (which always renders Today closed, for crawler
+  // SEO — see `TodayManager`), so the first hydrate pass can't disagree with
+  // it. Apply the URL's real open/closed state, and start the live URL sync,
+  // once right after mount.
+  useEffect(() => {
+    state.today.hydrateAutoOpen();
+  }, []);
+
   if (typeof document !== "undefined") {
     useSignalEffect(() => {
       document.title = state.app.title.value;

--- a/packages/seed-bible/seed-bible/managers/TodayManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/TodayManager.tsx
@@ -121,6 +121,18 @@ export interface TodayManager {
   getTranslationBooks: (translation: string) => Promise<TranslationBooks>;
   open: () => void;
   close: () => void;
+  /**
+   * Applies the URL's real open/closed state and starts the live URL <->
+   * `isOpen` sync.
+   *
+   * `isOpen` seeds to `false` unconditionally, on the client as well as
+   * during SSR, so the first hydrate pass can't disagree with the server
+   * over whether Today is showing. Call this once from a post-mount effect
+   * (see `MainBody` in `app/main.tsx`) so the real value -- and the two-way
+   * URL sync -- arrive as a normal diffed re-render instead, the same
+   * pattern `TabsManager.hydrateStoredTabs` uses for saved tabs. Idempotent.
+   */
+  hydrateAutoOpen: () => void;
   /** Tears down the internal effects. The app never calls this; tests do. */
   dispose: () => void;
 }
@@ -274,26 +286,41 @@ export function createTodayManager(options: {
       .trim();
   };
 
-  // Never open during SSR: `effectivePanes` renders fullscreen panes
-  // unconditionally (app/main.tsx), so a cold `/` request would otherwise
-  // serialize the whole Today screen into the crawled HTML. Safe because the
-  // client entry calls `render`, not `hydrate`, so there is no mismatch.
-  const isOpen: Signal<boolean> = signal(
-    import.meta.env.SSR
-      ? false
-      : todayWillAutoOpenForUrl(navigation.initialUrl, navigation.basePath)
-  );
+  // `effectivePanes` renders fullscreen panes unconditionally (app/main.tsx),
+  // so a cold `/` request would otherwise serialize the whole Today screen
+  // into the crawled HTML -- SSR always renders this closed. Seeding `false`
+  // here too, unconditionally, means the client's first hydrate pass matches
+  // that exactly rather than disagreeing over whether Today is open; the URL
+  // sync below (which would otherwise immediately overwrite this with the
+  // real value, before the first render) is deferred to `hydrateAutoOpen`
+  // for the same reason.
+  const isOpen: Signal<boolean> = signal(false);
 
-  const disposeUrlSync = navigation.syncSignalsToUrl({
-    today: {
-      get value() {
-        return isOpen.value ? "open" : null;
+  let autoOpenHydrated = false;
+  let disposeUrlSync = () => {};
+
+  const hydrateAutoOpen = () => {
+    if (autoOpenHydrated) {
+      return;
+    }
+    autoOpenHydrated = true;
+
+    isOpen.value = todayWillAutoOpenForUrl(
+      navigation.initialUrl,
+      navigation.basePath
+    );
+
+    disposeUrlSync = navigation.syncSignalsToUrl({
+      today: {
+        get value() {
+          return isOpen.value ? "open" : null;
+        },
+        set value(newValue) {
+          isOpen.value = newValue === "open";
+        },
       },
-      set value(newValue) {
-        isOpen.value = newValue === "open";
-      },
-    },
-  });
+    });
+  };
 
   // Unconditional writes on purpose: `syncSignalsToUrl`'s inbound effect reads
   // `currentUrl` and then calls this setter, so an `isOpen.value` guard here
@@ -322,6 +349,7 @@ export function createTodayManager(options: {
       bibleData.getTranslationBooks(translation),
     open,
     close,
+    hydrateAutoOpen,
     dispose: () => {
       disposeReadingHistory();
       disposeTranslationBooks();

--- a/test/unit/seed-bible/managers/TodayManager.test.ts
+++ b/test/unit/seed-bible/managers/TodayManager.test.ts
@@ -132,6 +132,30 @@ describe("Today pane wiring", () => {
     expect(paneIsOpen(state)).toBe(false);
   });
 
+  // The fix's core invariant: `isOpen` must stay `false` -- matching what SSR
+  // always renders -- until `hydrateAutoOpen` runs, even on a boot URL that
+  // will end up auto-opening Today. `skipHydrateAutoOpen` holds the fixture
+  // in that pre-hydrate window so this can be asserted directly, rather than
+  // only observing the already-corrected value every other test sees. Fails
+  // on the old construction-time seeding, which computed the real value
+  // immediately with no pre-hydrate window to observe.
+  it("seeds isOpen closed regardless of the URL, until hydrateAutoOpen runs", async () => {
+    window.history.replaceState(null, "", "/");
+
+    const state = await createTestSeedBibleState({
+      todayOpen: "fromUrl",
+      skipHydrateAutoOpen: true,
+    });
+
+    expect(state.today.isOpen.value).toBe(false);
+    expect(paneIsOpen(state)).toBe(false);
+
+    state.today.hydrateAutoOpen();
+
+    expect(state.today.isOpen.value).toBe(true);
+    await waitFor(() => paneIsOpen(state));
+  });
+
   // Reopening must reuse the same component thunk: a fresh one would remount
   // the whole Today tree and throw away its loaded reading history.
   it("keeps a stable component identity across reopens", async () => {

--- a/test/unit/seed-bible/testUtils/createTestSeedBibleState.ts
+++ b/test/unit/seed-bible/testUtils/createTestSeedBibleState.ts
@@ -235,9 +235,10 @@ export async function createTestSeedBibleState(
   installFreeUseBibleApiMock(globalThis as TestGlobalScope, responses);
   await ensureI18nInitialized();
 
-  // Pin Today's initial state before the state is built: `TodayManager` latches
-  // it from `initialUrl` at construction, so it cannot be set afterwards. Keeps
-  // whatever path the caller already navigated to.
+  // `TodayManager` reads `initialUrl` (captured from `window.location` at
+  // construction) when `hydrateAutoOpen` runs below, so the URL has to be
+  // pinned before the state is built. Keeps whatever path the caller already
+  // navigated to.
   if (typeof window !== "undefined" && options.todayOpen !== "fromUrl") {
     const url = new URL(window.location.href);
     url.searchParams.set("today", options.todayOpen ? "open" : "closed");
@@ -280,6 +281,11 @@ export async function createTestSeedBibleState(
   // to match SSR and only become real once this runs. Without it, anything
   // gated behind `tutorial.armAutoStart()` (called from here) never arms.
   state.app.hydrateFromStorage();
+  // Mirrors the same post-mount sequence's third one-time correction:
+  // `today.isOpen` seeds `false` to match SSR (which always renders Today
+  // closed), and only reflects the URL's real open/closed state once this
+  // runs.
+  state.today.hydrateAutoOpen();
   // Tabs first: awaiting anything else here would let asynchronously-created
   // tabs (e.g. an auto-joined shared session) appear before this runs, and those
   // tabs' reading states are mocked without a `loading` signal.

--- a/test/unit/seed-bible/testUtils/createTestSeedBibleState.ts
+++ b/test/unit/seed-bible/testUtils/createTestSeedBibleState.ts
@@ -61,6 +61,14 @@ export interface CreateTestSeedBibleStateOptions {
    * Pass a string to set a non-canonical value (e.g. `"1"`) for edge-case tests.
    */
   chatFirst?: boolean | string;
+  /**
+   * Skips the internal `state.today.hydrateAutoOpen()` call below, leaving
+   * `today.isOpen` at its pre-hydrate seed (`false`) instead of the URL's
+   * real open/closed state. For a test asserting the seed-then-correct
+   * invariant itself; every other test wants the fully-loaded-app behavior
+   * this helper otherwise mirrors, so this defaults to `false`.
+   */
+  skipHydrateAutoOpen?: boolean;
 }
 
 export async function waitFor(
@@ -285,7 +293,9 @@ export async function createTestSeedBibleState(
   // `today.isOpen` seeds `false` to match SSR (which always renders Today
   // closed), and only reflects the URL's real open/closed state once this
   // runs.
-  state.today.hydrateAutoOpen();
+  if (!options.skipHydrateAutoOpen) {
+    state.today.hydrateAutoOpen();
+  }
   // Tabs first: awaiting anything else here would let asynchronously-created
   // tabs (e.g. an auto-joined shared session) appear before this runs, and those
   // tabs' reading states are mocked without a `loading` signal.

--- a/test/unit/standalone/hydration.test.tsx
+++ b/test/unit/standalone/hydration.test.tsx
@@ -57,8 +57,8 @@ function seedStoredTabsState(
   );
 }
 
-async function renderSsrDocument(): Promise<string> {
-  jsdom.reconfigure({ url: `http://ssr.local${PATH}` });
+async function renderSsrDocument(path: string = PATH): Promise<string> {
+  jsdom.reconfigure({ url: `http://ssr.local${path}` });
   localStorage.clear();
   const responses = createDefaultManagerResponseMap();
   globalThis.fetch = (async (url: string) => {
@@ -71,7 +71,7 @@ async function renderSsrDocument(): Promise<string> {
   import.meta.env.SSR = true;
   try {
     const result = (await ssrRender({
-      path: PATH,
+      path,
       config: { ...DEFAULT_APP_CONFIG, acceptedLanguages: [] },
       html: TEMPLATE,
     })) as { html: string; notFound?: true; redirectTo?: string };
@@ -203,17 +203,17 @@ describe("client hydration", () => {
    * below can seed `localStorage` between the SSR render (which must not see it)
    * and the client's `createSeedBibleState` (which must).
    */
-  async function installSsrDocument(): Promise<{
+  async function installSsrDocument(path: string = PATH): Promise<{
     container: HTMLElement;
     beforeHtml: string;
   }> {
-    const html = await renderSsrDocument();
+    const html = await renderSsrDocument(path);
     document.open();
     document.write(html);
     document.close();
     // `document.write` re-navigates jsdom's location to "about:blank"; put it
     // back to what the server rendered for, matching a real browser.
-    jsdom.reconfigure({ url: `http://ssr.local${PATH}` });
+    jsdom.reconfigure({ url: `http://ssr.local${path}` });
     const container = document.getElementById("app")!;
     return { container, beforeHtml: container.innerHTML };
   }
@@ -238,6 +238,61 @@ describe("client hydration", () => {
       ".sb-tab-row:not(.sb-tab-mobile-add-inline)"
     ).length;
   }
+
+  // The reported repro: an explicit `?today=open` auto-opens Today once
+  // `TodayManager.hydrateAutoOpen` runs -- the exact case `isOpen`'s
+  // seed-then-correct pattern exists for. A bare "/" would also auto-open
+  // Today, but the reader canonicalizes it to an explicit reading path via
+  // `history.replaceState` before this point, which would make the live URL
+  // disagree with `renderedForPath` for an unrelated reason (a real
+  // "url-mismatch", not the bug this test exists to catch) -- an already-
+  // canonical path with `?today=open` added avoids that entirely.
+  const TODAY_OPEN_PATH = `${PATH}&today=open`;
+
+  it("hydrates Today closed on an explicit ?today=open, matching SSR, then opens it after mount", async () => {
+    const { container, beforeHtml } = await installSsrDocument(TODAY_OPEN_PATH);
+    // Sanity check: SSR really did render the reader closed rather than
+    // Today's Welcome screen, or the rest of this test wouldn't be
+    // exercising the mismatch at all.
+    expect(beforeHtml).not.toContain("sb-today-container");
+
+    const { config, state } = await createClientState();
+    // The fix's core invariant, asserted directly: `isOpen` still matches
+    // what SSR rendered (closed) here, even though this URL will auto-open
+    // Today as soon as the post-mount effect runs. On the pre-fix code,
+    // `isOpen` seeded from `todayWillAutoOpenForUrl` at construction, so
+    // this would already be `true`.
+    expect(state.today.isOpen.value).toBe(false);
+
+    const decision = decideHydration({
+      config,
+      pathname: location.pathname,
+      search: location.search,
+      container,
+      clientCommit: __GIT_COMMIT__,
+    });
+    expect(decision).toEqual({ hydrate: true });
+
+    hydrate(<Main initialState={state} config={config} />, container);
+
+    // Byte-identical to the served HTML. On the pre-fix code, `isOpen` would
+    // already have been `true` for this URL, and `hydrate()` would have
+    // silently patched the whole open Today screen onto markup the server
+    // never sent.
+    expect(normalizeKnownSsrClientDivergences(container.innerHTML)).toBe(
+      normalizeKnownSsrClientDivergences(beforeHtml)
+    );
+
+    // ...and only now, via `MainBody`'s post-mount effect calling
+    // `today.hydrateAutoOpen()`, does Today actually open.
+    await act(async () => {
+      state.today.hydrateAutoOpen();
+      await Promise.resolve();
+    });
+
+    expect(state.today.isOpen.value).toBe(true);
+    expect(container.innerHTML).toContain("sb-today-container");
+  });
 
   it("hydrates cleanly when the visitor already has this chapter's tab saved", async () => {
     // The reported repro: load a chapter, then refresh. The refresh finds an


### PR DESCRIPTION
## Summary

Fixes a hydration bug where loading (or refreshing) a URL that opens the Today screen — e.g. one with `?today=open`, or a bare `/` with no reading position — could corrupt the page: a broken bottom toolbar, a stray leftover chunk of chapter text, an unexpected extra selector panel.

## Problem

The app renders on the server first (fast first paint), then the client "attaches" to that markup instead of rebuilding it, on the assumption that the client would have built the exact same thing. `TodayManager`'s `isOpen` broke that assumption: SSR always forces it `false` (Today closed — deliberately, so a crawler indexing a cold `/` request sees real scripture instead of the Welcome screen), while the client computed its *initial* value from `todayWillAutoOpenForUrl(...)` reading the live URL. Whenever those disagreed, the client's first attach pass fought a structurally different SSR document instead of matching it, and Preact's `hydrate()` doesn't diff structure the way a full re-render does — it just silently patches, incorrectly.

## Changes

- **`managers/TodayManager.tsx`**: `isOpen` now seeds `false` unconditionally — client and server alike — instead of branching on `import.meta.env.SSR`. The real URL-derived value, and the two-way URL↔`isOpen` sync (previously wired up at construction time), are now applied by a new idempotent `hydrateAutoOpen()` method instead.
- **`app/main.tsx`**: calls `state.today.hydrateAutoOpen()` from a post-mount `useEffect(() => {...}, [])`, alongside the three existing effects that defer other SSR-seeded state (viewport, local settings, saved tabs) until right after the first commit.
- **`test/unit/seed-bible/testUtils/createTestSeedBibleState.ts`**: the test fixture now calls `hydrateAutoOpen()` too, mirroring `hydrateLocalConfig()`/`hydrateFromStorage()`, so it continues to represent a fully-loaded app.

## Alternatives considered

- **Decline hydration whenever the mismatch is detected** (fall back to a full `render()`): fixes the corruption, but trades away the fast-attach path for that page load, causing a visible flash. Ruled out — not acceptable to lose hydration for this.
- **Have SSR render Today open for an explicit `?today=open`**: no flash at all, but the "bare `/` also opens Today" case is trickier — SSR deliberately never opens it there for SEO, and would need care not to regress that. More invasive than necessary here.
- **What shipped**: seed both sides to the same safe default (`false`) so there's never a disagreement, then apply the real value one render later — the same pattern already used for restoring saved tabs (`TabsManager.hydrateStoredTabs`), local settings, and viewport size. No flash, no lost hydration, no SEO risk, and it reuses an established pattern instead of introducing a new one.

## Test plan

- [x] `TodayManager.test.ts`, `todayCoversReader.test.ts`, `todayStaysOpenOnBoot.test.ts` — all passing
- [x] Full suite (228 files, 5336 tests) — passing
- [x] `pnpm eslint` / `pnpm check:ts:client` — clean
