### PR TITLE
Fix toolbar menu overflow and floating pane z-index

### DIFF
--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.inline.css
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.inline.css
@@ -220,11 +220,38 @@
   border: var(--sb-reader-toolbar-border);
   background: var(--sb-reader-toolbar-background);
   box-shadow: var(--sb-reader-toolbar-box-shadow);
+  z-index: 2;
+}
+
+.sb-tool-context-menu-below {
+  bottom: auto;
+  top: calc(100% + 0.5rem);
+}
+
+.sb-tool-context-menu-scroll {
+  max-height: min(24rem, calc(100vh - 6rem));
+  overflow-y: auto;
   padding: 0.375rem;
   display: flex;
   flex-direction: column;
   gap: 0.25rem;
-  z-index: 2;
+}
+
+.sb-tool-context-menu-fade {
+  position: absolute;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  height: 4.5rem;
+  background: linear-gradient(
+    to bottom,
+    transparent,
+    transparent 15%,
+    color-mix(in srgb, var(--sb-reader-toolbar-background) 90%, transparent) 75%
+  );
+  border-radius: 0 0 var(--sb-reader-toolbar-border-radius)
+    var(--sb-reader-toolbar-border-radius);
+  pointer-events: none;
 }
 
 .sb-tool-context-menu-item {
@@ -1414,6 +1441,11 @@
    sits centered above it, so don't reserve extra side padding. */
 .sb-verse-toolbar-mobile .sb-verse-toolbar-cards .sb-tool-context-menu {
   bottom: calc(100% + 0.375rem);
+}
+
+.sb-verse-toolbar-mobile .sb-verse-toolbar-cards .sb-tool-context-menu-below {
+  bottom: auto;
+  top: calc(100% + 0.375rem);
 }
 
 /* Inline highlight swatches grouped as their own rounded pill, set off from the

--- a/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
+++ b/packages/seed-bible/seed-bible/components/BibleReaderToolbar/BibleReaderToolbar.tsx
@@ -375,6 +375,35 @@ function removeSharedHighlightsFromSelection(
 }
 
 /**
+ * Ref callback (not a hook — both menus render inside a per-tool loop) for
+ * the scrollable `.sb-tool-context-menu-scroll` list. Flips the menu to open
+ * downward when it doesn't fit above its button (the verse toolbar can dock
+ * near the top of the viewport), and toggles the `.sb-tool-context-menu-fade`
+ * sibling's `hidden` attribute to show more-content-below scroll affordance.
+ */
+function attachMenuOverflowFade(el: HTMLDivElement | null): void {
+  if (!el) {
+    return;
+  }
+  const menu = el.parentElement;
+  if (menu?.classList.contains("sb-tool-context-menu")) {
+    if (menu.getBoundingClientRect().top < 0) {
+      menu.classList.add("sb-tool-context-menu-below");
+    }
+  }
+
+  const fade = el.nextElementSibling as HTMLElement | null;
+  if (!fade?.classList.contains("sb-tool-context-menu-fade")) {
+    return;
+  }
+  const update = () => {
+    fade.hidden = el.scrollHeight - el.scrollTop - el.clientHeight <= 1;
+  };
+  update();
+  el.addEventListener("scroll", update, { passive: true });
+}
+
+/**
  * Applies a highlight to the current selection with the right lifetime for the
  * current context:
  *
@@ -2178,24 +2207,30 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                             );
                           }}
                         >
-                          {menuItems.map((item) => {
-                            const MenuItemIcon = item.icon;
-                            return (
-                              <button
-                                key={item.id}
-                                disabled={item.disabled.value}
-                                onClick={() => {
-                                  item.onSelect();
-                                  selectedToolbarToolId.value = null;
-                                }}
-                                className="sb-tool-context-menu-item"
-                                role="menuitem"
-                              >
-                                <MenuItemIcon />
-                                <span>{translateTitle(t, item.title)}</span>
-                              </button>
-                            );
-                          })}
+                          <div
+                            className="sb-tool-context-menu-scroll"
+                            ref={attachMenuOverflowFade}
+                          >
+                            {menuItems.map((item) => {
+                              const MenuItemIcon = item.icon;
+                              return (
+                                <button
+                                  key={item.id}
+                                  disabled={item.disabled.value}
+                                  onClick={() => {
+                                    item.onSelect();
+                                    selectedToolbarToolId.value = null;
+                                  }}
+                                  className="sb-tool-context-menu-item"
+                                  role="menuitem"
+                                >
+                                  <MenuItemIcon />
+                                  <span>{translateTitle(t, item.title)}</span>
+                                </button>
+                              );
+                            })}
+                          </div>
+                          <div className="sb-tool-context-menu-fade" hidden />
                         </div>
                       )}
                   </div>
@@ -2617,24 +2652,30 @@ export function BibleReaderToolbar(props: BibleReaderToolbarProps) {
                               );
                             }}
                           >
-                            {menuItems.map((item) => {
-                              const MenuItemIcon = item.icon;
-                              return (
-                                <button
-                                  key={item.id}
-                                  disabled={item.disabled.value}
-                                  onClick={() => {
-                                    item.onSelect();
-                                    selectedVerseToolId.value = null;
-                                  }}
-                                  className="sb-tool-context-menu-item"
-                                  role="menuitem"
-                                >
-                                  <MenuItemIcon />
-                                  <span>{translateTitle(t, item.title)}</span>
-                                </button>
-                              );
-                            })}
+                            <div
+                              className="sb-tool-context-menu-scroll"
+                              ref={attachMenuOverflowFade}
+                            >
+                              {menuItems.map((item) => {
+                                const MenuItemIcon = item.icon;
+                                return (
+                                  <button
+                                    key={item.id}
+                                    disabled={item.disabled.value}
+                                    onClick={() => {
+                                      item.onSelect();
+                                      selectedVerseToolId.value = null;
+                                    }}
+                                    className="sb-tool-context-menu-item"
+                                    role="menuitem"
+                                  >
+                                    <MenuItemIcon />
+                                    <span>{translateTitle(t, item.title)}</span>
+                                  </button>
+                                );
+                              })}
+                            </div>
+                            <div className="sb-tool-context-menu-fade" hidden />
                           </div>
                         )}
                     </div>

--- a/packages/seed-bible/seed-bible/components/PaneLayout/PaneLayout.tsx
+++ b/packages/seed-bible/seed-bible/components/PaneLayout/PaneLayout.tsx
@@ -190,8 +190,8 @@ export function PaneLayout(props: PaneLayoutProps) {
             height: `${pane.height}px`,
             zIndex:
               pane.id === selectedPaneId
-                ? 70 + overlayPanes.length
-                : 50 + index,
+                ? 170 + overlayPanes.length
+                : 150 + index,
           }}
           ref={(element: HTMLElement | null) =>
             registerPaneElement(pane.id, element)


### PR DESCRIPTION
## Summary

- Caps toolbar menu height with a scroll fade, and flips the menu to open downward when it doesn't fit above its button (the verse toolbar can dock near the top of the viewport)
- Fixes floating panes' z-index so they render above the toolbar

Both fixes were originally written alongside the Bible Atlas extension (#1796, still in draft) but are independent of it — the toolbar menu and pane layout are used app-wide.

## Test plan

- [ ] Open a toolbar menu with many items — it scrolls within a capped height, with a fade that shows/hides correctly
- [ ] Select a verse near the top of the screen — its menu opens downward instead of clipping off-screen
- [ ] Open a floating pane and confirm it renders above the toolbar

## Images / Video(s)

Max height and scroll fixes
<img width="582" height="506" alt="Screenshot 2026-09-11 at 8 40 10 AM" src="https://github.com/user-attachments/assets/b8f63ef1-b127-4ec3-99db-8553e97cac4a" />
<img width="429" height="490" alt="Screenshot 2026-09-11 at 8 40 49 AM" src="https://github.com/user-attachments/assets/55a1cbef-4d0a-40ac-ab2b-e05e2f0bfb47" />

Z-index fix
<img width="736" height="483" alt="Screenshot 2026-09-11 at 8 41 28 AM" src="https://github.com/user-attachments/assets/6f5ef7aa-5ecc-4de8-a406-6577668cafe9" />


