### PR TITLE
fix: collapsed sidebar tab list scrolls instead of overflowing

### DIFF
--- a/packages/seed-bible/seed-bible/components/SidebarSearch/SidebarSearch.css
+++ b/packages/seed-bible/seed-bible/components/SidebarSearch/SidebarSearch.css
@@ -127,6 +127,7 @@
   position: relative;
   width: 3.3125rem;
   height: 3.3125rem;
+  flex-shrink: 0;
   border-radius: 0.625rem;
   background: var(--sb-tab-background);
   color: var(--sb-tab-font-color);

--- a/packages/seed-bible/seed-bible/components/Tabs/Tabs.css
+++ b/packages/seed-bible/seed-bible/components/Tabs/Tabs.css
@@ -657,6 +657,15 @@
   flex-direction: column;
   align-items: center;
   gap: 0.5rem;
+  flex: 1 1 auto;
+  min-height: 0;
+  overflow-y: auto;
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none;
+  /* The tiles are slightly wider than this list's padded content box, and
+     overflow-y: auto forces overflow-x to clip too — without this, that
+     clips the tiles' rounded left/right edges. */
+  margin-inline: -0.10625rem;
 }
 
 .sb-sidebar-settings-view {
@@ -1168,6 +1177,7 @@
   &.sb-collapsed-tab-add-button {
     width: 3.3125rem;
     height: 3.3125rem;
+    flex-shrink: 0;
   }
 }
 


### PR DESCRIPTION
The collapsed sidebar's tab list didn't scroll, so tiles below the fold were unreachable once you had enough tabs open, and now it scrolls like the expanded list does. Fixing that also required stopping the tiles and the "new tab" button from getting flex-squashed to fit, and compensating for a side-effect where enabling vertical scroll made the browser start clipping the tiles' rounded corners on the left/right.

_Before:_
<img width="761" height="789" alt="image" src="https://github.com/user-attachments/assets/36d96ad1-8435-40ff-bd22-2839de1ebd13" />

_After:_
<img width="767" height="793" alt="image" src="https://github.com/user-attachments/assets/6ab93f4e-b0e2-4970-aa35-bfa482ba78e9" />
