### PR TITLE
Make the reader header's translation a real button on both layouts

### DIFF
--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
@@ -77,7 +77,7 @@
   flex: 1 1 auto;
   min-width: 0;
   display: flex;
-  align-items: flex-start;
+  align-items: center;
   flex-wrap: wrap;
   gap: 0.625rem;
 }
@@ -119,8 +119,7 @@
    changes, to suit each header's title. Keep the two in step. */
 .sb-bible-reader-translation,
 .sb-bible-reader-mobile-header-translation {
-  display: inline-flex;
-  align-items: center;
+  display: inline-block;
   cursor: pointer;
   border: none;
   font-family: var(--text-bookTitle-font);
@@ -250,6 +249,27 @@
   font-size: 1rem;
   padding: 0.3125rem 0.625rem;
   border-radius: 0.9375rem;
+}
+
+/* A line box reserves room for descenders that an all-caps abbreviation never
+   uses, so it sits high in an evenly padded chip — badly so in Newsreader,
+   which leaves 0.265em below the baseline but only 0.065em above the caps.
+   Trimming the box to the caps centres the letters themselves, whichever font
+   the reader has chosen. The padding grows to hold the chip's size once the
+   box shrinks from the full 1em to the cap height. */
+@supports (text-box: trim-both cap alphabetic) {
+  .sb-bible-reader-translation,
+  .sb-bible-reader-mobile-header-translation {
+    text-box: trim-both cap alphabetic;
+  }
+
+  .sb-bible-reader-translation {
+    padding-block: 0.5625rem;
+  }
+
+  .sb-bible-reader-mobile-header-translation {
+    padding-block: 0.475rem;
+  }
 }
 
 .sb-bible-reader-mobile-header-play {

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
@@ -71,8 +71,19 @@
   border-bottom: 1px solid var(--sb-divider-color);
 }
 
-.sb-bible-reader-title {
+/* Chapter title and translation chip sit on one row so the chip stays beside
+   the chapter number instead of drifting over to the action cluster. */
+.sb-bible-reader-heading {
   flex: 1 1 auto;
+  min-width: 0;
+  display: flex;
+  align-items: flex-start;
+  flex-wrap: wrap;
+  gap: 0.625rem;
+}
+
+.sb-bible-reader-title {
+  flex: 0 1 auto;
   min-width: 0;
   font-family: var(--text-bookTitle-font);
   /* color: var(--text-bookTitle-color); */
@@ -104,15 +115,38 @@
   color: inherit;
 }
 
+/* The translation chip is the same muted pill on both layouts; only its size
+   changes, to suit each header's title. Keep the two in step. */
+.sb-bible-reader-translation,
+.sb-bible-reader-mobile-header-translation {
+  display: inline-flex;
+  align-items: center;
+  cursor: pointer;
+  border: none;
+  font-family: var(--text-bookTitle-font);
+  font-weight: 500;
+  color: color-mix(in srgb, var(--sb-font-color), transparent 50%);
+  background: color-mix(in srgb, var(--sb-font-color), transparent 90%);
+}
+
 .sb-bible-reader-translation {
-  font-family: "Plus Jakarta Sans", sans-serif;
-  font-size: 1.5rem;
-  font-weight: 600;
+  flex-shrink: 0;
+  border-radius: 62.4375rem;
+  padding: 0.375rem 0.75rem;
+  font-size: 1.25rem;
   line-height: 1;
   letter-spacing: 0;
-  color: color-mix(in srgb, var(--sb-font-color), transparent 50%);
-  margin-inline-start: 0.4em;
-  vertical-align: 0.15em;
+  transition:
+    background-color 0.15s ease,
+    color 0.15s ease;
+}
+
+.sb-bible-reader-translation:hover,
+.sb-bible-reader-translation:focus-visible,
+.sb-bible-reader-mobile-header-translation:active,
+.sb-bible-reader-mobile-header-translation:focus-visible {
+  color: var(--sb-font-color);
+  background: color-mix(in srgb, var(--sb-font-color), transparent 84%);
 }
 
 .sb-bible-reader-meta {
@@ -214,11 +248,6 @@
 
 .sb-bible-reader-mobile-header-translation {
   font-size: 1rem;
-  font-weight: 400;
-  cursor: pointer;
-  color: color-mix(in srgb, var(--sb-font-color), transparent 50%);
-  background: color-mix(in srgb, var(--sb-font-color), transparent 90%);
-  display: inline-flex;
   padding: 0.3125rem 0.625rem;
   border-radius: 0.9375rem;
 }

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
@@ -1830,6 +1830,15 @@ export function BibleReader(props: BibleReaderProps) {
     selectorState.selectingTranslation.value = true;
   };
 
+  // The translation chip, in both the desktop and the mobile header: the short
+  // name to read, the full name to announce.
+  const translationLabel =
+    translation.value?.shortName ?? translationId.value ?? "";
+  const changeTranslationLabel = t("change-translation", {
+    defaultValue: "Change translation ({{name}})",
+    name: translation.value?.name ?? translationLabel,
+  });
+
   // True for the click that trails a drag-to-select gesture, so the verse's
   // own onClick doesn't toggle the verse back off after we've just selected
   // it from the text selection. Reset at the start of every new gesture.
@@ -2134,15 +2143,17 @@ export function BibleReader(props: BibleReaderProps) {
                   {currentBookName.value ?? bookId.value ?? ""}{" "}
                   {chapterNumber.value}
                 </span>
-                <span
+                <button
+                  type="button"
                   className="sb-bible-reader-mobile-header-translation"
+                  aria-label={changeTranslationLabel}
                   onClick={(e: MouseEvent) => {
                     e.stopPropagation();
-                    openTranslationSelector();
+                    void openTranslationSelector();
                   }}
                 >
-                  {translation.value?.shortName ?? translationId.value ?? ""}
-                </span>
+                  {translationLabel}
+                </button>
               </h1>
             </div>
             <ChapterNotesButton
@@ -2270,28 +2281,32 @@ export function BibleReader(props: BibleReaderProps) {
       ) : (
         <>
           <div className="sb-bible-reader-header">
-            <h2
-              {...flingSafeTapHandlers(() => {
-                void selectorState.setOpen(true, currentSlot);
-              })}
-              className="sb-bible-reader-title"
-            >
-              <span className="sb-bible-reader-book">
-                {currentBookName.value ?? bookId.value ?? "Select a book"}
-              </span>
-              <span className="sb-bible-reader-title-sep" aria-hidden="true">
-                {" "}
-              </span>
-              <span className="sb-bible-reader-chapter">
-                {chapterNumber.value}
-              </span>
-              <span className="sb-bible-reader-translation">
-                <span aria-hidden="true">{" / "}</span>
-                <span aria-label={translation.value?.name ?? ""}>
-                  {translationId.value ?? ""}
+            <div className="sb-bible-reader-heading">
+              <h2
+                {...flingSafeTapHandlers(openBookSelector)}
+                className="sb-bible-reader-title"
+              >
+                <span className="sb-bible-reader-book">
+                  {currentBookName.value ?? bookId.value ?? "Select a book"}
                 </span>
-              </span>
-            </h2>
+                <span className="sb-bible-reader-title-sep" aria-hidden="true">
+                  {" "}
+                </span>
+                <span className="sb-bible-reader-chapter">
+                  {chapterNumber.value}
+                </span>
+              </h2>
+              <button
+                type="button"
+                className="sb-bible-reader-translation"
+                aria-label={changeTranslationLabel}
+                onClick={() => {
+                  void openTranslationSelector();
+                }}
+              >
+                {translationLabel}
+              </button>
+            </div>
             {state && (
               <div className="sb-bible-reader-actions">
                 <QuickToolbar

--- a/packages/seed-bible/seed-bible/i18n/en.json
+++ b/packages/seed-bible/seed-bible/i18n/en.json
@@ -189,6 +189,7 @@
   "search-books": "Search books...",
   "no-results-found": "No results found.",
   "information-about-this-translation": "Information about this translation",
+  "change-translation": "Change translation ({{name}})",
   "import": "Import",
   "enter-url": "Enter URL",
   "complete-translations": "Complete translations",

--- a/test/integration/seed-bible/components/TabSlotReader.test.tsx
+++ b/test/integration/seed-bible/components/TabSlotReader.test.tsx
@@ -180,6 +180,7 @@ function createFixture(): ReaderFixture {
 
   const selectorState = {
     setOpen,
+    selectingTranslation: signal(false),
   } as any as BibleSelectorState;
 
   const slot: TabSlot = {

--- a/test/unit/seed-bible/components/BibleReader.test.tsx
+++ b/test/unit/seed-bible/components/BibleReader.test.tsx
@@ -208,6 +208,7 @@ function createFixture(): ReaderFixture {
 
   const selectorState = {
     setOpen,
+    selectingTranslation: signal(false),
   } as any as BibleSelectorState;
 
   const slot: TabSlot = {
@@ -231,8 +232,13 @@ function createFixture(): ReaderFixture {
   };
 }
 
-function createMobileState(): SeedBibleState {
+/**
+ * @param selectorState Wired in as `state.selector` for the mobile chrome's own
+ *   entry points into the Bible selector (the header's translation chip).
+ */
+function createMobileState(selectorState?: BibleSelectorState): SeedBibleState {
   return {
+    selector: selectorState,
     app: {
       isMobile: signal(true),
       effectiveSlots: signal([{ id: "slot-1", tab: null }]),
@@ -369,6 +375,59 @@ describe("BibleReader", () => {
     });
 
     expect(setOpen).toHaveBeenCalledWith(true, slot);
+  });
+
+  it("opens the selector on the book list when the title is clicked, even after the translation picker was left open", () => {
+    const { slot, selectorState, readingState, setOpen } = createFixture();
+    selectorState.selectingTranslation.value = true;
+
+    act(() => {
+      render(
+        <BibleReader
+          currentSlot={slot}
+          selectorState={selectorState}
+          readingState={readingState}
+        />,
+        container
+      );
+    });
+
+    act(() => {
+      container
+        .querySelector(".sb-bible-reader-title")
+        ?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setOpen).toHaveBeenCalledWith(true, slot);
+    expect(selectorState.selectingTranslation.value).toBe(false);
+  });
+
+  it("opens the translation picker from the header's translation button", async () => {
+    const { slot, selectorState, readingState, setOpen } = createFixture();
+
+    act(() => {
+      render(
+        <BibleReader
+          currentSlot={slot}
+          selectorState={selectorState}
+          readingState={readingState}
+        />,
+        container
+      );
+    });
+
+    const button = container.querySelector<HTMLButtonElement>(
+      "button.sb-bible-reader-translation"
+    );
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toBe("BSB");
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setOpen).toHaveBeenCalledWith(true, slot);
+    expect(selectorState.selectingTranslation.value).toBe(true);
   });
 
   it("shows a not-found state and lets the user jump to the translation's first book when the requested book isn't in the book list", () => {
@@ -2772,6 +2831,32 @@ describe("BibleReader", () => {
       accountButton?.querySelector(".sb-tab-user-icon-generic")
     ).not.toBeNull();
     expect(accountButton?.textContent).toContain("account_circle");
+  });
+
+  it("opens the translation picker from the mobile header's translation button", async () => {
+    const { slot, selectorState, readingState, setOpen } = createFixture();
+    const state = createMobileState(selectorState);
+
+    renderMobileReader({ slot, selectorState, readingState }, state, container);
+
+    const button = container.querySelector<HTMLButtonElement>(
+      "button.sb-bible-reader-mobile-header-translation"
+    );
+    expect(button).not.toBeNull();
+    expect(button?.textContent).toBe("BSB");
+    expect(button?.getAttribute("aria-label")).toBe(
+      "Change translation (Berean Standard Bible)"
+    );
+
+    await act(async () => {
+      button?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+    });
+
+    expect(setOpen).toHaveBeenCalledWith(
+      true,
+      expect.objectContaining({ id: "slot-1" })
+    );
+    expect(selectorState.selectingTranslation.value).toBe(true);
   });
 
   it("updates readingState.scrollPosition when the chapter scroller scrolls", () => {


### PR DESCRIPTION
## Summary

Makes the desktop reader header's translation control match the mobile one: the same muted pill, opening the translation picker directly. Both pills are now real buttons, so each is keyboard reachable and announces what it does, and the letters inside them sit optically centred.

## Problem

On desktop the translation was plain text inside the chapter title — `Genesis 1 / BSB` — and the whole `<h2>` opened the *book* list. So nothing signalled the text was a control, there was no way to reach the translation picker from the header at all, and it looked nothing like the pill mobile users see. It also printed the raw `translationId`, which for a translation served from a non-default endpoint is a full URL that would have splattered across the header.

Both pills were `<span>`s with an `onClick`. Neither was in the tab order, Enter and Space did nothing, and assistive tech announced them as ordinary text with no hint they were actionable.

The pill text also sat visibly high. A line box reserves room for descenders that an all-caps abbreviation like `BSB` never uses, and Newsreader — the default book-title font — is an extreme case: it leaves 0.265em below the baseline but only 0.065em above the caps, putting the ink 0.2em (4px at the desktop size) above centre. The other five selectable fonts are all within a pixel, so this reads as "something's subtly off" rather than as an obvious bug.

## Changes

- **`components/BibleReader/BibleReader.tsx`**: the desktop header's title and translation now sit in a `.sb-bible-reader-heading` flex row, with the translation as a `<button>` that calls `openTranslationSelector()`. The title's `<h2>` switches from calling `setOpen` directly to the existing `openBookSelector` helper — without that, opening the picker and dismissing the panel would leave the next title click showing translations instead of books. The mobile chip becomes a `<button>` too, and both take their visible short name and `aria-label` from one pair of values computed beside those two handlers.
- **`components/BibleReader/BibleReader.inline.css`**: one shared rule holds the pill's look for both layouts, with only size per layout, so the two can't drift. Adds hover/`:focus-visible` on desktop and `:active`/`:focus-visible` on mobile, and a `@supports (text-box: trim-both cap alphabetic)` block that trims the line box to the caps and compensates the padding so the pill keeps its size. Trimming is font-agnostic, so it holds for whatever fonts get added later, and browsers without it (Firefox, currently) render exactly what they render today. The block sits after both chips' own rules, since `@supports` adds no specificity.
- **`i18n/en.json`**: adds `change-translation`. English only, per the repo convention.
- **`test/unit/seed-bible/components/BibleReader.test.tsx`**: three regression tests, plus an optional `selectorState` argument to `createMobileState()` so the mobile chrome's own entry points into the selector can be exercised. Existing callers pass nothing and behave exactly as before.

## Test plan

- [x] Three new regression tests, each confirmed red against the pre-change component before being kept
- [x] `BibleReader.test.tsx` 76/76, `TabSlotReader.test.tsx` 31/31, `TutorialManager` + `BibleSelector` 39/39
- [x] `check:ts:client` clean; ESLint and stylelint clean on the touched files; Prettier matches
- [x] Desktop: pill against the title at each reader font size, narrow split pane, dark mode
- [x] Mobile: pill height and press feedback
- [x] Firefox: untrimmed fallback still looks right
- [x] Keyboard: Tab reaches both pills, Enter/Space opens the picker


## Screenshots

### Desktop

_Before:_
<img width="1019" height="780" alt="image" src="https://github.com/user-attachments/assets/408cf347-b273-4a5d-8ac2-84eb07ca9fcc" />

_After:_
<img width="1017" height="783" alt="image" src="https://github.com/user-attachments/assets/28a081dc-256f-46fd-aed1-7efc6c209f76" />

### Mobile

_Before:_
<img width="389" height="785" alt="image" src="https://github.com/user-attachments/assets/bd387227-e75c-4c82-b40d-a60aa7e78153" />

_After:_
<img width="390" height="789" alt="image" src="https://github.com/user-attachments/assets/0704236a-7eab-44af-b60b-0dc02411f0ec" />
