### PR TITLE
feat: Show where other people are reading in a shared session (#1692)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ✨ Added
 
+- See where everyone else is reading in a shared session. Each other participant gets a slim coloured bar beside the text spanning the verses on their screen, with their avatar on it, so you can tell at a glance whether they are with you or still a few verses back. Before this, the only clue was watching their highlights appear. ([#1692](https://github.com/HelloAOLab/seed-bible/issues/1692))
+
 ### 🔧 Changed
 
 ### 🐛 Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 ### ✨ Added
 
-- See where everyone else is reading in a shared session. Each other participant gets a slim coloured bar beside the text spanning the verses on their screen, with their avatar on it, so you can tell at a glance whether they are with you or still a few verses back. Before this, the only clue was watching their highlights appear. ([#1692](https://github.com/HelloAOLab/seed-bible/issues/1692))
+- See where everyone else is reading in a shared session. Each other participant gets a slim coloured bar beside the text spanning the verses on their screen, with their avatar on it, so you can tell at a glance whether they are with you or still a few verses back. The bars glide along as people move, and two people on the same verses stand side by side rather than one hiding the other. Before this, the only clue was watching their highlights appear. ([#1692](https://github.com/HelloAOLab/seed-bible/issues/1692))
 
 ### 🔧 Changed
 

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
@@ -498,8 +498,13 @@
   font-size: 1em;
 
   /* Covers dimming and un-dimming via `.sb-chapter-content-stale` (see below).
-     Short enough to read as immediate rather than as an animation. */
-  transition: opacity 0.1s ease;
+     Short enough to read as immediate rather than as an animation. The indent
+     is here too: it opens for the session presence gutter and widens as people
+     gather on the same verses (see `.sb-chapter-content-presence`), and the
+     text should move with them rather than reflow in a jump. */
+  transition:
+    opacity 0.1s ease,
+    padding-inline-start 0.35s ease;
 
   /* Positioning context + own stacking context so the highlight ribbon layer
      can sit behind the scripture text (z-index: -1) without slipping behind the
@@ -707,7 +712,14 @@
  * this chapter, so a solo reader keeps the full text width.
  */
 .sb-chapter-content.sb-chapter-content-presence {
-  --sb-presence-gutter-width: 1.5rem;
+  --sb-presence-lane-width: 1.5rem;
+
+  /* One lane per bar that has to stand beside another (`--sb-presence-lanes`
+     comes from the measured markers); a session reading in different places
+     needs only the one. */
+  --sb-presence-gutter-width: calc(
+    var(--sb-presence-lanes, 1) * var(--sb-presence-lane-width)
+  );
 
   padding-inline-start: calc(var(--sb-presence-gutter-width) + 0.25rem);
 }
@@ -721,13 +733,47 @@
 }
 
 /* Placed against measured line boxes: from the top of the first verse the
-   participant can see to the bottom of the last. */
+   participant can see to the bottom of the last.
+
+   A peer's whole scroll arrives as a single update once they come to rest, so
+   without a transition the bar teleports down the page. Gliding to the new
+   verses reads as somebody moving instead. A marker that has just appeared has
+   no previous position to travel from and none is invented: it fades in where
+   its owner is (`@starting-style` below), and the same fade covers the remount
+   on a chapter change, which the key in BibleReader.tsx forces so a bar can't
+   glide across a page whose text was replaced under it. */
 .sb-presence-marker {
   position: absolute;
-  inset-inline: 0;
+  inset-inline-start: calc(
+    var(--sb-presence-marker-lane, 0) * var(--sb-presence-lane-width)
+  );
+  width: var(--sb-presence-lane-width);
   display: flex;
   align-items: center;
   justify-content: center;
+  opacity: 1;
+  transition:
+    top 0.35s ease,
+    height 0.35s ease,
+    inset-inline-start 0.35s ease,
+    opacity 0.25s ease;
+}
+
+@starting-style {
+  .sb-presence-marker {
+    opacity: 0;
+  }
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .sb-presence-marker {
+    transition: none;
+  }
+
+  /* Keep the stale-content fade, drop the gutter's reflow. */
+  .sb-chapter-content {
+    transition: opacity 0.1s ease;
+  }
 }
 
 .sb-presence-range {

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
@@ -698,6 +698,60 @@
   cursor: pointer;
 }
 
+/* -------------------------------------------------------- session presence */
+
+/*
+ * Where the other people in a shared session are reading (#1692). Each one
+ * gets a thin bar down the start edge of the reader spanning the verses they
+ * can see, with their avatar on it. Only drawn when there is somebody else in
+ * this chapter, so a solo reader keeps the full text width.
+ */
+.sb-chapter-content.sb-chapter-content-presence {
+  --sb-presence-gutter-width: 1.5rem;
+
+  padding-inline-start: calc(var(--sb-presence-gutter-width) + 0.25rem);
+}
+
+.sb-presence-gutter {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 0;
+  width: var(--sb-presence-gutter-width);
+  pointer-events: none;
+}
+
+/* Placed against measured line boxes: from the top of the first verse the
+   participant can see to the bottom of the last. */
+.sb-presence-marker {
+  position: absolute;
+  inset-inline: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.sb-presence-range {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-start: 50%;
+  width: 2px;
+  border-radius: 1px;
+  transform: translateX(-50%);
+  /* Softer than the avatar so several overlapping ranges stay readable. */
+  opacity: 0.55;
+}
+
+.sb-presence-avatar {
+  position: relative;
+  display: flex;
+  font-size: 0.625rem;
+}
+
+.sb-presence-avatar .sb-tab-user-icon {
+  width: 1.25rem;
+  height: 1.25rem;
+}
+
 .sb-verse-number .material-symbols-outlined {
   font-size: 1em;
 }

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
@@ -17,12 +17,7 @@ import {
   useLayoutEffect,
   useState,
 } from "preact/compat";
-import {
-  computed,
-  useComputed,
-  type ReadonlySignal,
-  type Signal,
-} from "@preact/signals";
+import { computed, type ReadonlySignal, type Signal } from "@preact/signals";
 import {
   adjacentInlineRect,
   buildRibbonPath,
@@ -1344,6 +1339,13 @@ interface PresenceMarker {
   /** Offset from the top of the chapter content box, in px. */
   top: number;
   height: number;
+  /**
+   * Which column of the gutter this bar sits in. People reading the same
+   * verses would otherwise be drawn on top of each other, hiding everyone but
+   * whoever was painted last, so bars whose spans overlap are dealt out into
+   * side-by-side lanes. Zero whenever nobody overlaps.
+   */
+  lane: number;
 }
 
 interface ChapterContentProps {
@@ -1670,6 +1672,10 @@ function ChapterContent(props: ChapterContentProps) {
   // Signature of the last markers written to state, so the measure -> setState
   // -> re-render -> measure cycle settles instead of looping.
   const presenceSignatureRef = useRef("");
+  const presenceLaneCount = presenceMarkers.reduce(
+    (widest, marker) => Math.max(widest, marker.lane + 1),
+    1
+  );
 
   // A participant's bar spans from the top of the first verse they can see to
   // the bottom of the last, measured from the live line boxes so it follows
@@ -1703,14 +1709,34 @@ function ChapterContent(props: ChapterContentProps) {
           visual: participant.visual,
           top,
           height: bottom - top,
+          lane: 0,
         });
       }
+    }
+
+    // Deal the bars into lanes so people reading the same verses stand beside
+    // each other instead of hiding one another. Taking them top-down and
+    // putting each in the first lane whose previous occupant has already ended
+    // uses no more columns than there are people genuinely overlapping at once,
+    // so the common case of a session spread through a chapter still draws a
+    // single-column gutter. Ties break on connection id to keep a lane from
+    // changing hands between two bars that start on the same line.
+    next.sort(
+      (a, b) => a.top - b.top || a.connectionId.localeCompare(b.connectionId)
+    );
+    const laneBottoms: number[] = [];
+    for (const marker of next) {
+      const bottom = marker.top + marker.height;
+      const free = laneBottoms.findIndex((end) => marker.top >= end);
+      const lane = free === -1 ? laneBottoms.length : free;
+      laneBottoms[lane] = Math.max(laneBottoms[lane] ?? 0, bottom);
+      marker.lane = lane;
     }
 
     const signature = next
       .map(
         (m) =>
-          `${m.connectionId}:${Math.round(m.top)}:${Math.round(m.height)}:${m.imageUrl ?? ""}`
+          `${m.connectionId}:${Math.round(m.top)}:${Math.round(m.height)}:${m.lane}:${m.imageUrl ?? ""}`
       )
       .join("|");
     if (signature === presenceSignatureRef.current) return;
@@ -1775,6 +1801,10 @@ function ChapterContent(props: ChapterContentProps) {
         justConvertedSelectionRef.current = false;
       }}
       onPointerUp={selectVersesFromTextSelection}
+      // How many lanes of bars the gutter has to hold. The stylesheet turns it
+      // into both the gutter's width and the indent that keeps the scripture
+      // clear of it, so the text only gives up the room actually in use.
+      style={{ "--sb-presence-lanes": presenceLaneCount }}
     >
       <svg className="sb-highlight-layer" aria-hidden="true">
         {ribbons.map((ribbon) => (
@@ -1802,9 +1832,19 @@ function ChapterContent(props: ChapterContentProps) {
         <div className="sb-presence-gutter" aria-hidden="true">
           {presenceMarkers.map((marker) => (
             <div
-              key={marker.connectionId}
+              // Keyed by chapter as well as owner so a navigation gives every
+              // marker a fresh element. Its bar glides between positions within
+              // a chapter (see the transition in the stylesheet), and the whole
+              // page's text is replaced on a navigation — a bar left to travel
+              // from its old verses to its new ones would be gliding across
+              // scripture it was never measured against.
+              key={`${chapterKey}:${marker.connectionId}`}
               className="sb-presence-marker"
-              style={{ top: `${marker.top}px`, height: `${marker.height}px` }}
+              style={{
+                top: `${marker.top}px`,
+                height: `${marker.height}px`,
+                "--sb-presence-marker-lane": marker.lane,
+              }}
             >
               <span
                 className="sb-presence-range"
@@ -1920,30 +1960,33 @@ export function BibleReader(props: BibleReaderProps) {
   // reading the same chapter can be placed against verses on this page, and
   // this reader is never its own marker. Outside a session the list is empty
   // and no gutter is drawn at all.
-  const presence = useComputed<ParticipantPresence[]>(() => {
-    if (!sharedSession) {
-      return [];
-    }
+  //
+  // Built in the render body rather than in a `useComputed`: the session
+  // arrives as a prop, and a memoised computed that returns early on a null one
+  // subscribes to no signal at all, which leaves it permanently un-dirtied. A
+  // reader that first rendered outside a session and was then handed one (a
+  // session tab replacing a plain tab in the same slot reuses the component)
+  // would keep answering "nobody" for the rest of its life. Reading the signals
+  // here subscribes this component to them directly, which survives that prop
+  // change.
+  const presence: ParticipantPresence[] = [];
+  const presenceBookId = bookId.value;
+  const presenceChapterNumber = chapterNumber.value;
+  if (sharedSession && presenceBookId && presenceChapterNumber > 0) {
     const positions = sharedSession.participantPositions.value;
-    const currentBookId = bookId.value;
-    const currentChapterNumber = chapterNumber.value;
-    if (!currentBookId || currentChapterNumber <= 0) {
-      return [];
-    }
-    const markers: ParticipantPresence[] = [];
     for (const user of sharedSession.connectedUsers.value) {
       if (user.isSelf) continue;
       const position = positions.get(user.connectionId);
       if (
         !position ||
-        position.bookId !== currentBookId ||
-        position.chapterNumber !== currentChapterNumber ||
+        position.bookId !== presenceBookId ||
+        position.chapterNumber !== presenceChapterNumber ||
         position.firstVerse === undefined ||
         position.lastVerse === undefined
       ) {
         continue;
       }
-      markers.push({
+      presence.push({
         connectionId: user.connectionId,
         displayName: getUserDisplayName(user),
         imageUrl: user.profile?.pictureUrl ?? null,
@@ -1952,8 +1995,7 @@ export function BibleReader(props: BibleReaderProps) {
         lastVerse: position.lastVerse,
       });
     }
-    return markers;
-  }).value;
+  }
 
   // Stable identity so the observer in ChapterContent isn't torn down and
   // rebuilt on every render of the reader.

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
@@ -11,12 +11,18 @@ import {
 } from "preact";
 import {
   Suspense,
+  useCallback,
   useEffect,
   useRef,
   useLayoutEffect,
   useState,
 } from "preact/compat";
-import { computed, type ReadonlySignal, type Signal } from "@preact/signals";
+import {
+  computed,
+  useComputed,
+  type ReadonlySignal,
+  type Signal,
+} from "@preact/signals";
 import {
   adjacentInlineRect,
   buildRibbonPath,
@@ -29,6 +35,7 @@ import type {
   BibleReadingState,
   BibleSelectedVerse,
   VerseDecoration,
+  VisibleVerseRange,
 } from "../../managers/BibleReadingManager";
 import type {
   ChapterHighlight,
@@ -43,7 +50,11 @@ import {
   type Annotation,
   type AnnotationsManager,
 } from "../../managers/AnnotationsManager";
-import type { BibleReadingSession } from "../../managers/SessionsManager";
+import type {
+  BibleReadingSession,
+  ConnectionSessionUserVisual,
+} from "../../managers/SessionsManager";
+import { Avatar, getUserDisplayName } from "../Avatar/Avatar";
 import { useI18n } from "../../i18n/I18nManager";
 import { MobileSettingsSheet } from "../../components/MobileSettingsSheet/MobileSettingsSheet";
 import { MobileSessionParticipants } from "../../components/SessionParticipants/SessionParticipants";
@@ -1310,6 +1321,31 @@ const CHAPTER_SKELETON_PARAGRAPHS = [
   ["95%", "96%", "98%", "89%", "68%"],
 ] as const;
 
+/**
+ * One other participant's place in this chapter, ready to draw: the verses
+ * they can see plus what identifies them. Built in the reader from the shared
+ * session and measured into a bar by ChapterContent (#1692).
+ */
+export interface ParticipantPresence {
+  connectionId: string;
+  displayName: string;
+  imageUrl: string | null;
+  visual: ConnectionSessionUserVisual;
+  firstVerse: number;
+  lastVerse: number;
+}
+
+/** A presence bar, placed against measured line boxes. */
+interface PresenceMarker {
+  connectionId: string;
+  displayName: string;
+  imageUrl: string | null;
+  visual: ConnectionSessionUserVisual;
+  /** Offset from the top of the chapter content box, in px. */
+  top: number;
+  height: number;
+}
+
 interface ChapterContentProps {
   chapterData: Signal<TranslationBookChapter | null>;
   chapterDataPromise: Promise<void>;
@@ -1337,6 +1373,16 @@ interface ChapterContentProps {
    * the chapter they navigated to arrives.
    */
   isStale?: boolean;
+  /**
+   * Other participants reading this same chapter in a shared session, drawn as
+   * bars beside the text. Empty outside a session.
+   */
+  presence?: ParticipantPresence[];
+  /**
+   * Called as the reader scrolls with the span of verses on screen, or null
+   * when none are. Drives the presence this client publishes.
+   */
+  onVisibleVersesChange?: (range: VisibleVerseRange | null) => void;
 }
 
 function ChapterContent(props: ChapterContentProps) {
@@ -1354,6 +1400,8 @@ function ChapterContent(props: ChapterContentProps) {
     justConvertedSelectionRef,
     scriptureElements,
     onAnnotationVerseClick,
+    presence,
+    onVisibleVersesChange,
   } = props;
 
   const currentChapter = chapterData.value;
@@ -1570,14 +1618,118 @@ function ChapterContent(props: ChapterContentProps) {
     setRibbons(result);
   };
 
+  const chapterKey = currentChapter
+    ? `${currentChapter.translation.id}:${currentChapter.book.id}:${currentChapter.chapter.number}`
+    : "";
+
+  // What this reader can see, reported as it scrolls. An IntersectionObserver
+  // rather than a scroll listener: it only wakes when a verse crosses the edge
+  // of the viewport, so a scroll doesn't measure every verse on every frame.
+  // Re-armed per chapter, because the verse elements are replaced wholesale.
+  useEffect(() => {
+    const content = contentRef.current;
+    if (
+      !content ||
+      !onVisibleVersesChange ||
+      typeof IntersectionObserver === "undefined"
+    ) {
+      return;
+    }
+
+    const visible = new Set<number>();
+    const observer = new IntersectionObserver((entries) => {
+      for (const entry of entries) {
+        const verseNumber = Number(
+          (entry.target as HTMLElement).dataset.verseNumber ?? NaN
+        );
+        if (!Number.isFinite(verseNumber)) continue;
+        if (entry.isIntersecting) {
+          visible.add(verseNumber);
+        } else {
+          visible.delete(verseNumber);
+        }
+      }
+      onVisibleVersesChange(
+        visible.size === 0
+          ? null
+          : { first: Math.min(...visible), last: Math.max(...visible) }
+      );
+    });
+    for (const el of content.querySelectorAll<HTMLElement>(
+      ".sb-verse[data-verse-number]"
+    )) {
+      observer.observe(el);
+    }
+    return () => {
+      observer.disconnect();
+      onVisibleVersesChange(null);
+    };
+  }, [chapterKey, onVisibleVersesChange]);
+
+  const [presenceMarkers, setPresenceMarkers] = useState<PresenceMarker[]>([]);
+  // Signature of the last markers written to state, so the measure -> setState
+  // -> re-render -> measure cycle settles instead of looping.
+  const presenceSignatureRef = useRef("");
+
+  // A participant's bar spans from the top of the first verse they can see to
+  // the bottom of the last, measured from the live line boxes so it follows
+  // the text however it wraps.
+  const measurePresence = () => {
+    const content = contentRef.current;
+    if (!content) return;
+
+    const next: PresenceMarker[] = [];
+    if (presence && presence.length > 0) {
+      const box = content.getBoundingClientRect();
+      for (const participant of presence) {
+        const firstEl = content.querySelector<HTMLElement>(
+          `.sb-verse[data-verse-number="${participant.firstVerse}"]`
+        );
+        const lastEl = content.querySelector<HTMLElement>(
+          `.sb-verse[data-verse-number="${participant.lastVerse}"]`
+        );
+        const firstRects = firstEl?.getClientRects();
+        const lastRects = lastEl?.getClientRects();
+        const firstRect = firstRects?.[0];
+        const lastRect = lastRects?.[lastRects.length - 1];
+        if (!firstRect || !lastRect) continue;
+        const top = firstRect.top - box.top;
+        const bottom = lastRect.bottom - box.top;
+        if (bottom <= top) continue;
+        next.push({
+          connectionId: participant.connectionId,
+          displayName: participant.displayName,
+          imageUrl: participant.imageUrl,
+          visual: participant.visual,
+          top,
+          height: bottom - top,
+        });
+      }
+    }
+
+    const signature = next
+      .map(
+        (m) =>
+          `${m.connectionId}:${Math.round(m.top)}:${Math.round(m.height)}:${m.imageUrl ?? ""}`
+      )
+      .join("|");
+    if (signature === presenceSignatureRef.current) return;
+    presenceSignatureRef.current = signature;
+    setPresenceMarkers(next);
+  };
+
   useLayoutEffect(() => {
     measureRibbons();
+    measurePresence();
   });
 
   useLayoutEffect(() => {
     const content = contentRef.current;
     if (!content || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => measureRibbons());
+    const observer = new ResizeObserver(() => {
+      measureRibbons();
+      measurePresence();
+    });
     observer.observe(content);
     return () => observer.disconnect();
   }, []);
@@ -1616,6 +1768,8 @@ function ChapterContent(props: ChapterContentProps) {
       ref={contentRef}
       className={`sb-chapter-content${
         props.isStale ? " sb-chapter-content-stale" : ""
+      }${
+        presenceMarkers.length > 0 ? " sb-chapter-content-presence" : ""
       } ${containerClasses}`}
       onPointerDown={() => {
         justConvertedSelectionRef.current = false;
@@ -1644,6 +1798,29 @@ function ChapterContent(props: ChapterContentProps) {
           />
         ))}
       </svg>
+      {presenceMarkers.length > 0 && (
+        <div className="sb-presence-gutter" aria-hidden="true">
+          {presenceMarkers.map((marker) => (
+            <div
+              key={marker.connectionId}
+              className="sb-presence-marker"
+              style={{ top: `${marker.top}px`, height: `${marker.height}px` }}
+            >
+              <span
+                className="sb-presence-range"
+                style={{ background: marker.visual.color }}
+              />
+              <span className="sb-presence-avatar">
+                <Avatar
+                  imageUrl={marker.imageUrl}
+                  visual={marker.visual}
+                  title={marker.displayName}
+                />
+              </span>
+            </div>
+          ))}
+        </div>
+      )}
       {renderChapterContent(
         chapterData.value,
         (verse, event) => {
@@ -1738,6 +1915,58 @@ export function BibleReader(props: BibleReaderProps) {
   );
 
   const isMobile = state?.app.isMobile.value ?? false;
+
+  // Where the other people in this session are (#1692). Only participants
+  // reading the same chapter can be placed against verses on this page, and
+  // this reader is never its own marker. Outside a session the list is empty
+  // and no gutter is drawn at all.
+  const presence = useComputed<ParticipantPresence[]>(() => {
+    if (!sharedSession) {
+      return [];
+    }
+    const positions = sharedSession.participantPositions.value;
+    const currentBookId = bookId.value;
+    const currentChapterNumber = chapterNumber.value;
+    if (!currentBookId || currentChapterNumber <= 0) {
+      return [];
+    }
+    const markers: ParticipantPresence[] = [];
+    for (const user of sharedSession.connectedUsers.value) {
+      if (user.isSelf) continue;
+      const position = positions.get(user.connectionId);
+      if (
+        !position ||
+        position.bookId !== currentBookId ||
+        position.chapterNumber !== currentChapterNumber ||
+        position.firstVerse === undefined ||
+        position.lastVerse === undefined
+      ) {
+        continue;
+      }
+      markers.push({
+        connectionId: user.connectionId,
+        displayName: getUserDisplayName(user),
+        imageUrl: user.profile?.pictureUrl ?? null,
+        visual: user.visual,
+        firstVerse: position.firstVerse,
+        lastVerse: position.lastVerse,
+      });
+    }
+    return markers;
+  }).value;
+
+  // Stable identity so the observer in ChapterContent isn't torn down and
+  // rebuilt on every render of the reader.
+  const reportVisibleVerses = useCallback(
+    (range: VisibleVerseRange | null) => {
+      const current = readingState.visibleVerseRange.peek();
+      if (current?.first === range?.first && current?.last === range?.last) {
+        return;
+      }
+      readingState.visibleVerseRange.value = range;
+    },
+    [readingState]
+  );
 
   // Clicking an annotated verse number jumps straight to its note: on
   // mobile, it also selects the verse (like clicking its text does) and
@@ -2074,6 +2303,8 @@ export function BibleReader(props: BibleReaderProps) {
               selectFootnote={selectFootnote}
               scriptureElements={scriptureElements}
               onAnnotationVerseClick={handleAnnotationVerseClick}
+              presence={presence}
+              onVisibleVersesChange={reportVisibleVerses}
             />
           </Suspense>
         ))}

--- a/packages/seed-bible/seed-bible/managers/BibleReadingManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/BibleReadingManager.tsx
@@ -202,6 +202,12 @@ export interface VerseDecorationInput {
  * Consumers should observe `loading`/`error` and read `chapterData`/`translationBooks`
  * signals to know when content is ready.
  */
+/** A span of verses on screen, lowest to highest. */
+export interface VisibleVerseRange {
+  first: number;
+  last: number;
+}
+
 export interface BibleReadingState {
   /** The default translation for the current language. */
   defaultTranslation: TranslationWithLanguage;
@@ -302,6 +308,14 @@ export interface BibleReadingState {
    * expand and scroll to it, then cleared.
    */
   pendingAnnotationScrollVerse: Signal<number | null>;
+
+  /**
+   * The span of verses currently on screen in this reader, lowest to highest,
+   * or null before anything has been measured. Written by the reader as it
+   * scrolls and read by SessionsManager, which broadcasts it so peers can see
+   * whereabouts in the chapter this reader is (#1692).
+   */
+  visibleVerseRange: Signal<VisibleVerseRange | null>;
 
   /**
    * Toggles a verse in the current selection.
@@ -1344,6 +1358,7 @@ export function createBibleReadingState(
   const scrollPosition = signal<number>(0);
   const scrollToVerse = signal<number | null>(null);
   const pendingAnnotationScrollVerse = signal<number | null>(null);
+  const visibleVerseRange = signal<VisibleVerseRange | null>(null);
 
   // Reading-extension enablement (per reading state). Extensions are registered
   // globally on the BibleReadingExtensionManager but never enabled by default;
@@ -3233,6 +3248,7 @@ export function createBibleReadingState(
     selectedVerses,
     selectionAnnotations,
     pendingAnnotationScrollVerse,
+    visibleVerseRange,
     selectedFootnote,
     loading,
     error,

--- a/packages/seed-bible/seed-bible/managers/SessionsManager.tsx
+++ b/packages/seed-bible/seed-bible/managers/SessionsManager.tsx
@@ -231,6 +231,14 @@ function sharedUserProfileEntriesMatch(
 export interface ParticipantReadingPosition {
   bookId: string;
   chapterNumber: number;
+  /**
+   * The lowest and highest verse numbers on screen in that participant's
+   * reader, when they have reported them. Absent for a participant whose
+   * reader hasn't measured a range yet (and for entries written before this
+   * existed), so callers must treat the position as chapter-only.
+   */
+  firstVerse?: number;
+  lastVerse?: number;
 }
 
 function parseParticipantReadingPosition(
@@ -241,7 +249,14 @@ function parseParticipantReadingPosition(
   const bookId = toStringOrNull(record.bookId);
   const chapterNumber = toPositiveIntOrNull(record.chapterNumber);
   if (!bookId || chapterNumber === null) return null;
-  return { bookId, chapterNumber };
+  const firstVerse = toPositiveIntOrNull(record.firstVerse);
+  const lastVerse = toPositiveIntOrNull(record.lastVerse);
+  // A half-written range says nothing, so both ends have to be there and in
+  // order before it is reported.
+  if (firstVerse === null || lastVerse === null || lastVerse < firstVerse) {
+    return { bookId, chapterNumber };
+  }
+  return { bookId, chapterNumber, firstVerse, lastVerse };
 }
 
 /**
@@ -256,6 +271,17 @@ function parseParticipantReadingPosition(
  * feels immediate to everyone else.
  */
 const PUBLISH_DEBOUNCE_MS = 150;
+
+/**
+ * How long to wait after the visible verse range settles before publishing it.
+ *
+ * Longer than the navigation debounce because scrolling changes the range
+ * continuously: a flick through a chapter would otherwise write an entry for
+ * every verse it passed into a document that never shrinks. Half a second
+ * turns a scroll gesture into one write of where the reader stopped, which is
+ * all a presence marker needs.
+ */
+const RANGE_PUBLISH_DEBOUNCE_MS = 500;
 
 const DEFAULT_SESSION_OPTIONS: SessionOptions = {
   allowedNavigators: null,
@@ -758,6 +784,10 @@ async function createBibleReadingSession(
   let publishTimer: ReturnType<typeof setTimeout> | null = null;
   /** Armed while our own reading position is waiting to be broadcast. */
   let positionBroadcastTimer: ReturnType<typeof setTimeout> | null = null;
+  // What the debounce above last saw, so a chapter change can be told apart
+  // from a scroll within the same chapter and given the shorter window.
+  let lastBroadcastBookId: string | null = null;
+  let lastBroadcastChapter = 0;
   let remoteClientsVersion = 0;
   let applyingRemoteDecorations = false;
   let applyingRemoteExtensions = false;
@@ -1159,19 +1189,30 @@ async function createBibleReadingSession(
     if (!bookId || chapterNumber <= 0) {
       return;
     }
+    const range = readingState.visibleVerseRange.value;
+    const next: ParticipantReadingPosition = range
+      ? {
+          bookId,
+          chapterNumber,
+          firstVerse: range.first,
+          lastVerse: range.last,
+        }
+      : { bookId, chapterNumber };
     const currentEntry = parseParticipantReadingPosition(
       readingPositionsMap.get(localConnectionId)
     );
     if (
       currentEntry &&
-      currentEntry.bookId === bookId &&
-      currentEntry.chapterNumber === chapterNumber
+      currentEntry.bookId === next.bookId &&
+      currentEntry.chapterNumber === next.chapterNumber &&
+      currentEntry.firstVerse === next.firstVerse &&
+      currentEntry.lastVerse === next.lastVerse
     ) {
       return;
     }
     try {
       document.transact(() => {
-        readingPositionsMap.set(localConnectionId, { bookId, chapterNumber });
+        readingPositionsMap.set(localConnectionId, next);
       });
     } catch {
       // Best-effort — peers keep the last position we managed to publish.
@@ -1180,20 +1221,32 @@ async function createBibleReadingSession(
 
   // Deliberately not gated on `userCanNavigate` the way `stopSync` is: this
   // says where we are, which a participant who may not move the session is
-  // still entitled to report. Debounced on the same window so skimming
-  // chapters leaves one entry rather than one per chapter in a document that
-  // never shrinks. `scrollToVerse` is deliberately not read — presence is
-  // chapter-grained, and tracking it would rewrite the entry on every scroll.
+  // still entitled to report. Debounced so skimming chapters leaves one entry
+  // rather than one per chapter in a document that never shrinks.
+  //
+  // A scroll gets the longer window: the visible verse range changes far more
+  // often than the chapter does, and peers only need where the reader came to
+  // rest.
   const stopBroadcastLocalPosition = effect(() => {
     void readingState.bookId.value;
     void readingState.chapterNumber.value;
+    const rangeChanged = readingState.visibleVerseRange.value;
+    void rangeChanged;
+    const isNavigation =
+      lastBroadcastBookId !== readingState.bookId.peek() ||
+      lastBroadcastChapter !== readingState.chapterNumber.peek();
+    lastBroadcastBookId = readingState.bookId.peek();
+    lastBroadcastChapter = readingState.chapterNumber.peek();
     if (positionBroadcastTimer !== null) {
       clearTimeout(positionBroadcastTimer);
     }
-    positionBroadcastTimer = setTimeout(() => {
-      positionBroadcastTimer = null;
-      broadcastLocalPosition();
-    }, PUBLISH_DEBOUNCE_MS);
+    positionBroadcastTimer = setTimeout(
+      () => {
+        positionBroadcastTimer = null;
+        broadcastLocalPosition();
+      },
+      isNavigation ? PUBLISH_DEBOUNCE_MS : RANGE_PUBLISH_DEBOUNCE_MS
+    );
   });
 
   const readingPositionsSubscription = readingPositionsMap.changes.subscribe(

--- a/test/integration/seed-bible/components/TabSlotReader.test.tsx
+++ b/test/integration/seed-bible/components/TabSlotReader.test.tsx
@@ -7,6 +7,7 @@ import {
 } from "@packages/seed-bible/seed-bible/components/TabsLayout";
 import type {
   BibleReadingState,
+  VisibleVerseRange,
   SelectedFootnote,
   VerseDecoration,
 } from "@packages/seed-bible/seed-bible/managers/BibleReadingManager";
@@ -179,6 +180,7 @@ function createFixture(): ReaderFixture {
     title: signal<string>(""),
     selectionAnnotations: signal([]),
     pendingAnnotationScrollVerse: signal<number | null>(null),
+    visibleVerseRange: signal<VisibleVerseRange | null>(null),
   } as BibleReadingState;
 
   const selectorState = {

--- a/test/unit/seed-bible/components/BibleReader.test.tsx
+++ b/test/unit/seed-bible/components/BibleReader.test.tsx
@@ -8,6 +8,7 @@ import {
 import { TabSlotReader } from "@packages/seed-bible/seed-bible/components/TabsLayout";
 import {
   type BibleReadingState,
+  type VisibleVerseRange,
   type SelectedFootnote,
   type VerseDecoration,
 } from "@packages/seed-bible/seed-bible/managers/BibleReadingManager";
@@ -207,6 +208,7 @@ function createFixture(): ReaderFixture {
     title: signal<string>("title"),
     selectionAnnotations: signal([]),
     pendingAnnotationScrollVerse: signal<number | null>(null),
+    visibleVerseRange: signal<VisibleVerseRange | null>(null),
   } as BibleReadingState;
 
   const selectorState = {
@@ -2396,6 +2398,265 @@ describe("BibleReader", () => {
 
     expect(state.discover.scrollToVerse.value).toBeNull();
     expect(state.app.openDiscover).toHaveBeenCalledTimes(1);
+  });
+
+  // #1692: in a shared session, each other participant gets a bar down the
+  // side of the reader spanning the verses they can see. jsdom does no layout,
+  // so the line boxes those bars are measured against are stubbed here.
+  describe("session presence", () => {
+    let clientRectsSpy: { mockRestore: () => void } | null = null;
+
+    afterEach(() => {
+      clientRectsSpy?.mockRestore();
+      clientRectsSpy = null;
+      vi.unstubAllGlobals();
+    });
+
+    /** One 24px line box per verse, at the given offsets. */
+    function stubLineBoxes(tops: Record<number, number>) {
+      clientRectsSpy = vi
+        .spyOn(Element.prototype, "getClientRects")
+        .mockImplementation(function (this: Element) {
+          const verseNumber = Number(
+            (this as HTMLElement).dataset?.verseNumber ?? NaN
+          );
+          const top = tops[verseNumber];
+          if (top === undefined) {
+            return [] as unknown as DOMRectList;
+          }
+          const rect = {
+            top,
+            bottom: top + 24,
+            left: 0,
+            right: 100,
+            width: 100,
+            height: 24,
+            x: 0,
+            y: top,
+            toJSON() {},
+          } as DOMRect;
+          return [rect] as unknown as DOMRectList;
+        });
+    }
+
+    const visual = {
+      defaultIcon: "pets",
+      color: "rgb(10, 20, 30)",
+      colorName: "blue",
+    };
+
+    function createSession(
+      users: Array<{
+        connectionId: string;
+        isSelf?: boolean;
+        name?: string;
+        pictureUrl?: string | null;
+      }>,
+      positions: Record<
+        string,
+        {
+          bookId: string;
+          chapterNumber: number;
+          firstVerse?: number;
+          lastVerse?: number;
+        }
+      >
+    ) {
+      return {
+        connectedUsers: signal(
+          users.map((user) => ({
+            connectionId: user.connectionId,
+            userId: user.connectionId,
+            isSelf: user.isSelf ?? false,
+            isActive: true,
+            joinedAtMs: 0,
+            profile: {
+              name: user.name ?? user.connectionId,
+              pictureUrl: user.pictureUrl ?? null,
+            },
+            visual,
+          }))
+        ),
+        participantPositions: signal(new Map(Object.entries(positions))),
+        options: signal({ hostUserId: null, allowedNavigators: [] }),
+      } as any;
+    }
+
+    function renderReader(session: unknown, fixture: ReaderFixture) {
+      act(() => {
+        render(
+          <BibleReader
+            currentSlot={fixture.slot}
+            selectorState={fixture.selectorState}
+            readingState={fixture.readingState}
+            state={createMobileState()}
+            sharedSession={session as any}
+          />,
+          container
+        );
+      });
+    }
+
+    it("draws a bar spanning the verses another participant can see", () => {
+      stubLineBoxes({ 1: 40, 2: 70 });
+      const fixture = createFixture();
+      renderReader(
+        createSession(
+          [
+            { connectionId: "me", isSelf: true },
+            { connectionId: "peer", name: "Mary" },
+          ],
+          {
+            peer: {
+              bookId: "GEN",
+              chapterNumber: 1,
+              firstVerse: 1,
+              lastVerse: 2,
+            },
+          }
+        ),
+        fixture
+      );
+
+      const markers = container.querySelectorAll(".sb-presence-marker");
+      expect(markers).toHaveLength(1);
+      const marker = markers[0] as HTMLElement;
+      // From the top of verse 1's first line to the bottom of verse 2's last.
+      expect(marker.style.top).toBe("40px");
+      expect(marker.style.height).toBe("54px");
+      expect(
+        (marker.querySelector(".sb-presence-range") as HTMLElement).style
+          .background
+      ).toBe("rgb(10, 20, 30)");
+      expect(
+        marker.querySelector(".sb-tab-user-icon")?.getAttribute("title")
+      ).toBe("Mary");
+    });
+
+    it("never draws the reader's own position", () => {
+      stubLineBoxes({ 1: 40, 2: 70 });
+      const fixture = createFixture();
+      renderReader(
+        createSession([{ connectionId: "me", isSelf: true }], {
+          me: { bookId: "GEN", chapterNumber: 1, firstVerse: 1, lastVerse: 2 },
+        }),
+        fixture
+      );
+
+      expect(container.querySelector(".sb-presence-gutter")).toBeNull();
+    });
+
+    // A peer in another chapter has no verses on this page to point at.
+    it("leaves out a participant reading a different chapter", () => {
+      stubLineBoxes({ 1: 40, 2: 70 });
+      const fixture = createFixture();
+      renderReader(
+        createSession([{ connectionId: "peer", name: "Mary" }], {
+          peer: {
+            bookId: "GEN",
+            chapterNumber: 2,
+            firstVerse: 1,
+            lastVerse: 2,
+          },
+        }),
+        fixture
+      );
+
+      expect(container.querySelector(".sb-presence-gutter")).toBeNull();
+    });
+
+    // Positions written before verse ranges existed carry the chapter only.
+    it("leaves out a participant who has not reported a verse range", () => {
+      stubLineBoxes({ 1: 40, 2: 70 });
+      const fixture = createFixture();
+      renderReader(
+        createSession([{ connectionId: "peer", name: "Mary" }], {
+          peer: { bookId: "GEN", chapterNumber: 1 },
+        }),
+        fixture
+      );
+
+      expect(container.querySelector(".sb-presence-gutter")).toBeNull();
+    });
+
+    it("draws no gutter outside a shared session", () => {
+      stubLineBoxes({ 1: 40, 2: 70 });
+      const fixture = createFixture();
+      act(() => {
+        render(
+          <BibleReader
+            currentSlot={fixture.slot}
+            selectorState={fixture.selectorState}
+            readingState={fixture.readingState}
+            state={createMobileState()}
+          />,
+          container
+        );
+      });
+
+      expect(container.querySelector(".sb-presence-gutter")).toBeNull();
+    });
+
+    it("reports the verses on screen so peers can be shown where it is", () => {
+      const observed: Element[] = [];
+      let fire: ((entries: unknown[]) => void) | null = null;
+      vi.stubGlobal(
+        "IntersectionObserver",
+        class {
+          constructor(callback: IntersectionObserverCallback) {
+            fire = (entries) =>
+              callback(
+                entries as IntersectionObserverEntry[],
+                this as unknown as IntersectionObserver
+              );
+          }
+          observe(el: Element) {
+            observed.push(el);
+          }
+          unobserve() {}
+          disconnect() {}
+          takeRecords() {
+            return [];
+          }
+        }
+      );
+
+      const fixture = createFixture();
+      act(() => {
+        render(
+          <BibleReader
+            currentSlot={fixture.slot}
+            selectorState={fixture.selectorState}
+            readingState={fixture.readingState}
+            state={createMobileState()}
+          />,
+          container
+        );
+      });
+
+      expect(observed.length).toBeGreaterThan(0);
+      act(() => {
+        fire?.([
+          { target: observed[0], isIntersecting: true },
+          { target: observed[1], isIntersecting: true },
+        ]);
+      });
+
+      expect(fixture.readingState.visibleVerseRange.value).toEqual({
+        first: 1,
+        last: 2,
+      });
+
+      // Scrolling verse 1 off the top narrows the range rather than keeping a
+      // verse nobody can see any more.
+      act(() => {
+        fire?.([{ target: observed[0], isIntersecting: false }]);
+      });
+      expect(fixture.readingState.visibleVerseRange.value).toEqual({
+        first: 2,
+        last: 2,
+      });
+    });
   });
 
   it("separates adjacent verses with a space when verse numbers are hidden", () => {

--- a/test/unit/seed-bible/components/BibleReader.test.tsx
+++ b/test/unit/seed-bible/components/BibleReader.test.tsx
@@ -2533,6 +2533,104 @@ describe("BibleReader", () => {
       ).toBe("Mary");
     });
 
+    // Two people on the same verses used to be drawn in the same 2px column,
+    // so only whoever was painted last could be seen.
+    it("puts participants reading the same verses in side-by-side lanes", () => {
+      stubLineBoxes({ 1: 40, 2: 70 });
+      const fixture = createFixture();
+      renderReader(
+        createSession(
+          [
+            { connectionId: "me", isSelf: true },
+            { connectionId: "mary", name: "Mary" },
+            { connectionId: "john", name: "John" },
+          ],
+          {
+            mary: {
+              bookId: "GEN",
+              chapterNumber: 1,
+              firstVerse: 1,
+              lastVerse: 2,
+            },
+            john: {
+              bookId: "GEN",
+              chapterNumber: 1,
+              firstVerse: 1,
+              lastVerse: 2,
+            },
+          }
+        ),
+        fixture
+      );
+
+      const lanes = [...container.querySelectorAll(".sb-presence-marker")].map(
+        (marker) => ({
+          who: marker.querySelector(".sb-tab-user-icon")?.getAttribute("title"),
+          lane: (marker as HTMLElement).style.getPropertyValue(
+            "--sb-presence-marker-lane"
+          ),
+        })
+      );
+
+      // Both are on the same verses, so neither may be drawn over the other.
+      expect(lanes.map((entry) => entry.who).sort()).toEqual(["John", "Mary"]);
+      expect(new Set(lanes.map((entry) => entry.lane))).toEqual(
+        new Set(["0", "1"])
+      );
+      // And the text steps aside far enough for both columns.
+      expect(
+        (
+          container.querySelector(".sb-chapter-content-presence") as HTMLElement
+        ).style.getPropertyValue("--sb-presence-lanes")
+      ).toBe("2");
+    });
+
+    // Bars that never overlap share the one lane, so a session spread through a
+    // chapter doesn't push the text aside for columns nobody is standing in.
+    it("keeps participants in separate parts of the chapter in one lane", () => {
+      // Verse 1 ends at 64, verse 2 starts at 70: the two bars never meet.
+      stubLineBoxes({ 1: 40, 2: 70 });
+      const fixture = createFixture();
+      renderReader(
+        createSession(
+          [
+            { connectionId: "me", isSelf: true },
+            { connectionId: "mary", name: "Mary" },
+            { connectionId: "john", name: "John" },
+          ],
+          {
+            mary: {
+              bookId: "GEN",
+              chapterNumber: 1,
+              firstVerse: 1,
+              lastVerse: 1,
+            },
+            john: {
+              bookId: "GEN",
+              chapterNumber: 1,
+              firstVerse: 2,
+              lastVerse: 2,
+            },
+          }
+        ),
+        fixture
+      );
+
+      const lanes = [...container.querySelectorAll(".sb-presence-marker")].map(
+        (marker) =>
+          (marker as HTMLElement).style.getPropertyValue(
+            "--sb-presence-marker-lane"
+          )
+      );
+
+      expect(lanes).toEqual(["0", "0"]);
+      expect(
+        (
+          container.querySelector(".sb-chapter-content-presence") as HTMLElement
+        ).style.getPropertyValue("--sb-presence-lanes")
+      ).toBe("1");
+    });
+
     it("never draws the reader's own position", () => {
       stubLineBoxes({ 1: 40, 2: 70 });
       const fixture = createFixture();
@@ -2595,6 +2693,42 @@ describe("BibleReader", () => {
       });
 
       expect(container.querySelector(".sb-presence-gutter")).toBeNull();
+    });
+
+    // Joining a session hands the already-mounted reader a session it didn't
+    // have: the tab it is rendered in keeps its slot, so the same component
+    // instance goes from no session to one full of people.
+    it("draws the gutter when a reader that started outside a session is given one", () => {
+      stubLineBoxes({ 1: 40, 2: 70 });
+      const fixture = createFixture();
+      renderReader(null, fixture);
+
+      expect(container.querySelector(".sb-presence-gutter")).toBeNull();
+
+      renderReader(
+        createSession(
+          [
+            { connectionId: "me", isSelf: true },
+            { connectionId: "peer", name: "Mary" },
+          ],
+          {
+            peer: {
+              bookId: "GEN",
+              chapterNumber: 1,
+              firstVerse: 1,
+              lastVerse: 2,
+            },
+          }
+        ),
+        fixture
+      );
+
+      const markers = container.querySelectorAll(".sb-presence-marker");
+      expect(markers).toHaveLength(1);
+      const marker = markers[0] as HTMLElement;
+      expect(
+        marker.querySelector(".sb-tab-user-icon")?.getAttribute("title")
+      ).toBe("Mary");
     });
 
     it("reports the verses on screen so peers can be shown where it is", () => {

--- a/test/unit/seed-bible/managers/SessionsManager.test.ts
+++ b/test/unit/seed-bible/managers/SessionsManager.test.ts
@@ -4,7 +4,10 @@ import {
   getUserAnimalVisual,
   type BibleReadingSession,
 } from "@packages/seed-bible/seed-bible/managers/SessionsManager";
-import { createBibleReadingState } from "@packages/seed-bible/seed-bible/managers/BibleReadingManager";
+import {
+  createBibleReadingState,
+  type VisibleVerseRange,
+} from "@packages/seed-bible/seed-bible/managers/BibleReadingManager";
 import type { TranslationBookChapter } from "@packages/seed-bible/seed-bible/managers/FreeUseBibleAPI";
 import type {
   VerseDecoration,
@@ -136,6 +139,7 @@ function createMockReadingState() {
   const bookId = signal<string | null>("GEN");
   const chapterNumber = signal<number>(1);
   const scrollToVerse = signal<number | null>(null);
+  const visibleVerseRange = signal<VisibleVerseRange | null>(null);
   const chapterData = signal<any>(null);
   const decorations = signal<VerseDecoration[]>([]);
 
@@ -197,6 +201,7 @@ function createMockReadingState() {
     bookId,
     chapterNumber,
     scrollToVerse,
+    visibleVerseRange,
     chapterData,
     decorations,
     translationBooks: signal<any>(null),
@@ -299,6 +304,14 @@ function deferred<T>() {
  */
 async function flushPublishDebounce(): Promise<void> {
   await new Promise((resolve) => setTimeout(resolve, 250));
+}
+
+/**
+ * Waits out the longer trailing debounce on publishing the visible verse range
+ * (`RANGE_PUBLISH_DEBOUNCE_MS` in SessionsManager, 500ms).
+ */
+async function flushRangePublishDebounce(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 700));
 }
 
 /**
@@ -2009,6 +2022,130 @@ describe("SessionsManager", () => {
     expect(mockReadingPositionsMap.delete).toHaveBeenCalledWith(
       os.connectionId
     );
+  });
+
+  it("publishes the verses on screen alongside the chapter", async () => {
+    const manager = createSessionsManager(
+      os,
+      mockDataManager as any,
+      mockLoginManager as any,
+      mockHighlightsManager as any,
+      i18n
+    );
+    const session = await manager.joinSession("group-abc");
+
+    await flushPublishDebounce();
+    mockReadingPositionsMap.set.mockClear();
+
+    session.readingState.visibleVerseRange.value = { first: 3, last: 9 };
+    await flushRangePublishDebounce();
+
+    expect(mockReadingPositionsMap.set).toHaveBeenCalledWith(os.connectionId, {
+      bookId: "GEN",
+      chapterNumber: 1,
+      firstVerse: 3,
+      lastVerse: 9,
+    });
+  });
+
+  // Scrolling changes the range continuously, so a settled scroll has to leave
+  // one entry in a document that never shrinks — not one per verse it passed.
+  it("publishes one entry for a scroll that passes several verses", async () => {
+    const manager = createSessionsManager(
+      os,
+      mockDataManager as any,
+      mockLoginManager as any,
+      mockHighlightsManager as any,
+      i18n
+    );
+    const session = await manager.joinSession("group-abc");
+
+    await flushPublishDebounce();
+    mockReadingPositionsMap.set.mockClear();
+
+    for (let first = 1; first <= 5; first++) {
+      session.readingState.visibleVerseRange.value = {
+        first,
+        last: first + 4,
+      };
+    }
+    await flushRangePublishDebounce();
+
+    expect(mockReadingPositionsMap.set).toHaveBeenCalledTimes(1);
+    expect(mockReadingPositionsMap.set).toHaveBeenCalledWith(os.connectionId, {
+      bookId: "GEN",
+      chapterNumber: 1,
+      firstVerse: 5,
+      lastVerse: 9,
+    });
+  });
+
+  it("reports a peer's verse range with their position", async () => {
+    const manager = createSessionsManager(
+      os,
+      mockDataManager as any,
+      mockLoginManager as any,
+      mockHighlightsManager as any,
+      i18n
+    );
+    const session = await manager.joinSession("group-abc");
+
+    mockRemoteClients.emit({
+      type: "client_connected",
+      isSelf: false,
+      client: { connectionId: "conn-1", userId: "user-1" },
+    });
+    await waitFor(() => session.connectedUsers.value.length === 1);
+
+    mockReadingPositionsMap.set("conn-1", {
+      bookId: "REV",
+      chapterNumber: 22,
+      firstVerse: 2,
+      lastVerse: 6,
+    });
+    mockReadingPositionsMap.emitChange();
+    await waitFor(() => session.participantPositions.value.has("conn-1"));
+
+    expect(session.participantPositions.value.get("conn-1")).toEqual({
+      bookId: "REV",
+      chapterNumber: 22,
+      firstVerse: 2,
+      lastVerse: 6,
+    });
+  });
+
+  // A half-written or back-to-front range would draw a marker in the wrong
+  // place, so the chapter is kept and the range dropped.
+  it("keeps the chapter but drops an unusable verse range", async () => {
+    const manager = createSessionsManager(
+      os,
+      mockDataManager as any,
+      mockLoginManager as any,
+      mockHighlightsManager as any,
+      i18n
+    );
+    const session = await manager.joinSession("group-abc");
+
+    mockRemoteClients.emit({
+      type: "client_connected",
+      isSelf: false,
+      client: { connectionId: "conn-1", userId: "user-1" },
+    });
+    await waitFor(() => session.connectedUsers.value.length === 1);
+
+    mockReadingPositionsMap.set("conn-1", {
+      bookId: "REV",
+      chapterNumber: 22,
+      firstVerse: 9,
+      lastVerse: 2,
+    });
+    mockReadingPositionsMap.emitChange();
+    await waitFor(() => session.participantPositions.value.has("conn-1"));
+
+    expect(session.participantPositions.value.get("conn-1")).toEqual({
+      bookId: "REV",
+      chapterNumber: 22,
+    });
   });
 
   it("joins with inactive users seeded from user_profiles map", async () => {


### PR DESCRIPTION
Until now the only clue to where a peer was in a chapter was watching their highlights appear. Each other participant now gets a thin bar down the start edge of the reader, in their session colour, spanning the verses they can see, with their avatar on it.

fixes #1692

- The reader reports the verses on screen through an IntersectionObserver (so a scroll doesn't measure every verse on every frame) into a new `visibleVerseRange` on the reading state.
- SessionsManager publishes that range alongside the chapter it already broadcast. A scroll gets a longer debounce than a navigation: the range changes continuously, and peers only need where the reader came to rest, so a whole scroll gesture leaves one entry in a document that never shrinks.
- A position written without a range (or with a back-to-front one) still reports its chapter, so entries from before this existed keep working.
- Only other participants are drawn, only in the chapter on screen, and no gutter appears outside a session.