### PR TITLE
Add SSR support for Customizations

### DIFF
--- a/packages/seed-bible/seed-bible/app/main.tsx
+++ b/packages/seed-bible/seed-bible/app/main.tsx
@@ -55,16 +55,31 @@ import { OfflineDownloadPrompt } from "../components/OfflineDownloadPrompt/Offli
  * the server but not on the client, causing a hydration mismatch; Preact also
  * never diffs `dangerouslySetInnerHTML` during hydration, so this stays
  * inert even if the two sides' CSS text does legitimately differ.
+ *
+ * The SSR suspend below is deliberately scoped to just this component rather
+ * than gating `MainContent` as a whole: `_renderToString`'s array-of-children
+ * traversal doesn't block later siblings on an earlier one suspending, so
+ * gating only here keeps everything else's first-render timing (most notably
+ * `BibleReader`'s own chapter-load suspend) exactly as it is without a
+ * `?customization=` link in play.
  */
 export function ExternalResourceDependencies({
   themeCssVariables,
   themeCssClasses,
   googleFontFamilies,
+  initialCustomizationLoadPromise,
+  initialCustomizationLoadSettled,
 }: {
   themeCssVariables: ReadonlySignal<string>;
   themeCssClasses: ReadonlySignal<string>;
   googleFontFamilies: ReadonlySignal<string[]>;
+  initialCustomizationLoadPromise: Promise<void>;
+  initialCustomizationLoadSettled: ReadonlySignal<boolean>;
 }) {
+  if (import.meta.env.SSR && !initialCustomizationLoadSettled.value) {
+    throw initialCustomizationLoadPromise;
+  }
+
   return (
     <>
       <link
@@ -256,6 +271,12 @@ function MainContent(props: {
           themeCssVariables={theme.themeCssVariables}
           themeCssClasses={theme.themeCssClasses}
           googleFontFamilies={theme.googleFontFamiliesToLoad}
+          initialCustomizationLoadPromise={
+            state.customizations.initialCustomizationLoadPromise
+          }
+          initialCustomizationLoadSettled={
+            state.customizations.initialCustomizationLoadSettled
+          }
         />
         <Sidebar state={state} />
 

--- a/packages/seed-bible/seed-bible/managers/CustomizationsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/CustomizationsManager.tsx
@@ -614,6 +614,18 @@ export interface CustomizationsManager {
    */
   linkedCustomization: ReadonlySignal<SeedBibleCustomization | null>;
   /**
+   * Resolves once the initial `?customization=...` load (if any) reaches a
+   * terminal outcome: loaded, failed, or (during SSR only) exceeded a
+   * deadline. Resolves immediately if there was no `?customization=` param.
+   * Throw this in a component to suspend SSR rendering until then.
+   *
+   * Never rejects — a rejected promise thrown during `renderToStringAsync`
+   * surfaces as a render exception and takes down the whole SSR document.
+   */
+  initialCustomizationLoadPromise: Promise<void>;
+  /** True once the initial `?customization=` load has settled — see above. */
+  initialCustomizationLoadSettled: ReadonlySignal<boolean>;
+  /**
    * The local, unpersisted draft of the customization currently open in the
    * editor settings pages, or null when none is open. Edits accumulate here
    * and are only written to CasualOS by `saveEditingCustomization`.
@@ -736,6 +748,12 @@ export function createCustomizationsManager(
   const linkedCustomization = signal<SeedBibleCustomization | null>(null);
   const linkedCustomizationLocator = signal<string | null>(null);
 
+  const initialCustomizationLoadSettled = signal<boolean>(false);
+  let resolveInitialCustomizationLoadPromise: () => void = () => {};
+  const initialCustomizationLoadPromise = new Promise<void>((resolve) => {
+    resolveInitialCustomizationLoadPromise = resolve;
+  });
+
   const loadByLocator = async (locator: string): Promise<void> => {
     // `id` is always `customization_<uuid>` (no dots); split on the LAST dot
     // so a recordName that happens to contain one still parses correctly.
@@ -778,8 +796,40 @@ export function createCustomizationsManager(
 
   const initialLocator =
     navigation.initialUrl.searchParams.get("customization");
+
+  let initialCustomizationLoadTimer: ReturnType<typeof setTimeout> | null =
+    null;
+  const settleInitialCustomizationLoad = () => {
+    if (initialCustomizationLoadTimer !== null) {
+      clearTimeout(initialCustomizationLoadTimer);
+      initialCustomizationLoadTimer = null;
+    }
+    initialCustomizationLoadSettled.value = true;
+    resolveInitialCustomizationLoadPromise();
+  };
+
   if (initialLocator) {
-    void loadByLocator(initialLocator);
+    void loadByLocator(initialLocator).then(settleInitialCustomizationLoad);
+
+    // During SSR the render blocks on `initialCustomizationLoadPromise`, so an
+    // `os.getData()` that never answers would hold the request open
+    // indefinitely — `loadByLocator` itself always resolves (its try/catch
+    // covers every other failure mode), so this timeout is purely a backstop
+    // for that one case. Not armed on the client: there the promise only
+    // gates a Suspense boundary, and a genuinely slow connection deserves to
+    // keep waiting rather than have the customization silently dropped.
+    const SSR_INITIAL_CUSTOMIZATION_TIMEOUT_MS = 5000;
+    if (import.meta.env.SSR) {
+      initialCustomizationLoadTimer = setTimeout(() => {
+        console.warn(
+          "Timed out waiting for initial customization load:",
+          initialLocator
+        );
+        settleInitialCustomizationLoad();
+      }, SSR_INITIAL_CUSTOMIZATION_TIMEOUT_MS);
+    }
+  } else {
+    settleInitialCustomizationLoad();
   }
 
   // The only two ways for a customization to become "active" (applied to
@@ -1475,6 +1525,8 @@ export function createCustomizationsManager(
     resolveVariantBaseTheme,
     activeExtensionIds,
     linkedCustomization,
+    initialCustomizationLoadPromise,
+    initialCustomizationLoadSettled,
     editingCustomization,
     editingVariantId,
     load,

--- a/packages/seed-bible/seed-bible/managers/CustomizationsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/CustomizationsManager.tsx
@@ -815,9 +815,11 @@ export function createCustomizationsManager(
     // `os.getData()` that never answers would hold the request open
     // indefinitely — `loadByLocator` itself always resolves (its try/catch
     // covers every other failure mode), so this timeout is purely a backstop
-    // for that one case. Not armed on the client: there the promise only
-    // gates a Suspense boundary, and a genuinely slow connection deserves to
-    // keep waiting rather than have the customization silently dropped.
+    // for that one case. Not armed on the client: the promise is only thrown
+    // (to suspend) during SSR (see `ExternalResourceDependencies` in
+    // `app/main.tsx`), so on the client it's never awaited and a slow load
+    // simply applies the customization late, exactly as it did before this
+    // feature existed.
     const SSR_INITIAL_CUSTOMIZATION_TIMEOUT_MS = 5000;
     if (import.meta.env.SSR) {
       initialCustomizationLoadTimer = setTimeout(() => {

--- a/standalone/entry-ssr.tsx
+++ b/standalone/entry-ssr.tsx
@@ -465,8 +465,26 @@ export async function render(
 
   // Block until the detected language's translations are loaded so the
   // server-rendered HTML (and og:locale meta below) is in the right language
-  // rather than the bundled "en" fallback.
-  await state.i18n.ready;
+  // rather than the bundled "en" fallback. Also block on the initial tab's
+  // own chapter load: it starts fetching synchronously at state creation and
+  // has always finished by the time rendering below actually reaches
+  // `BibleReader`/`BibleReaderToolbar` — but only because nothing here used
+  // to make that first render wait on anything else. Any additional
+  // SSR-blocking wait added above this (the `?customization=` load, most
+  // notably) delays when that render is reached without slowing the chapter
+  // fetch down to match, so the two can now race — and if the chapter load
+  // loses, `BibleReader` suspends on its own `chapterDataPromise` for real,
+  // which `preact-render-to-string` cannot actually resolve: it never calls
+  // `options._catchError` for a component that throws to suspend, so
+  // `@preact/signals`' render-tracking cleanup for that component never
+  // runs, and every later signal write "queued" behind it — including the
+  // one that would resolve `chapterDataPromise` — never flushes. Waiting for
+  // it here, before any suspending render is attempted, keeps that race from
+  // being reachable at all.
+  await Promise.all([
+    state.i18n.ready,
+    state.app.selectedTab.value?.readingState.chapterDataPromise,
+  ]);
 
   const [appHtml] = await Promise.all([
     renderToStringAsync(

--- a/test/unit/seed-bible/managers/CustomizationsManager.test.ts
+++ b/test/unit/seed-bible/managers/CustomizationsManager.test.ts
@@ -1690,6 +1690,145 @@ describe("CustomizationsManager", () => {
     expect(manager.activeCustomization.value?.extensionSettings).toEqual({});
   });
 
+  it("initialCustomizationLoadSettled is true immediately with no ?customization= param", () => {
+    const { manager } = createManager();
+
+    expect(manager.initialCustomizationLoadSettled.value).toBe(true);
+  });
+
+  it("initialCustomizationLoadSettled stays false until a valid ?customization= link resolves", async () => {
+    const sharedRecord = {
+      id: "customization_shared",
+      name: "Shared",
+      variants: [
+        {
+          id: "variant_shared",
+          name: "Shared variant",
+          themes: { primaryColor: "#abc123" },
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      ],
+      defaultVariantId: "variant_shared",
+      logoUrl: null,
+      createdAt: 1,
+      updatedAt: 1,
+    };
+    let resolveGetData: (value: unknown) => void = () => {};
+    getDataMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveGetData = resolve;
+      })
+    );
+    const linkedNavigation = createNavigationManager({
+      initialHref:
+        "http://localhost/?customization=other-user.customization_shared",
+    });
+
+    const { manager } = createManager(linkedNavigation);
+
+    expect(manager.initialCustomizationLoadSettled.value).toBe(false);
+
+    resolveGetData({ success: true, data: sharedRecord });
+    await manager.initialCustomizationLoadPromise;
+
+    expect(manager.initialCustomizationLoadSettled.value).toBe(true);
+    expect(manager.linkedCustomization.value?.id).toBe("customization_shared");
+  });
+
+  it("initialCustomizationLoadPromise settles promptly for a malformed locator", async () => {
+    const linkedNavigation = createNavigationManager({
+      initialHref: "http://localhost/?customization=no-dot-here",
+    });
+
+    const { manager } = createManager(linkedNavigation);
+    await manager.initialCustomizationLoadPromise;
+
+    expect(manager.initialCustomizationLoadSettled.value).toBe(true);
+    expect(manager.linkedCustomization.value).toBeNull();
+  });
+
+  it("initialCustomizationLoadPromise settles promptly when the record isn't found", async () => {
+    getDataMock.mockResolvedValue({
+      success: false,
+      errorCode: "data_not_found",
+      errorMessage: "Data not found",
+    });
+    const linkedNavigation = createNavigationManager({
+      initialHref:
+        "http://localhost/?customization=owner.customization_missing",
+    });
+
+    const { manager } = createManager(linkedNavigation);
+    await manager.initialCustomizationLoadPromise;
+
+    expect(manager.initialCustomizationLoadSettled.value).toBe(true);
+    expect(manager.linkedCustomization.value).toBeNull();
+  });
+
+  it("initialCustomizationLoadPromise settles promptly for a Zod-invalid record", async () => {
+    getDataMock.mockResolvedValue({
+      success: true,
+      data: { not: "a valid customization" },
+    });
+    const linkedNavigation = createNavigationManager({
+      initialHref: "http://localhost/?customization=owner.customization_bad",
+    });
+
+    const { manager } = createManager(linkedNavigation);
+    await manager.initialCustomizationLoadPromise;
+
+    expect(manager.initialCustomizationLoadSettled.value).toBe(true);
+    expect(manager.linkedCustomization.value).toBeNull();
+  });
+
+  it("SSR: initialCustomizationLoadSettled backstops on a getData() that never resolves", async () => {
+    vi.useFakeTimers();
+    getDataMock.mockReturnValue(new Promise(() => {}));
+    const linkedNavigation = createNavigationManager({
+      initialHref:
+        "http://localhost/?customization=other-user.customization_shared",
+    });
+
+    try {
+      import.meta.env.SSR = true;
+      const { manager } = createManager(linkedNavigation);
+
+      expect(manager.initialCustomizationLoadSettled.value).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(manager.initialCustomizationLoadSettled.value).toBe(true);
+      expect(manager.linkedCustomization.value).toBeNull();
+    } finally {
+      delete import.meta.env.SSR;
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
+  it("client-side: initialCustomizationLoadSettled does not time out on a hung getData()", async () => {
+    vi.useFakeTimers();
+    getDataMock.mockReturnValue(new Promise(() => {}));
+    const linkedNavigation = createNavigationManager({
+      initialHref:
+        "http://localhost/?customization=other-user.customization_shared",
+    });
+
+    try {
+      const { manager } = createManager(linkedNavigation);
+
+      expect(manager.initialCustomizationLoadSettled.value).toBe(false);
+
+      await vi.advanceTimersByTimeAsync(5000);
+
+      expect(manager.initialCustomizationLoadSettled.value).toBe(false);
+    } finally {
+      vi.clearAllTimers();
+      vi.useRealTimers();
+    }
+  });
+
   it("an in-progress edit draft takes priority over a URL-linked customization", async () => {
     const sharedRecord = {
       id: "customization_shared",

--- a/test/unit/standalone/entry-ssr.test.ts
+++ b/test/unit/standalone/entry-ssr.test.ts
@@ -842,4 +842,88 @@ describe("render() server-rendered meta tags", () => {
     );
     expect(translationsCalls).toHaveLength(1);
   });
+
+  // These are the tests that actually exercise the SSR customization fix:
+  // `CustomizationsManager`'s `?customization=` fetch used to race
+  // `renderToStringAsync` instead of blocking it, so the served HTML always
+  // carried the visitor's own default theme, then flashed to the
+  // customization's colors once the client-side fetch resolved after
+  // hydration. `ExternalResourceDependencies` now throws
+  // `initialCustomizationLoadPromise` during SSR until that fetch settles,
+  // so the customization's CSS variables must already be present in the
+  // HTML this test reads back.
+  describe("?customization= share link", () => {
+    const CALL_PROCEDURE_URL =
+      "https://auth.seedbible.org/api/v3/callProcedure";
+
+    // A real (short) delay, not just an extra microtask tick: `render()`
+    // also blocks on the initial chapter's own load before ever attempting
+    // to render (see `entry-ssr.tsx`), so a customization response that
+    // resolves on the same tick as everything else the mocked fetch serves
+    // would settle before rendering starts regardless of whether
+    // `ExternalResourceDependencies` actually suspends on it — which would
+    // make this test pass even with that suspend removed. Delaying it past
+    // that first render attempt is what actually exercises the suspend.
+    function mockFetchWithCustomizationResponse(
+      customizationResponse: unknown
+    ) {
+      const responses = createDefaultManagerResponseMap();
+      globalThis.fetch = (async (url: string) => {
+        if (url === CALL_PROCEDURE_URL) {
+          await new Promise((resolve) => setTimeout(resolve, 20));
+          return createResponse(customizationResponse);
+        }
+        const response = responses[url];
+        if (!response) {
+          throw new Error(`No mocked response for ${url}`);
+        }
+        return response;
+      }) as typeof globalThis.fetch;
+    }
+
+    it("includes the linked customization's theme colors in the SSR'd HTML", async () => {
+      mockFetchWithCustomizationResponse({
+        success: true,
+        data: {
+          id: "customization_shared",
+          name: "Shared",
+          variants: [
+            {
+              id: "variant_shared",
+              name: "Shared variant",
+              themes: { primaryColor: "#abc123" },
+              createdAt: 1,
+              updatedAt: 1,
+            },
+          ],
+          defaultVariantId: "variant_shared",
+          logoUrl: null,
+          createdAt: 1,
+          updatedAt: 1,
+        },
+      });
+
+      const html = await renderHtml(
+        "/en/AAB/genesis/1?useFreeBibleAPI=true&customization=owner.customization_shared"
+      );
+
+      expect(html).toContain("Verse 1");
+      expect(html).toContain("--sb-primary-color: #abc123;");
+    });
+
+    it("renders normally, with no customization CSS, when the record isn't found", async () => {
+      mockFetchWithCustomizationResponse({
+        success: false,
+        errorCode: "data_not_found",
+        errorMessage: "Data not found",
+      });
+
+      const html = await renderHtml(
+        "/en/AAB/genesis/1?useFreeBibleAPI=true&customization=owner.customization_missing"
+      );
+
+      expect(html).toContain("Verse 1");
+      expect(html).not.toContain("--sb-primary-color: #abc123;");
+    });
+  });
 });

--- a/test/unit/standalone/entry-ssr.test.ts
+++ b/test/unit/standalone/entry-ssr.test.ts
@@ -911,6 +911,13 @@ describe("render() server-rendered meta tags", () => {
       expect(html).toContain("--sb-primary-color: #abc123;");
     });
 
+    // Unlike the test above, this one doesn't actually exercise the SSR
+    // suspend: a `data_not_found` response makes `loadByLocator` return
+    // before it ever sets `linkedCustomization`, so `--sb-primary-color`
+    // would be absent from the HTML whether or not the suspend/settle path
+    // works. Kept because it proves a missing record doesn't crash SSR or
+    // inject phantom colors — just not as regression coverage for the fix
+    // itself.
     it("renders normally, with no customization CSS, when the record isn't found", async () => {
       mockFetchWithCustomizationResponse({
         success: false,


### PR DESCRIPTION
## Summary

A shared `?customization=<recordName>.<id>` link lets someone send a styled version of Seed Bible, but the customization's colors previously only applied **after** the client hydrated and re-fetched the record — the server-rendered page always showed the visitor's own default theme first, then flashed to the customization's colors. This stacked PR fixes that by making the server wait for the customization to load before it finishes rendering.

- **`CustomizationsManager.tsx`**: exposes `initialCustomizationLoadPromise` / `initialCustomizationLoadSettled`, resolving once the `?customization=` load reaches a terminal outcome (loaded, failed, or — SSR only — a 5s timeout backstop). The promise never rejects, so it's safe to throw from a component.
- **`main.tsx`**: `ExternalResourceDependencies` (the component that emits the theme `<style>` tags) throws that promise during SSR until it settles, following the codebase's existing "throw a promise to suspend" pattern (the same one `BibleReadingManager`'s `chapterDataPromise` uses). The gate is scoped to just this component rather than to `MainContent` as a whole — `preact-render-to-string` doesn't block later siblings on an earlier one suspending, so a narrower gate leaves the rest of the tree's first-render timing untouched.
- **`entry-ssr.tsx`**: also now blocks on the initial tab's own `chapterDataPromise` alongside `state.i18n.ready` before attempting any render. This turned out to be necessary: any additional SSR-blocking wait introduced before the first render attempt can outrun the initial chapter fetch (which starts at state construction), and `preact-render-to-string` never calls `options._catchError` for a component that throws to suspend — so if `BibleReader` itself ends up needing to suspend on its own `chapterDataPromise`, the signal write that would resolve it never flushes, and the request hangs forever. That fetch has always finished by the time rendering reaches `BibleReader` today purely because nothing made the render wait on anything else first; explicitly waiting for it keeps that race unreachable regardless of what else (the customization load, or anything added later) delays the first render.

## Test plan

- [x] `pnpm vitest run CustomizationsManager.test.ts entry-ssr.test.ts` — 172 tests pass, including new coverage for the settlement latch/timeout and an end-to-end SSR render with a linked customization
- [x] Confirmed the new SSR test actually catches the regression: reverting the `ExternalResourceDependencies` guard makes it fail (missing `--sb-primary-color` in the HTML) — the customization response is deliberately delayed so it can't slip past `render()`'s other await first
- [x] `pnpm check:ts` — clean
- [x] `pnpm lint` — 0 errors (only pre-existing unrelated warnings)
- [x] `pnpm test` — full suite (234 files / 5608 tests) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01K8axGRHv1cGfzmkPnzQs4t

---
_Generated by [Claude Code](https://claude.ai/code/session_01K8axGRHv1cGfzmkPnzQs4t)_