### PR TITLE
Strip existing query params from customization share links

### DIFF
--- a/packages/seed-bible/seed-bible/managers/CustomizationsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/CustomizationsManager.tsx
@@ -1503,7 +1503,7 @@ export function createCustomizationsManager(
 
   const getShareLink = (customization: SeedBibleCustomization): string => {
     const recordName = login.userId.value ?? "";
-    return navigation.linkToQuery({
+    return navigation.linkToBareQuery({
       customization: buildCustomizationLocator(recordName, customization.id),
     });
   };

--- a/packages/seed-bible/seed-bible/managers/CustomizationsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/CustomizationsManager.tsx
@@ -1503,7 +1503,7 @@ export function createCustomizationsManager(
 
   const getShareLink = (customization: SeedBibleCustomization): string => {
     const recordName = login.userId.value ?? "";
-    return navigation.linkToBareQuery({
+    return navigation.linkToBareRoot({
       customization: buildCustomizationLocator(recordName, customization.id),
     });
   };

--- a/packages/seed-bible/seed-bible/managers/NavigationManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/NavigationManager.tsx
@@ -438,6 +438,23 @@ export function createNavigationManager(
     return url.toString();
   };
 
+  /**
+   * Like `linkToQuery`, but drops every existing query parameter first —
+   * for links that should carry only the parameters passed in (e.g. a
+   * customization share link), not whatever the current page happens to
+   * have in its URL (language, translation, book, chapter, ...).
+   */
+  const linkToBareQuery = (query: Record<string, string | null>) => {
+    const url = new URL(currentUrl.value);
+    url.search = "";
+    for (const [key, value] of Object.entries(query)) {
+      if (value !== null) {
+        url.searchParams.set(key, value);
+      }
+    }
+    return url.toString();
+  };
+
   return {
     currentUrl: computed(() => currentUrl.value),
     initialUrl,
@@ -451,6 +468,7 @@ export function createNavigationManager(
     updatePathAndQueryParams,
     syncSignalsToUrl,
     linkToQuery,
+    linkToBareQuery,
     dispose,
   };
 }

--- a/packages/seed-bible/seed-bible/managers/NavigationManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/NavigationManager.tsx
@@ -439,13 +439,18 @@ export function createNavigationManager(
   };
 
   /**
-   * Like `linkToQuery`, but drops every existing query parameter first —
-   * for links that should carry only the parameters passed in (e.g. a
+   * Like `linkToQuery`, but drops the current URL entirely first, keeping
+   * only the origin and the deployment root (`basePath`, or "/") — for
+   * links that should carry only the parameters passed in (e.g. a
    * customization share link), not whatever the current page happens to
-   * have in its URL (language, translation, book, chapter, ...).
+   * have. The reading position (language, translation, book, chapter) lives
+   * in the URL *path* now, not the query string — see `ReadingUrlPath.ts` —
+   * so a link that must not leak the sharer's current reading position has
+   * to drop the path too, not just the query.
    */
-  const linkToBareQuery = (query: Record<string, string | null>) => {
+  const linkToBareRoot = (query: Record<string, string | null>) => {
     const url = new URL(currentUrl.value);
+    url.pathname = basePath || "/";
     url.search = "";
     for (const [key, value] of Object.entries(query)) {
       if (value !== null) {
@@ -468,7 +473,7 @@ export function createNavigationManager(
     updatePathAndQueryParams,
     syncSignalsToUrl,
     linkToQuery,
-    linkToBareQuery,
+    linkToBareRoot,
     dispose,
   };
 }

--- a/test/unit/seed-bible/i18n/I18nManager.test.ts
+++ b/test/unit/seed-bible/i18n/I18nManager.test.ts
@@ -60,6 +60,7 @@ describe("I18nManager getInitialLanguage()", () => {
       batchWrites: vi.fn((fn: () => unknown) => fn()),
       updateQueryParam: vi.fn(),
       linkToQuery: vi.fn(),
+      linkToBareQuery: vi.fn(),
       updateQueryParams: vi.fn(),
       updatePathAndQueryParams: vi.fn(),
       dispose: vi.fn(),
@@ -194,6 +195,7 @@ describe("I18nManager language fallback prompt", () => {
       updateQueryParams: vi.fn(),
       updatePathAndQueryParams: vi.fn(),
       linkToQuery: vi.fn(),
+      linkToBareQuery: vi.fn(),
       dispose: vi.fn(),
     } as NavigationManager;
     manager = createI18nManager(nav, ["en"]);
@@ -250,6 +252,7 @@ describe("I18nManager UI language switch prompt", () => {
       updateQueryParams: vi.fn(),
       updatePathAndQueryParams: vi.fn(),
       linkToQuery: vi.fn(),
+      linkToBareQuery: vi.fn(),
       dispose: vi.fn(),
       batchWrites: vi.fn((fn: () => unknown) => fn()),
     } as NavigationManager;

--- a/test/unit/seed-bible/i18n/I18nManager.test.ts
+++ b/test/unit/seed-bible/i18n/I18nManager.test.ts
@@ -60,7 +60,7 @@ describe("I18nManager getInitialLanguage()", () => {
       batchWrites: vi.fn((fn: () => unknown) => fn()),
       updateQueryParam: vi.fn(),
       linkToQuery: vi.fn(),
-      linkToBareQuery: vi.fn(),
+      linkToBareRoot: vi.fn(),
       updateQueryParams: vi.fn(),
       updatePathAndQueryParams: vi.fn(),
       dispose: vi.fn(),
@@ -195,7 +195,7 @@ describe("I18nManager language fallback prompt", () => {
       updateQueryParams: vi.fn(),
       updatePathAndQueryParams: vi.fn(),
       linkToQuery: vi.fn(),
-      linkToBareQuery: vi.fn(),
+      linkToBareRoot: vi.fn(),
       dispose: vi.fn(),
     } as NavigationManager;
     manager = createI18nManager(nav, ["en"]);
@@ -252,7 +252,7 @@ describe("I18nManager UI language switch prompt", () => {
       updateQueryParams: vi.fn(),
       updatePathAndQueryParams: vi.fn(),
       linkToQuery: vi.fn(),
-      linkToBareQuery: vi.fn(),
+      linkToBareRoot: vi.fn(),
       dispose: vi.fn(),
       batchWrites: vi.fn((fn: () => unknown) => fn()),
     } as NavigationManager;

--- a/test/unit/seed-bible/managers/CustomizationsManager.test.ts
+++ b/test/unit/seed-bible/managers/CustomizationsManager.test.ts
@@ -1327,6 +1327,19 @@ describe("CustomizationsManager", () => {
     expect(link).toBe(`http://localhost/?customization=user-1.${created.id}`);
   });
 
+  it("getShareLink() strips other query params (language, translation, book, chapter, ...) from the current URL, keeping only customization", async () => {
+    const nav = createNavigationManager({
+      initialHref:
+        "http://localhost/?language=en&translation=BSB&book=GEN&chapter=1&foo=bar",
+    });
+    const { manager } = createManager(nav);
+    const created = await manager.create();
+
+    const link = manager.getShareLink(created);
+
+    expect(link).toBe(`http://localhost/?customization=user-1.${created.id}`);
+  });
+
   it("addEditingVariant() appends a new variant to the draft, based on the viewer's current preset with no overrides of its own", async () => {
     const { manager, theme } = createManager();
     const created = await manager.create();

--- a/test/unit/seed-bible/managers/CustomizationsManager.test.ts
+++ b/test/unit/seed-bible/managers/CustomizationsManager.test.ts
@@ -1327,7 +1327,7 @@ describe("CustomizationsManager", () => {
     expect(link).toBe(`http://localhost/?customization=user-1.${created.id}`);
   });
 
-  it("getShareLink() strips other query params (language, translation, book, chapter, ...) from the current URL, keeping only customization", async () => {
+  it("getShareLink() strips legacy reading-position query params (language, translation, book, chapter, ...) from the current URL, keeping only customization", async () => {
     const nav = createNavigationManager({
       initialHref:
         "http://localhost/?language=en&translation=BSB&book=GEN&chapter=1&foo=bar",
@@ -1338,6 +1338,35 @@ describe("CustomizationsManager", () => {
     const link = manager.getShareLink(created);
 
     expect(link).toBe(`http://localhost/?customization=user-1.${created.id}`);
+  });
+
+  it("getShareLink() drops the sharer's reading position from the URL path too, keeping only customization", async () => {
+    // The reading position (language, translation, book, chapter) lives in
+    // the path now, not the query string — see ReadingUrlPath.ts.
+    const nav = createNavigationManager({
+      initialHref: "http://localhost/en/BSB/genesis/1?foo=bar",
+    });
+    const { manager } = createManager(nav);
+    const created = await manager.create();
+
+    const link = manager.getShareLink(created);
+
+    expect(link).toBe(`http://localhost/?customization=user-1.${created.id}`);
+  });
+
+  it("getShareLink() keeps the deployment's basePath prefix while dropping the reading position", async () => {
+    const nav = createNavigationManager({
+      initialHref: "http://localhost/b/some-branch/en/BSB/genesis/1",
+      basePath: "/b/some-branch",
+    });
+    const { manager } = createManager(nav);
+    const created = await manager.create();
+
+    const link = manager.getShareLink(created);
+
+    expect(link).toBe(
+      `http://localhost/b/some-branch?customization=user-1.${created.id}`
+    );
   });
 
   it("addEditingVariant() appends a new variant to the draft, based on the viewer's current preset with no overrides of its own", async () => {

--- a/test/unit/seed-bible/managers/NavigationManager.test.ts
+++ b/test/unit/seed-bible/managers/NavigationManager.test.ts
@@ -279,6 +279,71 @@ describe("createNavigationManager batchWrites", () => {
   });
 });
 
+describe("createNavigationManager linkToBareQuery", () => {
+  it("builds a link with only the given params, dropping the current URL's existing ones", () => {
+    const navigation = createNavigationManager({
+      initialHref:
+        "http://localhost/genesis/1?language=en&translation=BSB&book=GEN&chapter=1",
+    });
+
+    const link = navigation.linkToBareQuery({ customization: "user-1.abc" });
+
+    expect(link).toBe("http://localhost/genesis/1?customization=user-1.abc");
+  });
+
+  it("keeps the pathname (including basePath) unchanged", () => {
+    const navigation = createNavigationManager({
+      initialHref: "http://localhost/b/some-branch/genesis/1?book=GEN",
+      basePath: "/b/some-branch",
+    });
+
+    const link = navigation.linkToBareQuery({ foo: "bar" });
+
+    expect(link).toBe("http://localhost/b/some-branch/genesis/1?foo=bar");
+  });
+
+  it("sets multiple params when given multiple keys", () => {
+    const navigation = createNavigationManager({
+      initialHref: "http://localhost/?stale=1",
+    });
+
+    const link = navigation.linkToBareQuery({ a: "1", b: "2" });
+
+    expect(link).toBe("http://localhost/?a=1&b=2");
+  });
+
+  it("omits keys whose value is null", () => {
+    const navigation = createNavigationManager({
+      initialHref: "http://localhost/?stale=1",
+    });
+
+    const link = navigation.linkToBareQuery({ a: "1", b: null });
+
+    expect(link).toBe("http://localhost/?a=1");
+  });
+
+  it("produces a bare origin+path link when every given value is null", () => {
+    const navigation = createNavigationManager({
+      initialHref: "http://localhost/genesis/1?stale=1",
+    });
+
+    const link = navigation.linkToBareQuery({ a: null });
+
+    expect(link).toBe("http://localhost/genesis/1");
+  });
+
+  it("does not mutate currentUrl", () => {
+    const navigation = createNavigationManager({
+      initialHref: "http://localhost/?book=GEN&chapter=1",
+    });
+    const hrefBefore = navigation.currentUrl.value.href;
+
+    navigation.linkToBareQuery({ customization: "user-1.abc" });
+
+    expect(navigation.currentUrl.value.href).toBe(hrefBefore);
+  });
+});
+
 describe("createNavigationManager nested batchWrites", () => {
   it("flushes once, when the outermost batch ends", () => {
     const navigation = createNavigationManager();

--- a/test/unit/seed-bible/managers/NavigationManager.test.ts
+++ b/test/unit/seed-bible/managers/NavigationManager.test.ts
@@ -279,66 +279,77 @@ describe("createNavigationManager batchWrites", () => {
   });
 });
 
-describe("createNavigationManager linkToBareQuery", () => {
-  it("builds a link with only the given params, dropping the current URL's existing ones", () => {
+describe("createNavigationManager linkToBareRoot", () => {
+  it("resets the path to root and drops query params, keeping only the given ones", () => {
     const navigation = createNavigationManager({
-      initialHref:
-        "http://localhost/genesis/1?language=en&translation=BSB&book=GEN&chapter=1",
+      initialHref: "http://localhost/en/BSB/genesis/1?foo=bar",
     });
 
-    const link = navigation.linkToBareQuery({ customization: "user-1.abc" });
+    const link = navigation.linkToBareRoot({ customization: "user-1.abc" });
 
-    expect(link).toBe("http://localhost/genesis/1?customization=user-1.abc");
+    expect(link).toBe("http://localhost/?customization=user-1.abc");
   });
 
-  it("keeps the pathname (including basePath) unchanged", () => {
+  it('resets the path to basePath, not "/", when a deployment prefix is set', () => {
     const navigation = createNavigationManager({
-      initialHref: "http://localhost/b/some-branch/genesis/1?book=GEN",
+      initialHref: "http://localhost/b/some-branch/en/BSB/genesis/1",
       basePath: "/b/some-branch",
     });
 
-    const link = navigation.linkToBareQuery({ foo: "bar" });
+    const link = navigation.linkToBareRoot({ customization: "user-1.abc" });
 
-    expect(link).toBe("http://localhost/b/some-branch/genesis/1?foo=bar");
+    expect(link).toBe(
+      "http://localhost/b/some-branch?customization=user-1.abc"
+    );
+  });
+
+  it("resets the path even when the current URL is already at root", () => {
+    const navigation = createNavigationManager({
+      initialHref: "http://localhost/?language=en&translation=BSB",
+    });
+
+    const link = navigation.linkToBareRoot({ customization: "user-1.abc" });
+
+    expect(link).toBe("http://localhost/?customization=user-1.abc");
   });
 
   it("sets multiple params when given multiple keys", () => {
     const navigation = createNavigationManager({
-      initialHref: "http://localhost/?stale=1",
+      initialHref: "http://localhost/en/BSB/genesis/1",
     });
 
-    const link = navigation.linkToBareQuery({ a: "1", b: "2" });
+    const link = navigation.linkToBareRoot({ a: "1", b: "2" });
 
     expect(link).toBe("http://localhost/?a=1&b=2");
   });
 
   it("omits keys whose value is null", () => {
     const navigation = createNavigationManager({
-      initialHref: "http://localhost/?stale=1",
+      initialHref: "http://localhost/en/BSB/genesis/1",
     });
 
-    const link = navigation.linkToBareQuery({ a: "1", b: null });
+    const link = navigation.linkToBareRoot({ a: "1", b: null });
 
     expect(link).toBe("http://localhost/?a=1");
   });
 
-  it("produces a bare origin+path link when every given value is null", () => {
+  it("produces a bare origin+root link when every given value is null", () => {
     const navigation = createNavigationManager({
-      initialHref: "http://localhost/genesis/1?stale=1",
+      initialHref: "http://localhost/en/BSB/genesis/1?stale=1",
     });
 
-    const link = navigation.linkToBareQuery({ a: null });
+    const link = navigation.linkToBareRoot({ a: null });
 
-    expect(link).toBe("http://localhost/genesis/1");
+    expect(link).toBe("http://localhost/");
   });
 
   it("does not mutate currentUrl", () => {
     const navigation = createNavigationManager({
-      initialHref: "http://localhost/?book=GEN&chapter=1",
+      initialHref: "http://localhost/en/BSB/genesis/1",
     });
     const hrefBefore = navigation.currentUrl.value.href;
 
-    navigation.linkToBareQuery({ customization: "user-1.abc" });
+    navigation.linkToBareRoot({ customization: "user-1.abc" });
 
     expect(navigation.currentUrl.value.href).toBe(hrefBefore);
   });


### PR DESCRIPTION
getShareLink() built on linkToQuery(), which starts from the current
page URL and only adds/overwrites the given params — so the share link
carried whatever the current page happened to have (language,
translation, book, chapter, etc.) in addition to the customization
param. Add linkToBareQuery(), which clears the URL's search params
before applying the given ones, and use it for the share link so it
only ever contains ?customization=....

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UUCbSXQxUXYKanfuTE2dSH