### PR TITLE
feat: Show note markers beside the text on mobile (#1691)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@
 
 ### ✨ Added
 
+- See your notes at a glance while reading on a phone. Every verse a note starts on now gets a small note icon beside the text, lined up with its verse number; tapping it selects the verse and opens the note. Previously the only sign a verse had a note was a box around its number, and there was no way to read the note without hunting for it. ([#1691](https://github.com/HelloAOLab/seed-bible/issues/1691))
+
 ### 🔧 Changed
 
 ### 🐛 Fixed

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.inline.css
@@ -698,6 +698,57 @@
   cursor: pointer;
 }
 
+/* ------------------------------------------------------------ note gutter */
+
+/*
+ * Mobile note markers (#1691). Desktop reads its notes in the Discover panel
+ * beside the text; mobile has no such panel, so the markers move into a gutter
+ * at the end edge of the reader. The gutter only appears when the chapter
+ * actually has notes, so an unannotated chapter keeps its full text width.
+ */
+.sb-chapter-content.sb-chapter-content-noted {
+  --sb-note-gutter-width: 1.75rem;
+
+  padding-inline-end: calc(var(--sb-note-gutter-width) + 0.25rem);
+}
+
+/* With a marker in the gutter, the inline one (shown when verse numbers are
+   turned off) would be the same note flagged twice on the same line. */
+.sb-chapter-content-noted .sb-verse-annotation-icon {
+  display: none;
+}
+
+.sb-note-gutter {
+  position: absolute;
+  inset-block: 0;
+  inset-inline-end: 0;
+  width: var(--sb-note-gutter-width);
+  pointer-events: none;
+}
+
+/*
+ * Placed against a measured line box: `top` and `height` come from the first
+ * line rect of the verse the note starts at, which is the line carrying the
+ * verse number — so the icon lines up with it however the text wraps.
+ */
+.sb-note-gutter-marker {
+  position: absolute;
+  inset-inline: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 0;
+  border: none;
+  background: none;
+  color: var(--sb-primary-color);
+  cursor: pointer;
+  pointer-events: auto;
+}
+
+.sb-note-gutter-marker .material-symbols-outlined {
+  font-size: 1.125rem;
+}
+
 .sb-verse-number .material-symbols-outlined {
   font-size: 1em;
 }

--- a/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReader/BibleReader.tsx
@@ -1310,6 +1310,15 @@ const CHAPTER_SKELETON_PARAGRAPHS = [
   ["95%", "96%", "98%", "89%", "68%"],
 ] as const;
 
+/** A note marker in the mobile gutter, placed against a measured line box. */
+interface NoteMarker {
+  verseNumber: number;
+  /** Offset from the top of the chapter content box, in px. */
+  top: number;
+  /** Height of the verse's first line box, so the icon centres on it. */
+  height: number;
+}
+
 interface ChapterContentProps {
   chapterData: Signal<TranslationBookChapter | null>;
   chapterDataPromise: Promise<void>;
@@ -1337,6 +1346,11 @@ interface ChapterContentProps {
    * the chapter they navigated to arrives.
    */
   isStale?: boolean;
+  /**
+   * Mobile has no Discover panel to read notes alongside the text, so the
+   * note markers move out into a gutter beside the scripture there (#1691).
+   */
+  isMobile?: boolean;
 }
 
 function ChapterContent(props: ChapterContentProps) {
@@ -1354,8 +1368,10 @@ function ChapterContent(props: ChapterContentProps) {
     justConvertedSelectionRef,
     scriptureElements,
     onAnnotationVerseClick,
+    isMobile = false,
   } = props;
 
+  const { t } = useI18n();
   const currentChapter = chapterData.value;
   const chapterAnnotations =
     currentChapter && annotations
@@ -1570,14 +1586,72 @@ function ChapterContent(props: ChapterContentProps) {
     setRibbons(result);
   };
 
+  // The verse each note starts at, deduplicated: two notes on the same verse
+  // get one marker, and a note spanning 3-6 marks verse 3 only.
+  const noteVerseNumbers = Array.from(
+    new Set(
+      chapterAnnotations
+        .map((annotation) => {
+          const verses = annotationVerseNumbers(annotation);
+          return verses.length > 0 ? Math.min(...verses) : null;
+        })
+        .filter((verseNumber): verseNumber is number => verseNumber !== null)
+    )
+  ).sort((a, b) => a - b);
+  const showNoteGutter = isMobile && noteVerseNumbers.length > 0;
+
+  const [noteMarkers, setNoteMarkers] = useState<NoteMarker[]>([]);
+  // Signature of the last markers written to state, so the measure -> setState
+  // -> re-render -> measure cycle settles instead of looping.
+  const noteMarkerSignatureRef = useRef("");
+
+  // Where each note marker sits vertically. Markers live in a gutter beside
+  // the text rather than in the flow, so their position has to be measured:
+  // it is the top of the verse's *first* line box, which is the line carrying
+  // the verse number.
+  const measureNoteMarkers = () => {
+    const content = contentRef.current;
+    if (!content) return;
+
+    const next: NoteMarker[] = [];
+    if (showNoteGutter) {
+      const box = content.getBoundingClientRect();
+      for (const verseNumber of noteVerseNumbers) {
+        const verseEl = content.querySelector<HTMLElement>(
+          `.sb-verse[data-verse-number="${verseNumber}"]`
+        );
+        const rect = verseEl?.getClientRects()[0];
+        if (!rect) continue;
+        next.push({
+          verseNumber,
+          top: rect.top - box.top,
+          height: rect.height,
+        });
+      }
+    }
+
+    const signature = next
+      .map(
+        (m) => `${m.verseNumber}:${Math.round(m.top)}:${Math.round(m.height)}`
+      )
+      .join("|");
+    if (signature === noteMarkerSignatureRef.current) return;
+    noteMarkerSignatureRef.current = signature;
+    setNoteMarkers(next);
+  };
+
   useLayoutEffect(() => {
     measureRibbons();
+    measureNoteMarkers();
   });
 
   useLayoutEffect(() => {
     const content = contentRef.current;
     if (!content || typeof ResizeObserver === "undefined") return;
-    const observer = new ResizeObserver(() => measureRibbons());
+    const observer = new ResizeObserver(() => {
+      measureRibbons();
+      measureNoteMarkers();
+    });
     observer.observe(content);
     return () => observer.disconnect();
   }, []);
@@ -1611,12 +1685,26 @@ function ChapterContent(props: ChapterContentProps) {
     .map((d) => d.containerClassName)
     .join(" ");
 
+  // verse number -> full ChapterVerse, so a gutter marker can select its verse
+  // the same way tapping the verse itself does.
+  const verseByNumber = new Map<number, ChapterVerse>();
+  for (const entry of chapterData.value.chapter.content) {
+    if (
+      entry &&
+      typeof entry === "object" &&
+      entry.type === "verse" &&
+      typeof entry.number === "number"
+    ) {
+      verseByNumber.set(entry.number, entry as ChapterVerse);
+    }
+  }
+
   return (
     <div
       ref={contentRef}
       className={`sb-chapter-content${
         props.isStale ? " sb-chapter-content-stale" : ""
-      } ${containerClasses}`}
+      }${showNoteGutter ? " sb-chapter-content-noted" : ""} ${containerClasses}`}
       onPointerDown={() => {
         justConvertedSelectionRef.current = false;
       }}
@@ -1644,6 +1732,38 @@ function ChapterContent(props: ChapterContentProps) {
           />
         ))}
       </svg>
+      {showNoteGutter && (
+        <div className="sb-note-gutter" aria-hidden={noteMarkers.length === 0}>
+          {noteMarkers.map((marker) => (
+            <button
+              key={marker.verseNumber}
+              type="button"
+              className="sb-note-gutter-marker"
+              style={{ top: `${marker.top}px`, height: `${marker.height}px` }}
+              aria-label={t("notes-for-verse", {
+                verse: marker.verseNumber,
+                defaultValue: "Notes for verse {{verse}}",
+              })}
+              onClick={(event: MouseEvent) => {
+                const value = verseByNumber.get(marker.verseNumber);
+                if (!value || !chapterData.value) return;
+                onAnnotationVerseClick(
+                  {
+                    bookId: chapterData.value.book.id,
+                    chapterNumber: chapterData.value.chapter.number,
+                    verse: value,
+                    translationId: chapterData.value.translation.id,
+                  },
+                  marker.verseNumber,
+                  event
+                );
+              }}
+            >
+              <span className="material-symbols-outlined">sticky_note_2</span>
+            </button>
+          ))}
+        </div>
+      )}
       {renderChapterContent(
         chapterData.value,
         (verse, event) => {
@@ -2074,6 +2194,7 @@ export function BibleReader(props: BibleReaderProps) {
               selectFootnote={selectFootnote}
               scriptureElements={scriptureElements}
               onAnnotationVerseClick={handleAnnotationVerseClick}
+              isMobile={isMobile}
             />
           </Suspense>
         ))}

--- a/packages/seed-bible/seed-bible/i18n/en.json
+++ b/packages/seed-bible/seed-bible/i18n/en.json
@@ -796,6 +796,7 @@
   "resume-reading-loading": "Loading your reading history…",
   "selected-year": "Year: {{year}}",
   "this-month": "This month",
+  "notes-for-verse": "Notes for verse {{verse}}",
   "this-week": "This week",
   "unread-mention": "Unread mention",
   "unread-messages": "Unread messages: {{count}}",

--- a/test/unit/seed-bible/components/BibleReader.test.tsx
+++ b/test/unit/seed-bible/components/BibleReader.test.tsx
@@ -2398,6 +2398,156 @@ describe("BibleReader", () => {
     expect(state.app.openDiscover).toHaveBeenCalledTimes(1);
   });
 
+  // #1691: mobile has no Discover panel, so notes are flagged in a gutter
+  // beside the text. jsdom does no layout, so the line boxes the markers are
+  // placed against are stubbed here.
+  describe("note gutter", () => {
+    let clientRectsSpy: { mockRestore: () => void } | null = null;
+
+    afterEach(() => {
+      clientRectsSpy?.mockRestore();
+      clientRectsSpy = null;
+    });
+
+    function stubLineBoxes(tops: Record<number, number>) {
+      clientRectsSpy = vi
+        .spyOn(Element.prototype, "getClientRects")
+        .mockImplementation(function (this: Element) {
+          const verseNumber = Number(
+            (this as HTMLElement).dataset?.verseNumber ?? NaN
+          );
+          const top = tops[verseNumber];
+          if (top === undefined) {
+            return [] as unknown as DOMRectList;
+          }
+          const rect = {
+            top,
+            bottom: top + 24,
+            left: 0,
+            right: 100,
+            width: 100,
+            height: 24,
+            x: 0,
+            y: top,
+            toJSON() {},
+          } as DOMRect;
+          return [rect] as unknown as DOMRectList;
+        });
+    }
+
+    /** A state whose chapter carries the given annotations. */
+    function annotatedState(
+      annotations: Array<Record<string, unknown>>,
+      isMobile = true
+    ): SeedBibleState {
+      const chapterAnnotations = signal(annotations);
+      const state = createMobileState();
+      return {
+        ...state,
+        app: { ...state.app, isMobile: signal(isMobile) },
+        annotations: {
+          getAnnotationsForChapter: vi.fn(() => chapterAnnotations),
+        },
+      } as any as SeedBibleState;
+    }
+
+    function renderReader(state: SeedBibleState, fixture: ReaderFixture) {
+      act(() => {
+        render(
+          <BibleReader
+            currentSlot={fixture.slot}
+            selectorState={fixture.selectorState}
+            readingState={fixture.readingState}
+            state={state}
+          />,
+          container
+        );
+      });
+    }
+
+    const note = (extra: Record<string, unknown> = {}) => ({
+      id: "a1",
+      bookId: "GEN",
+      chapterNumber: 1,
+      verseNumber: 1,
+      data: { type: "comment", html: "<p>Note</p>" },
+      ...extra,
+    });
+
+    it("marks an annotated verse in the gutter, level with its first line", () => {
+      stubLineBoxes({ 1: 40 });
+      const fixture = createFixture();
+      renderReader(annotatedState([note()]), fixture);
+
+      const markers = container.querySelectorAll(".sb-note-gutter-marker");
+      expect(markers).toHaveLength(1);
+      expect((markers[0] as HTMLElement).style.top).toBe("40px");
+      expect(markers[0]?.textContent).toBe("sticky_note_2");
+    });
+
+    it("marks only the first verse of a note that spans several", () => {
+      stubLineBoxes({ 1: 40, 2: 70 });
+      const fixture = createFixture();
+      renderReader(annotatedState([note({ endVerseNumber: 2 })]), fixture);
+
+      const markers = container.querySelectorAll(".sb-note-gutter-marker");
+      expect(markers).toHaveLength(1);
+      expect((markers[0] as HTMLElement).style.top).toBe("40px");
+    });
+
+    it("shows one marker when a verse carries several notes", () => {
+      stubLineBoxes({ 1: 40 });
+      const fixture = createFixture();
+      renderReader(annotatedState([note(), note({ id: "a2" })]), fixture);
+
+      expect(container.querySelectorAll(".sb-note-gutter-marker")).toHaveLength(
+        1
+      );
+    });
+
+    it("leaves the gutter out of a chapter with no notes", () => {
+      stubLineBoxes({ 1: 40 });
+      const fixture = createFixture();
+      renderReader(annotatedState([]), fixture);
+
+      expect(container.querySelector(".sb-note-gutter")).toBeNull();
+      expect(
+        container
+          .querySelector(".sb-chapter-content")
+          ?.classList.contains("sb-chapter-content-noted")
+      ).toBe(false);
+    });
+
+    // Desktop reads its notes in the Discover panel beside the text, so a
+    // second column of markers there would be the same information twice.
+    it("leaves the gutter out on desktop", () => {
+      stubLineBoxes({ 1: 40 });
+      const fixture = createFixture();
+      renderReader(annotatedState([note()], false), fixture);
+
+      expect(container.querySelector(".sb-note-gutter")).toBeNull();
+    });
+
+    it("selects the verse and asks the toolbar to scroll to the note", () => {
+      stubLineBoxes({ 1: 40 });
+      const fixture = createFixture();
+      renderReader(annotatedState([note()]), fixture);
+
+      act(() => {
+        (
+          container.querySelector(".sb-note-gutter-marker") as HTMLButtonElement
+        ).click();
+      });
+
+      expect(fixture.selectVerse).toHaveBeenCalledTimes(1);
+      expect(fixture.selectVerse.mock.calls[0]?.[0]).toMatchObject({
+        bookId: "GEN",
+        chapterNumber: 1,
+      });
+      expect(fixture.readingState.pendingAnnotationScrollVerse.value).toBe(1);
+    });
+  });
+
   it("separates adjacent verses with a space when verse numbers are hidden", () => {
     const { slot, selectorState, readingState, chapterData } = createFixture();
 


### PR DESCRIPTION
Desktop can read its notes in the Discover panel while reading; mobile could not, so the only sign a verse had a note was the box around its verse number.

fixes #1691

Mobile now draws a marker in a gutter at the end edge of the reader for every verse a note begins at. Each marker is placed against the measured first line box of its verse, so it lines up with the verse number however the text wraps. Tapping one does what tapping the boxed number does: selects the verse, expands the verse toolbar and scrolls to the note.

A note spanning several verses marks only the verse it starts at, and a verse with several notes gets one marker. The gutter (and its extra inline padding) only appears when the chapter has notes, so an unannotated chapter keeps its full text width.