### PR TITLE
Dismissing the login prompt no longer breaks the action that asked for it

### DIFF
--- a/packages/seed-bible/seed-bible/managers/LoginManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/LoginManager.tsx
@@ -127,6 +127,11 @@ export interface LoginManager {
 
   /**
    * Attempts to login the user.
+   *
+   * Resolves with the signed-in user, or `null` when no account was obtained —
+   * including when the user dismisses the prompt. Dismissal is deliberately not
+   * a rejection: callers offer sign-in as a convenience and carry on without an
+   * account, so throwing would abandon whatever the user was actually doing.
    */
   login: () => Promise<UserInfo | null>;
 
@@ -156,6 +161,8 @@ export interface LoginManager {
 
   /**
    * Cancels an in-progress login attempt, if one exists. This is useful to abort a login flow if the user navigates away or closes the login modal before completing authentication.
+   *
+   * Any pending {@link login} call resolves with `null`.
    */
   cancelLogin: () => Promise<void>;
 
@@ -465,7 +472,6 @@ export function createLoginManager({
 
   let loginPromise: Promise<UserInfo | null> | null = null;
   let resolveLoginPromise: ((value: UserInfo | null) => void) | null = null;
-  let rejectLoginPromise: ((err: Error) => void) | null = null;
   let currentLoginPromise: Promise<UserInfo | null> | null = null;
 
   // const userId = os.userId;
@@ -652,11 +658,16 @@ export function createLoginManager({
 
   async function cancelLogin() {
     isLoginOpen.value = false;
-    if (loginPromise && rejectLoginPromise) {
-      rejectLoginPromise(new Error("Login cancelled"));
+    if (loginPromise && resolveLoginPromise) {
+      // Resolves null rather than rejecting. Dismissing the prompt is an
+      // answer ("carry on without an account"), not a failure, and every
+      // caller is written to read that answer from the resolved value. A
+      // rejection instead threw out of the caller mid-way, which is what
+      // stopped a dismissed prompt from leaving a signed-out user able to
+      // write a note (#1591).
+      resolveLoginPromise(null);
       loginPromise = null;
       resolveLoginPromise = null;
-      rejectLoginPromise = null;
     }
   }
 
@@ -726,7 +737,6 @@ export function createLoginManager({
       if (resolveLoginPromise) {
         resolveLoginPromise(userInfo.value);
         resolveLoginPromise = null;
-        rejectLoginPromise = null;
         loginPromise = null;
       }
 
@@ -739,9 +749,8 @@ export function createLoginManager({
   async function loginCore(): Promise<UserInfo | null> {
     if (!sessionKey.value) {
       if (!loginPromise) {
-        loginPromise = new Promise((resolve, reject) => {
+        loginPromise = new Promise((resolve) => {
           resolveLoginPromise = resolve;
-          rejectLoginPromise = reject;
         });
       }
 

--- a/test/unit/seed-bible/managers/AnnotationsManager.test.ts
+++ b/test/unit/seed-bible/managers/AnnotationsManager.test.ts
@@ -1148,6 +1148,28 @@ describe("AnnotationsManager", () => {
       expect(manager.editingAnnotation.value).not.toBeNull();
     });
 
+    it("starts a signed-out draft online after the sign-in prompt is dismissed", async () => {
+      // Online, so sign-in is offered. Dismissing it means "carry on without an
+      // account", and a device with somewhere to put the note must honour that:
+      // the editor opens and the note is kept locally. Before #1591 the
+      // dismissal threw out of `createNewAnnotation`, so the editor never
+      // opened and the user was simply stuck.
+      login.userId.value = null;
+      login.login.mockResolvedValue(null);
+      const manager = createOfflineManager();
+
+      await manager.createNewAnnotation();
+
+      expect(login.login).toHaveBeenCalled();
+      const draft = manager.editingAnnotation.value;
+      expect(draft).not.toBeNull();
+
+      await manager.saveEditingAnnotation();
+
+      expect(await store.get(LOCAL_OWNER, draft!.id)).not.toBeNull();
+      expect(recordDataMock).not.toHaveBeenCalled();
+    });
+
     it("shows signed-out drafts in the chapter listing", async () => {
       login.userId.value = null;
       const manager = createOfflineManager();

--- a/test/unit/seed-bible/managers/AnnotationsManager.test.ts
+++ b/test/unit/seed-bible/managers/AnnotationsManager.test.ts
@@ -13,7 +13,10 @@ import {
   type OfflineAnnotationStore,
 } from "@packages/seed-bible/seed-bible/managers/OfflineAnnotationStore";
 import { createDiscoverManager } from "@packages/seed-bible/seed-bible/managers/DiscoverManager";
-import type { LoginManager } from "@packages/seed-bible/seed-bible/managers/LoginManager";
+import {
+  createLoginManager,
+  type LoginManager,
+} from "@packages/seed-bible/seed-bible/managers/LoginManager";
 import { CasualOSManager } from "@packages/seed-bible/seed-bible/managers/OsManager";
 import type {
   ReaderTab,
@@ -988,6 +991,20 @@ describe("AnnotationsManager", () => {
       return new Promise((resolve) => setTimeout(resolve, 0));
     }
 
+    /** Polls until `check` passes, so no test has to guess at a duration. */
+    async function waitForCondition(
+      check: () => boolean,
+      timeoutMs = 1000
+    ): Promise<void> {
+      const start = Date.now();
+      while (!check()) {
+        if (Date.now() - start > timeoutMs) {
+          throw new Error("waitForCondition timed out");
+        }
+        await new Promise((resolve) => setTimeout(resolve, 5));
+      }
+    }
+
     /** Puts the manager in the state of having no connection. */
     function goOffline() {
       window.dispatchEvent(new Event("offline"));
@@ -1148,22 +1165,40 @@ describe("AnnotationsManager", () => {
       expect(manager.editingAnnotation.value).not.toBeNull();
     });
 
-    it("starts a signed-out draft online after the sign-in prompt is dismissed", async () => {
-      // Online, so sign-in is offered. Dismissing it means "carry on without an
-      // account", and a device with somewhere to put the note must honour that:
-      // the editor opens and the note is kept locally. Before #1591 the
-      // dismissal threw out of `createNewAnnotation`, so the editor never
-      // opened and the user was simply stuck.
-      login.userId.value = null;
-      login.login.mockResolvedValue(null);
-      const manager = createOfflineManager();
+    it("starts a signed-out draft when the user dismisses the real sign-in prompt", async () => {
+      // Deliberately driven through a real `LoginManager` rather than the mock
+      // this file uses elsewhere. The bug being guarded here lived in the
+      // boundary between the two: `cancelLogin()` rejected the pending
+      // `login()` promise, so the dismissal threw out of `createNewAnnotation`
+      // before it could open the editor, and the user was simply stuck with
+      // nothing on screen and nothing explaining why. A mocked `login()`
+      // resolving `null` cannot catch that — it agrees with the caller while
+      // disagreeing with the manager, which is why the original bug shipped.
+      const realLogin = createLoginManager({ os });
+      const manager = createAnnotationsManager(
+        os,
+        realLogin,
+        tabs,
+        discover,
+        undefined,
+        { store }
+      );
+      offlineManagers.push(manager);
 
-      await manager.createNewAnnotation();
+      // Not awaited yet: `createNewAnnotation` is parked on the prompt until it
+      // is answered, which is the state a dismissal has to be delivered into.
+      const drafting = manager.createNewAnnotation();
+      await waitForCondition(() => realLogin.isLoginOpen.value);
 
-      expect(login.login).toHaveBeenCalled();
+      await realLogin.cancelLogin();
+      await drafting;
+
       const draft = manager.editingAnnotation.value;
       expect(draft).not.toBeNull();
+      expect(discover.view.value).toBe("create_annotation");
 
+      // And the note the editor was opened for is genuinely kept, under the
+      // signed-out bucket, without reaching for a record that doesn't exist.
       await manager.saveEditingAnnotation();
 
       expect(await store.get(LOCAL_OWNER, draft!.id)).not.toBeNull();

--- a/test/unit/seed-bible/managers/LoginManager.test.ts
+++ b/test/unit/seed-bible/managers/LoginManager.test.ts
@@ -237,7 +237,7 @@ describe("createLoginManager", () => {
 
       await manager.cancelLogin();
 
-      await expect(loginPromise).rejects.toThrow("Login cancelled");
+      await expect(loginPromise).resolves.toBeNull();
       await waitFor(() => manager.isLoginOpen.value === false);
       expect(getUserInfoMock).not.toHaveBeenCalled();
     });


### PR DESCRIPTION
Fixes: #1734

## Summary

`LoginManager.cancelLogin()` rejected the pending `login()` promise instead of resolving it, so dismissing the sign-in modal threw out of whatever the user was doing. This makes dismissal resolve `null` — the value every caller was already written to expect.

## Problem

Signed out, open a chapter and try to add an annotation. The login modal appears. Dismiss it and nothing happens: the annotation editor never opens, and no error is shown.

The prompt is meant to be an offer rather than a requirement — a signed-out note is kept on the device and adopted into the account on first sign-in. But `await login.login()` threw on dismissal, so every line after it was skipped, including the two that build the draft and switch the Discover pane to the editor. The call site is `void annotations.createNewAnnotation()`, so the throw surfaced only as an unhandled rejection in the console.

The signed-out handling was already written correctly and simply never ran. `createNewAnnotation` checks `if (!userId && !recordOverride && !store)` and only gives up when there is nowhere local to write — it never got that far.

This was never caught because the manager tests mock `login.login` as resolving `null`, which is what the callers expect but not what `LoginManager` did. The mock and the caller agreed with each other while disagreeing with the real implementation.

## The Fix

`cancelLogin()` now resolves the pending promise with `null` rather than rejecting it. `rejectLoginPromise` had no other use and is removed, and the `login()` / `cancelLogin()` doc comments now state the contract.

Dismissing a prompt is an answer — "carry on without an account" — not a failure. `login()` already declared `Promise<UserInfo | null>`, so `null` was always the intended way to say "no account".

## Blast radius

All nine `login()` call sites were checked. Every one of them already assumed a resolved value, so this fixes more than annotations:

| Call site | Before | After |
|---|---|---|
| `AnnotationsManager.createNewAnnotation` | editor never opens | opens a local draft |
| `PlaylistManager.createNewPlaylist` | editor never opens; the AI tool's "sign-in was required and did not complete" message was unreachable | returns `null`, message reachable |
| `BookmarksManager.addBookmark` | bookmark modal stays open, because `onClose()` came after the throw | modal closes cleanly |
| `transcriptionManager` (AI transcript) | throws out of its sign-in handler, `isLoggedIn` left unset | sets `isLoggedIn` to false |
| `transcript-ui` `init.tsx` | `TypeError` reading `currentPane.id`, because its `catch` nulled `currentPane` first | closes the pane cleanly |
| `HighlightsManager` (×2) | guard clauses unreachable, unhandled rejection | clean no-op with a warning |
| `SettingsPage` sign-in button | unhandled rejection on dismiss | resolves quietly |
| `twitchPubManager` | already correct — its `catch` and its `if (!userInfo)` do the same thing | unchanged; the `catch` is now redundant |

## Testing

- `LoginManager.test.ts` — "can cancel the login flow" now asserts `resolves.toBeNull()`. Confirmed red against the pre-fix code.
- `AnnotationsManager.test.ts` — new test covering the reported case: signed out, **online**, prompt dismissed, local store present. The editor opens and the note is written to the `local` bucket without touching the server. Existing coverage only had the offline case and the no-store case, so this exact combination was untested.
- Full suite: 5376 tests across 229 files, all passing. `pnpm check:ts` clean, Prettier clean.

**Manual check:** sign out, open a chapter, Discover → Annotations → new note, dismiss the sign-in modal. The editor should open, and the note should still be there after a reload.

## Notes

Found while investigating #1591 (offline and anonymous highlighting), which needs this same path to work — highlighting signed out currently hits the same rejection.

This changes a documented, tested contract on `LoginManager`. I went this way rather than adding `try`/`catch` at nine call sites because the return type already advertised `null` and every caller assumed it, but it's worth a look during review.