### PR TITLE
Add audio timing support to Bible API and managers

### DIFF
--- a/packages/seed-bible/seed-bible/managers/BibleDataManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/BibleDataManager.tsx
@@ -3,6 +3,7 @@ import { safeLocalStorage } from "../app/ssrEnv";
 import {
   FreeUseBibleAPI,
   type ApiRequestOptions,
+  type AudioTimings,
   type Translation,
   type TranslationBook,
   type TranslationBookChapter,
@@ -111,6 +112,20 @@ export interface BibleDataManager {
     chapter: TranslationBookChapter,
     options?: ApiRequestOptions
   ) => Promise<TranslationBookChapter | null>;
+
+  /**
+   * Loads a single reader's per-verse audio timings for a chapter.
+   *
+   * @param translationId The translation the chapter belongs to, used to
+   * resolve which API endpoint to read the link from.
+   * @param link A URL from that chapter's `thisChapterAudioTimings` (or
+   * `nextChapterAudioTimings`/`previousChapterAudioTimings`) map.
+   */
+  getAudioTimings: (
+    translationId: string,
+    link: string,
+    options?: ApiRequestOptions
+  ) => Promise<AudioTimings>;
 
   /**
    * Gets the API endpoint associated with a given translation. If the translation is not associated with a specific endpoint, it returns the default endpoint.
@@ -1173,6 +1188,15 @@ export function createBibleDataManager(
     return await api.getPreviousChapter(chapter, endpoint, options);
   };
 
+  const getAudioTimings = async (
+    translationId: string,
+    link: string,
+    options?: ApiRequestOptions
+  ): Promise<AudioTimings> => {
+    const endpoint = getEndpointForTranslation(translationId);
+    return await api.getAudioTimings(link, endpoint, options);
+  };
+
   const buildTranslationId = (translationId: string) => {
     const endpoint = getTranslationEndpointInfo(translationId);
     if (endpoint.isDefault) {
@@ -1262,6 +1286,7 @@ export function createBibleDataManager(
     getTranslationBookChapter,
     getNextChapter,
     getPreviousChapter,
+    getAudioTimings,
     getTranslationEndpointInfo,
     buildTranslationId,
     hydrateCachedCatalog,

--- a/packages/seed-bible/seed-bible/managers/FreeUseBibleAPI.tsx
+++ b/packages/seed-bible/seed-bible/managers/FreeUseBibleAPI.tsx
@@ -234,6 +234,13 @@ export interface TranslationBookChapter {
   thisChapterAudioLinks: TranslationBookChapterAudioLinks;
 
   /**
+   * Per-reader links to this chapter's audio-timing files. Fetch one with
+   * {@link FreeUseBibleAPI.getAudioTimings} to get that reader's per-verse
+   * timestamps.
+   */
+  thisChapterAudioTimings: TranslationBookChapterAudioTimingsLinks;
+
+  /**
    * The link to the next chapter.
    * Null if this is the last chapter in the translation.
    */
@@ -246,6 +253,12 @@ export interface TranslationBookChapter {
   nextChapterAudioLinks: TranslationBookChapterAudioLinks | null;
 
   /**
+   * Per-reader links to the next chapter's audio-timing files.
+   * Null if this is the last chapter in the translation.
+   */
+  nextChapterAudioTimings: TranslationBookChapterAudioTimingsLinks | null;
+
+  /**
    * The link to the previous chapter.
    * Null if this is the first chapter in the translation.
    */
@@ -256,6 +269,12 @@ export interface TranslationBookChapter {
    * Null if this is the first chapter in the translation.
    */
   previousChapterAudioLinks: TranslationBookChapterAudioLinks | null;
+
+  /**
+   * Per-reader links to the previous chapter's audio-timing files.
+   * Null if this is the first chapter in the translation.
+   */
+  previousChapterAudioTimings: TranslationBookChapterAudioTimingsLinks | null;
 
   /**
    * The number of verses that the chapter contains.
@@ -472,6 +491,96 @@ export interface TranslationBookChapterAudioLinks {
 }
 
 /**
+ * The audio-timing links for a book chapter, as returned by the per-chapter
+ * endpoint (`api/{translation}/{book}/{chapter}.json`). Unlike
+ * {@link CompleteTranslationChapterAudioTimings}, the timing values
+ * themselves aren't inlined here — each entry is a URL to a separate
+ * `*.audioTimings.json` file (fetch it with
+ * {@link FreeUseBibleAPI.getAudioTimings}) so that the chapter response stays
+ * small when a caller doesn't need timing data.
+ */
+export interface TranslationBookChapterAudioTimingsLinks {
+  /**
+   * The reader for the chapter and the URL link to that reader's
+   * audio-timings file.
+   */
+  [reader: string]: string;
+}
+
+/**
+ * A single reader's per-verse audio timings for one chapter, as returned by
+ * a `*.audioTimings.json` file — the files linked to by
+ * {@link TranslationBookChapterAudioTimingsLinks} and
+ * {@link CompleteTranslationChapterAudioTimings}.
+ */
+export interface AudioTimings {
+  /**
+   * The ID of the translation the chapter belongs to.
+   */
+  translationId: string;
+
+  /**
+   * The ID of the book the chapter belongs to.
+   */
+  bookId: string;
+
+  /**
+   * The number of the chapter.
+   */
+  chapterNumber: number;
+
+  /**
+   * The reader these timings belong to.
+   */
+  reader: string;
+
+  /**
+   * The URL to this reader's audio file for the chapter.
+   */
+  audioLink: string;
+
+  /**
+   * The API link for the current chapter.
+   */
+  thisChapterLink: string;
+
+  /**
+   * The API link for the next chapter.
+   * Null if this is the last chapter in the translation.
+   */
+  nextChapterLink: string | null;
+
+  /**
+   * The API link for the previous chapter.
+   * Null if this is the first chapter in the translation.
+   */
+  previousChapterLink: string | null;
+
+  /**
+   * The link to this file itself.
+   */
+  thisChapterAudioTimingsLink: string;
+
+  /**
+   * The link to the next chapter's audio-timings file for this reader.
+   * Null if this is the last chapter in the translation.
+   */
+  nextChapterAudioTimingsLink: string | null;
+
+  /**
+   * The link to the previous chapter's audio-timings file for this reader.
+   * Null if this is the first chapter in the translation.
+   */
+  previousChapterAudioTimingsLink: string | null;
+
+  /**
+   * One cumulative timestamp (in seconds, from the start of the audio) per
+   * verse, in verse order — the moment that verse's reading ends.
+   */
+  verses: number[];
+}
+
+/**
  * An entire translation — every book and every chapter — as returned by the
  * `api/{translation}/complete.json` endpoint.
  *
@@ -553,9 +662,31 @@ export interface CompleteTranslationChapter {
   thisChapterAudioLinks: TranslationBookChapterAudioLinks;
 
   /**
+   * Per-reader audio timings for the chapter. Unlike
+   * {@link TranslationBookChapterAudioTimingsLinks}, the timing values are
+   * inlined directly here rather than linked to a separate file — the
+   * complete-translation download is meant to be self-contained for offline
+   * use, so it isn't worth the extra round trip per chapter per reader.
+   */
+  thisChapterAudioTimings: CompleteTranslationChapterAudioTimings;
+
+  /**
    * The information for the chapter.
    */
   chapter: ChapterData;
+}
+
+/**
+ * Per-verse audio timings for a book chapter, keyed by reader, as returned by
+ * the `complete.json` endpoint.
+ */
+export interface CompleteTranslationChapterAudioTimings {
+  /**
+   * The reader for the chapter, and one cumulative timestamp (in seconds,
+   * from the start of that reader's audio) per verse, in verse order — the
+   * moment that verse's reading ends.
+   */
+  [reader: string]: number[];
 }
 
 /**
@@ -1366,6 +1497,23 @@ export class FreeUseBibleAPI {
       endpoint,
       options
     );
+  }
+
+  /**
+   * Fetches a single reader's per-verse audio timings for a chapter.
+   *
+   * @param link A URL from a chapter's `thisChapterAudioTimings` (or
+   * `nextChapterAudioTimings`/`previousChapterAudioTimings`) map — e.g.
+   * `/api/AAB/GEN/1.david.audioTimings.json`. Relative links are resolved
+   * against `endpoint` the same way every other request path is.
+   * @param endpoint The endpoint to read from. Defaults to this API's endpoint.
+   */
+  async getAudioTimings(
+    link: string,
+    endpoint?: string,
+    options?: ApiRequestOptions
+  ): Promise<AudioTimings> {
+    return this._getJson<AudioTimings>(link, endpoint, options);
   }
 
   private _getJson<T>(

--- a/packages/seed-bible/seed-bible/managers/OfflineTranslationsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/OfflineTranslationsManager.tsx
@@ -960,6 +960,10 @@ export function createOfflineTranslationsManager(
         chapterNumber
       ),
       thisChapterAudioLinks: stored.thisChapterAudioLinks ?? {},
+      // Audio-timing files are fetched live from the API (see
+      // `FreeUseBibleAPI.getAudioTimings`) rather than stored offline, so a
+      // chapter read from a download never has links to offer here.
+      thisChapterAudioTimings: {},
       nextChapterApiLink: nextRef
         ? chapterApiLink(
             record.endpoint,
@@ -969,6 +973,7 @@ export function createOfflineTranslationsManager(
           )
         : null,
       nextChapterAudioLinks: nextStored?.thisChapterAudioLinks ?? null,
+      nextChapterAudioTimings: nextRef ? {} : null,
       previousChapterApiLink: previousRef
         ? chapterApiLink(
             record.endpoint,
@@ -978,6 +983,7 @@ export function createOfflineTranslationsManager(
           )
         : null,
       previousChapterAudioLinks: previousStored?.thisChapterAudioLinks ?? null,
+      previousChapterAudioTimings: previousRef ? {} : null,
       numberOfVerses: stored.numberOfVerses,
       chapter: stored.chapter,
     };

--- a/test/integration/seed-bible/components/TabSlotReader.test.tsx
+++ b/test/integration/seed-bible/components/TabSlotReader.test.tsx
@@ -80,10 +80,13 @@ function createFixture(): ReaderFixture {
     },
     thisChapterLink: "/api/BSB/GEN/1.json",
     thisChapterAudioLinks: {},
+    thisChapterAudioTimings: {},
     nextChapterApiLink: "/api/BSB/GEN/2.json",
     nextChapterAudioLinks: {},
+    nextChapterAudioTimings: {},
     previousChapterApiLink: null,
     previousChapterAudioLinks: null,
+    previousChapterAudioTimings: null,
     numberOfVerses: 2,
     chapter: {
       number: 1,

--- a/test/unit/seed-bible/components/BibleReader.test.tsx
+++ b/test/unit/seed-bible/components/BibleReader.test.tsx
@@ -85,10 +85,13 @@ function createFixture(): ReaderFixture {
     },
     thisChapterLink: "/api/BSB/GEN/1.json",
     thisChapterAudioLinks: {},
+    thisChapterAudioTimings: {},
     nextChapterApiLink: "/api/BSB/GEN/2.json",
     nextChapterAudioLinks: {},
+    nextChapterAudioTimings: {},
     previousChapterApiLink: null,
     previousChapterAudioLinks: null,
+    previousChapterAudioTimings: null,
     numberOfVerses: 2,
     chapter: {
       number: 1,

--- a/test/unit/seed-bible/managers/BibleDataManager.test.ts
+++ b/test/unit/seed-bible/managers/BibleDataManager.test.ts
@@ -20,6 +20,7 @@ import {
   EXAMPLE_API_ENDPOINT,
   bsbBooks,
   createResponse,
+  makeAudioTimings,
   makeChapter,
   nivBooks,
   translations,
@@ -236,6 +237,33 @@ describe("createBibleDataManager", () => {
     );
     expect(webGetMock).toHaveBeenCalledWith(
       makeEndpointUrl(ALT_ENDPOINT, "api/NIV/MAT/1.json"),
+      expect.anything()
+    );
+  });
+
+  it("getAudioTimings() resolves the link against the translation's endpoint", async () => {
+    const altNiv = createAltNivTranslation();
+    const timingsPayload = makeAudioTimings("NIV", "MAT", 1, "david");
+
+    const responses: WebResponseMap = {
+      [makeEndpointUrl(ALT_ENDPOINT, "api/available_translations.json")]:
+        createResponse({ translations: [altNiv] }),
+      [makeEndpointUrl(ALT_ENDPOINT, "api/NIV/MAT/1.david.audioTimings.json")]:
+        createResponse(timingsPayload),
+    };
+
+    setWebResponses(responses);
+    const manager = createManager();
+    await manager.getTranslations(ALT_ENDPOINT);
+
+    const result = await manager.getAudioTimings(
+      "NIV",
+      "/api/NIV/MAT/1.david.audioTimings.json"
+    );
+
+    expect(result).toEqual(timingsPayload);
+    expect(webGetMock).toHaveBeenCalledWith(
+      makeEndpointUrl(ALT_ENDPOINT, "api/NIV/MAT/1.david.audioTimings.json"),
       expect.anything()
     );
   });

--- a/test/unit/seed-bible/managers/FreeUseBibleAPI.test.ts
+++ b/test/unit/seed-bible/managers/FreeUseBibleAPI.test.ts
@@ -237,6 +237,67 @@ describe("FreeUseBibleAPI", () => {
     );
   });
 
+  it("fetches a reader's audio timings from a chapter's link", async () => {
+    const payload = {
+      translationId: "AAB",
+      bookId: "GEN",
+      chapterNumber: 1,
+      reader: "david",
+      audioLink:
+        "https://audio.bible.helloao.org/api/BSB/GEN/1/audio/david.mp3",
+      thisChapterLink: "/api/AAB/GEN/1.json",
+      nextChapterLink: "/api/AAB/GEN/2.json",
+      previousChapterLink: null,
+      thisChapterAudioTimingsLink: "/api/AAB/GEN/1.david.audioTimings.json",
+      nextChapterAudioTimingsLink: "/api/AAB/GEN/2.david.audioTimings.json",
+      previousChapterAudioTimingsLink: null,
+      verses: [8.056, 11.288, 19.514],
+    };
+    fetchMock.mockResolvedValue(createResponse(payload));
+
+    const api = new FreeUseBibleAPI(FREE_USE_BIBLE_API_ENDPOINT);
+    const result = await api.getAudioTimings(
+      "/api/AAB/GEN/1.david.audioTimings.json"
+    );
+
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://bible.helloao.org/api/AAB/GEN/1.david.audioTimings.json",
+      expect.anything()
+    );
+  });
+
+  it("uses endpoint override for audio timings links", async () => {
+    const payload = {
+      translationId: "AAB",
+      bookId: "GEN",
+      chapterNumber: 1,
+      reader: "david",
+      audioLink:
+        "https://audio.bible.helloao.org/api/BSB/GEN/1/audio/david.mp3",
+      thisChapterLink: "/api/AAB/GEN/1.json",
+      nextChapterLink: "/api/AAB/GEN/2.json",
+      previousChapterLink: null,
+      thisChapterAudioTimingsLink: "/api/AAB/GEN/1.david.audioTimings.json",
+      nextChapterAudioTimingsLink: "/api/AAB/GEN/2.david.audioTimings.json",
+      previousChapterAudioTimingsLink: null,
+      verses: [8.056, 11.288, 19.514],
+    };
+    fetchMock.mockResolvedValue(createResponse(payload));
+
+    const api = new FreeUseBibleAPI("https://default.example/");
+    const result = await api.getAudioTimings(
+      "/api/AAB/GEN/1.david.audioTimings.json",
+      "https://override.example"
+    );
+
+    expect(result).toEqual(payload);
+    expect(fetchMock).toHaveBeenCalledWith(
+      "https://override.example/api/AAB/GEN/1.david.audioTimings.json",
+      expect.anything()
+    );
+  });
+
   it("caches in-flight requests by URL", async () => {
     const payload = { translations: [{ id: "eng_kjv" }] };
     fetchMock.mockResolvedValue(createResponse(payload));

--- a/test/unit/seed-bible/managers/testUtils/mockBibleApiData.ts
+++ b/test/unit/seed-bible/managers/testUtils/mockBibleApiData.ts
@@ -1,4 +1,5 @@
 import type {
+  AudioTimings,
   AvailableTranslations,
   ChapterData,
   CompleteTranslation,
@@ -439,6 +440,9 @@ export function makeCompleteTranslation(
         thisChapterAudioLinks: {
           reader: `https://audio.example/${book.id}/${index + 1}.mp3`,
         },
+        thisChapterAudioTimings: {
+          reader: [1.5, 3],
+        },
         chapter: {
           number: index + 1,
           content: [
@@ -491,13 +495,16 @@ export function makeChapter(
     book: selectedBook,
     thisChapterLink: `/api/${translationBooks.translation.id}/${book}/${chapter}.json`,
     thisChapterAudioLinks: {},
+    thisChapterAudioTimings: {},
     nextChapterApiLink: `/api/${translationBooks.translation.id}/${book}/${chapter + 1}.json`,
     nextChapterAudioLinks: {},
+    nextChapterAudioTimings: {},
     previousChapterApiLink:
       chapter > 1
         ? `/api/${translationBooks.translation.id}/${book}/${chapter - 1}.json`
         : null,
     previousChapterAudioLinks: chapter > 1 ? {} : null,
+    previousChapterAudioTimings: chapter > 1 ? {} : null,
     numberOfVerses: 2,
     chapter: {
       number: chapter,
@@ -507,6 +514,34 @@ export function makeChapter(
       ],
       footnotes: [],
     },
+  };
+}
+
+export function makeAudioTimings(
+  translationId: string,
+  book: string,
+  chapter: number,
+  reader: string,
+  overrides: Partial<AudioTimings> = {}
+): AudioTimings {
+  return {
+    translationId,
+    bookId: book,
+    chapterNumber: chapter,
+    reader,
+    audioLink: `https://audio.example/${book}/${chapter}/${reader}.mp3`,
+    thisChapterLink: `/api/${translationId}/${book}/${chapter}.json`,
+    nextChapterLink: `/api/${translationId}/${book}/${chapter + 1}.json`,
+    previousChapterLink:
+      chapter > 1 ? `/api/${translationId}/${book}/${chapter - 1}.json` : null,
+    thisChapterAudioTimingsLink: `/api/${translationId}/${book}/${chapter}.${reader}.audioTimings.json`,
+    nextChapterAudioTimingsLink: `/api/${translationId}/${book}/${chapter + 1}.${reader}.audioTimings.json`,
+    previousChapterAudioTimingsLink:
+      chapter > 1
+        ? `/api/${translationId}/${book}/${chapter - 1}.${reader}.audioTimings.json`
+        : null,
+    verses: [1.5, 3],
+    ...overrides,
   };
 }
 


### PR DESCRIPTION
## Summary

This change adds support for per-verse audio timings across the Bible API and data managers. Audio timings are timestamps (in seconds) marking when each verse ends in a reader's audio file, enabling features like synchronized highlighting during playback.

## Key Changes

- **New API interfaces and method:**
  - `AudioTimings` — represents a single reader's per-verse timings for one chapter (fetched from `*.audioTimings.json` files)
  - `TranslationBookChapterAudioTimingsLinks` — maps reader names to timing file URLs in chapter responses
  - `CompleteTranslationChapterAudioTimings` — inlines timing values directly in complete-translation downloads (for offline use)
  - `FreeUseBibleAPI.getAudioTimings()` — fetches a reader's timing file from a given link

- **Updated chapter data structures:**
  - `TranslationBookChapter` now includes `thisChapterAudioTimings`, `nextChapterAudioTimings`, and `previousChapterAudioTimings` (links to timing files)
  - `CompleteTranslationChapter` now includes `thisChapterAudioTimings` (inlined timing values)

- **Manager support:**
  - `BibleDataManager.getAudioTimings()` resolves timing links against the correct translation endpoint
  - `OfflineTranslationsManager` returns empty timing links for offline chapters (timings are fetched live, not stored)

- **Test coverage:**
  - Unit tests for `FreeUseBibleAPI.getAudioTimings()` with endpoint override support
  - Unit tests for `BibleDataManager.getAudioTimings()` endpoint resolution
  - Mock data helper `makeAudioTimings()` for test fixtures
  - Updated existing test fixtures to include the new timing fields

## Implementation Details

Timing files are kept separate from chapter responses (linked rather than inlined) to keep chapter payloads small when timing data isn't needed. The complete-translation download is an exception — it inlines timings for all readers to remain self-contained for offline use, avoiding extra round trips per chapter per reader.

Offline translations never provide timing links, since timings are fetched live from the API rather than stored in downloads.

https://claude.ai/code/session_01NNTNnkmZkQ7xGgDb5e7Vdx